### PR TITLE
tests: use pytest instead of unittest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pyee
+        pip install -r local-requirements.txt
+        pip install .
     - name: Build driver
       run: python build_driver.py
     - name: Build package
       run: python build_package.py
     - name: Test
-      run: python -m unittest
+      run: pytest

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a Python 3 version of the [https://github.com/microsoft/playwright](http
 # Install
 
 ```sh
-pip3 install playwright_web
+pip install playwright_web
 ```
 
 # Run

--- a/local-requirements.txt
+++ b/local-requirements.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-asyncio

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
 
 import setuptools
 
-with open('README.md', 'r', encoding="utf-8") as fh:
+with open('README.md', 'r', encoding='utf-8') as fh:
   long_description = fh.read()
 
 setuptools.setup(

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
 
 import setuptools
 
-with open('README.md', 'r') as fh:
+with open('README.md', 'r', encoding="utf-8") as fh:
   long_description = fh.read()
 
 setuptools.setup(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,15 +1,29 @@
+# Copyright (c) Microsoft Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import playwright_web
 import pytest
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope='session')
 def event_loop():
     loop = playwright_web.playwright.loop
     yield loop
     loop.close()
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope='session')
 async def browser():
     browser = await playwright_web.chromium.launch()
     yield browser

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,29 @@
+import playwright_web
+import pytest
+
+
+@pytest.fixture(scope="session")
+def event_loop():
+    loop = playwright_web.playwright.loop
+    yield loop
+    loop.close()
+
+
+@pytest.fixture(scope="session")
+async def browser():
+    browser = await playwright_web.chromium.launch()
+    yield browser
+    await browser.close()
+
+
+@pytest.fixture
+async def context(browser):
+    context = await browser.newContext()
+    yield context
+    await context.close()
+
+@pytest.fixture
+async def page(context):
+    page = await context.newPage()
+    yield page
+    await page.close()


### PR DESCRIPTION
As discussed a small showcase how tests with pytest will look like. They are simpler and its easier to have reusable content with pre and post methods called fixtures. In general its more common to use asserts instead of the expect way like we did in JavaScript. For parallelism there are packages out there like [that](https://github.com/pytest-dev/pytest-xdist).