### PR TITLE
ci: added initial GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Set up Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pyee
+    - name: Build driver
+      run: python build_driver.py
+    - name: Build package
+      run: python build_package.py
+    - name: Test
+      run: python -m unittest

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ playwright_web.egg-info/
 build/
 dist/
 **/*.pyc
+env/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ build/
 dist/
 **/*.pyc
 env/
+htmlcov/
+.coverage

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ⚠️ **EXPERIMENTAL** ⚠️
 
-This is a Python3 version of the [https://github.com/microsoft/playwright](https://github.com/microsoft/playwright) project. In only contains initial stub implementation with **NO** tests. It can not be used in production yet.
+This is a Python 3 version of the [https://github.com/microsoft/playwright](https://github.com/microsoft/playwright) project. In only contains initial stub implementation with **NO** tests. It can not be used in production yet.
 
 # Install
 
@@ -42,19 +42,19 @@ asyncio.get_event_loop().run_until_complete(run())
 
 Build driver:
 ```sh
-python3 ./build_driver.py
+python ./build_driver.py
 ```
 
 Run tests:
 ```sh
-python3 -m unittest
+python -m unittest
 ```
 
 Deploy:
 ```sh
-python3 ./build_package.py
+python ./build_package.py
 ... check
-python3 ./upload_package.py
+python ./upload_package.py
 ```
 
 # Contributing

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ Run tests:
 python -m unittest
 ```
 
+Run tests with coverage:
+```
+pip install coverage
+coverage run -m unittest
+coverage html
+open htmlcov/index.html
+```
+
 Deploy:
 ```sh
 python ./build_package.py

--- a/build_driver.py
+++ b/build_driver.py
@@ -31,8 +31,8 @@ if os.path.exists(os.path.join(driver_path, 'node_modules')):
 if os.path.exists(os.path.join(driver_path, 'out')):
   shutil.rmtree(os.path.join(driver_path, 'out'))
 
-subprocess.run(['npm', 'i'], cwd=driver_path)
-subprocess.run(['npm', 'run', 'bake'], cwd=driver_path)
+subprocess.run('npm i', cwd=driver_path, shell=True)
+subprocess.run('npm run bake', cwd=driver_path, shell=True)
 
 for driver in ['driver-linux', 'driver-macos', 'driver-win.exe']:
   if os.path.exists(os.path.join(package_path, driver)):

--- a/build_package.py
+++ b/build_package.py
@@ -24,4 +24,4 @@ if os.path.exists(os.path.join(folder, 'dist')):
 if os.path.exists(os.path.join(folder, 'playwright_web.egg-info')):
   shutil.rmtree(os.path.join(folder, 'playwright_web.egg-info'))
 
-subprocess.run(['python3', 'setup.py', 'sdist', 'bdist_wheel'])
+subprocess.run('python setup.py sdist bdist_wheel', shell=True)

--- a/playwright_web/playwright.py
+++ b/playwright_web/playwright.py
@@ -50,7 +50,7 @@ class Playwright:
     if st.st_mode & stat.S_IEXEC == 0:
       os.chmod(driver_executable, st.st_mode | stat.S_IEXEC)
 
-    subprocess.run([driver_executable, 'install'])
+    subprocess.run(f"{driver_executable} install", shell=True)
 
     self._proc = await asyncio.create_subprocess_exec(driver_executable,
       stdin=asyncio.subprocess.PIPE,

--- a/upload_package.py
+++ b/upload_package.py
@@ -14,4 +14,4 @@
 
 import subprocess
 
-subprocess.run(['python3', '-m', 'twine', 'upload', 'dist/*'])
+subprocess.run('python -m twine upload dist/*', shell=True)


### PR DESCRIPTION
- added GitHub Action which builds the driver and package on all major operating systems and runs the tests too. Found there the Windows bug, which lead to the behaviour that the `npm` executable could not be found.
- Moved python3 over to python, because mostly either virtualenv, Pipenv or conda will be used

Seems like GitHub Actions needs to be enabled on that repository. Successfully tested on my fork: https://github.com/mxschmitt/playwright-python/actions/runs/160301567