### PR TITLE
enh: fixed some Python types and Dicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 env/
 htmlcov/
 .coverage
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ python ./build_package.py
 python ./upload_package.py
 ```
 
+Checking for typing errors
+```sh
+mypy playwright_web
+```
+
 # Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/local-requirements.txt
+++ b/local-requirements.txt
@@ -1,3 +1,4 @@
-pytest
-pytest-asyncio
-pytest-cov
+pytest==5.4.3
+pytest-asyncio==0.14.0
+pytest-cov==2.10.0
+mypy==0.782

--- a/playwright_web/browser_context.py
+++ b/playwright_web/browser_context.py
@@ -18,7 +18,10 @@ from playwright_web.helper import Cookie, Error, FunctionWithSource, PendingWait
 from playwright_web.network import Request, Response, Route
 from playwright_web.page import BindingCall, Page
 from types import SimpleNamespace
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union, TYPE_CHECKING
+
+if TYPE_CHECKING:
+  from playwright_web.browser import Browser
 
 class BrowserContext(ChannelOwner):
 
@@ -83,8 +86,6 @@ class BrowserContext(ChannelOwner):
   async def cookies(self, urls: Union[str, List[str]]) -> List[Cookie]:
     if urls == None:
       urls = list()
-    if urls and isinstance(urls, list):
-      urls = [ urls ]
     return await self._channel.send('cookies', dict(urls=urls))
 
   async def addCookies(self, cookies: List[Cookie]) -> None:

--- a/playwright_web/connection.py
+++ b/playwright_web/connection.py
@@ -16,7 +16,6 @@ import asyncio
 from playwright_web.helper import parse_error
 from playwright_web.transport import Transport
 from pyee import BaseEventEmitter
-from types import SimpleNamespace
 from typing import Any, Awaitable, Dict, List, Optional
 
 

--- a/playwright_web/download.py
+++ b/playwright_web/download.py
@@ -35,4 +35,4 @@ class Download(ChannelOwner):
     return await self._channel.send('failure')
 
   async def path(self) -> Optional[str]:
-    await self._channel.send('path')
+    return await self._channel.send('path')

--- a/playwright_web/element_handle.py
+++ b/playwright_web/element_handle.py
@@ -16,7 +16,10 @@ import base64
 from playwright_web.connection import Channel, ChannelOwner, ConnectionScope, from_nullable_channel
 from playwright_web.helper import ConsoleMessageLocation, FilePayload, SelectOption, locals_to_params
 from playwright_web.js_handle import parse_result, serialize_argument, JSHandle
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING
+
+if TYPE_CHECKING:
+  from playwright_web.frame import Frame
 
 class ElementHandle(JSHandle):
 

--- a/playwright_web/file_chooser.py
+++ b/playwright_web/file_chooser.py
@@ -13,7 +13,12 @@
 # limitations under the License.
 
 from playwright_web.helper import FilePayload
-from typing import Dict, List, Union
+
+from typing import Dict, List, Union, TYPE_CHECKING
+
+if TYPE_CHECKING:
+  from playwright_web.page import Page
+  from playwright_web.element_handle import ElementHandle
 
 class FileChooser():
 

--- a/playwright_web/frame.py
+++ b/playwright_web/frame.py
@@ -18,7 +18,10 @@ from playwright_web.element_handle import ElementHandle, convertSelectOptionValu
 from playwright_web.helper import ConsoleMessageLocation, FilePayload, SelectOption, is_function_body, locals_to_params
 from playwright_web.js_handle import JSHandle, parse_result, serialize_argument
 from playwright_web.network import Request, Response, Route
-from typing import Any, Awaitable, Dict, List, Optional, Union
+from typing import Any, Awaitable, Dict, List, Optional, Union, TYPE_CHECKING
+
+if TYPE_CHECKING:
+  from playwright_web.page import Page
 
 class Frame(ChannelOwner):
 

--- a/playwright_web/helper.py
+++ b/playwright_web/helper.py
@@ -17,20 +17,50 @@ import collections
 import fnmatch
 import re
 
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
-# from typing import TypedDict
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, TYPE_CHECKING
+
+import sys
+
+if sys.version_info >= (3, 8):
+    from typing import TypedDict  # pylint: disable=no-name-in-module
+else:
+    from typing_extensions import TypedDict
+
+
+if TYPE_CHECKING:
+  from playwright_web.network import Route, Request
 
 Cookie = List[Dict[str, Union[str, int, bool]]]
 URLMatch = Union[str, Callable[[str], bool]]
-FilePayload = Dict # TypedDict('FilePayload', name=str, mimeType=str, buffer=bytes)
-FrameMatch = Dict # TypedDict('FrameMatch', url=URLMatch, name=str)
-PendingWaitEvent = Dict # TypedDict('PendingWaitEvent', event=str, future=asyncio.Future)
 RouteHandler = Callable[['Route', 'Request'], None]
-RouteHandlerEntry = Dict # TypedDict('RouteHandlerEntry', matcher=URLMatcher, handler=RouteHandler)
-SelectOption = Dict # TypedDict('SelectOption', value=Optional[str], label=Optional[str], index=Optional[str])
-ConsoleMessageLocation = Dict #TypedDict('ConsoleMessageLocation', url=Optional[str], lineNumber=Optional[int], columnNumber=Optional[int])
 FunctionWithSource = Callable[[Dict], Any]
-ErrorPayload = Dict  # TypedDict('ErrorPayload', message=str, name=str, stack=str, value=Any)
+class FilePayload(TypedDict):
+ name: str
+ mimeType: str
+ buffer: bytes
+class FrameMatch(TypedDict):
+  url: URLMatch
+  name: str
+class PendingWaitEvent(TypedDict):
+  event: str
+  future: asyncio.Future
+
+class RouteHandlerEntry(TypedDict):
+  matcher: "URLMatcher"
+  handler: RouteHandler
+class SelectOption(TypedDict):
+  value: Optional[str]
+  label: Optional[str]
+  index: Optional[str]
+class ConsoleMessageLocation(TypedDict):
+  url: Optional[str]
+  lineNumber: Optional[int]
+  columnNumber: Optional[int]
+class ErrorPayload(TypedDict):
+  message: str
+  name: str
+  stack: str
+  value: Any
 
 class URLMatcher:
   def __init__(self, match: URLMatch):

--- a/playwright_web/js_handle.py
+++ b/playwright_web/js_handle.py
@@ -17,7 +17,10 @@ import math
 from datetime import datetime
 from playwright_web.connection import Channel, ChannelOwner, ConnectionScope, from_channel
 from playwright_web.helper import ConsoleMessageLocation, Error, is_function_body
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+  from playwright_web.element_handle import ElementHandle
 
 class JSHandle(ChannelOwner):
 

--- a/playwright_web/network.py
+++ b/playwright_web/network.py
@@ -16,7 +16,10 @@ import base64
 import json
 from playwright_web.connection import Channel, ChannelOwner, ConnectionScope, from_nullable_channel, from_channel
 from playwright_web.helper import Error
-from typing import Awaitable, Dict, List, Optional, Union
+from typing import Awaitable, Dict, List, Optional, Union, TYPE_CHECKING
+
+if TYPE_CHECKING:
+  from playwright_web.frame import Frame
 
 class Request(ChannelOwner):
 
@@ -69,7 +72,7 @@ class Request(ChannelOwner):
     return self._redirected_to
 
   @property
-  def failure(self) -> Optional[str]:    
+  def failure(self) -> Optional[str]:
     return self._failure_text
 
 

--- a/playwright_web/page.py
+++ b/playwright_web/page.py
@@ -29,7 +29,10 @@ from playwright_web.helper import is_function_body, parse_error, serialize_error
 from playwright_web.network import Request, Response, Route
 from playwright_web.worker import Worker
 from types import SimpleNamespace
-from typing import Any, Awaitable, Callable, Dict, List, Union
+from typing import Any, Awaitable, Callable, Dict, List, Union, TYPE_CHECKING
+
+if TYPE_CHECKING:
+  from playwright_web.browser_context import BrowserContext
 
 class Page(ChannelOwner):
 
@@ -296,7 +299,7 @@ class Page(ChannelOwner):
 
   async def waitForResponse(self, urlOrPredicate: Union[str, Callable[[Request], bool]]) -> Optional[Response]:
     matcher = URLMatcher(urlOrPredicate) if isinstance(urlOrPredicate, str) else None
-    def predicate(request: Request):    
+    def predicate(request: Request):
       if matcher:
         return matcher.matches(request.url())
       return urlOrPredicate(request)
@@ -498,7 +501,7 @@ class Page(ChannelOwner):
     if not is_function_body(expression):
       force_expr = True
     return await self._main_frame.waitForFunction(**locals_to_params(locals()))
- 
+
   def workers(self) -> List[Worker]:
     return self._workers.copy()
 

--- a/playwright_web/transport.py
+++ b/playwright_web/transport.py
@@ -22,9 +22,9 @@ from typing import Awaitable, Dict
 class Transport:
   def __init__(self, input: asyncio.StreamReader, output: asyncio.StreamWriter, loop: asyncio.AbstractEventLoop) -> None:
     super().__init__()
-    self._input = input
-    self._output = output
-    self.loop = loop
+    self._input: asyncio.StreamReader = input
+    self._output: asyncio.StreamWriter = output
+    self.loop: asyncio.AbstractEventLoop = loop
     self.on_message = lambda _: None
     loop.create_task(self._run())
 
@@ -50,11 +50,11 @@ class Transport:
         if 'DEBUG' in os.environ:
           print('\x1b[33mRECV>\x1b[0m', obj.get('method'))
         self.on_message(obj)
-      except asyncio.streams.IncompleteReadError:
+      except asyncio.IncompleteReadError:
         break
       await asyncio.sleep(0)
 
-  def send(self, message: Dict) -> Awaitable:
+  def send(self, message: Dict) -> None:
     msg = json.dumps(message)
     if 'DEBUGP' in os.environ:
       print('\x1b[32mSEND>\x1b[0m', json.dumps(message, indent=2))

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setuptools.setup(
   include_package_data=True,
   install_requires=[
     'pyee',
+    'typing-extensions',
   ],
   classifiers=[
     'Programming Language :: Python :: 3',


### PR DESCRIPTION
Fixes #3

Changes:
- added these `if TYPE_CHECKING` conditions to fix circular imports and by that types which were not resolved
- added mypy to the local dependencies and readme to check for typing issues. Currently we have quite a lot of errors (around 40) would be nice to fix them and enforce it in the end on the CI

Tested on Python 3.7.7 and 3.8.2, works. Should I add 3.7 also to our testing matrix in the CI?