### PR TITLE
chore: add black as a pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.1.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+-   repo: https://github.com/psf/black
+    rev: 19.10b0
+    hooks:
+    -   id: black

--- a/docs/development.md
+++ b/docs/development.md
@@ -38,3 +38,9 @@ mypy playwright
 ```sh
 black .
 ```
+
+## Installing the Git hooks (auto format etc. on commit)
+
+```sh
+pre-commit install
+```

--- a/local-requirements.txt
+++ b/local-requirements.txt
@@ -8,3 +8,4 @@ setuptools==49.1.0
 twisted==20.3.0
 wheel==0.34.2
 black==19.10b0
+pre-commit==2.6.0


### PR DESCRIPTION
So in general you then can code whatever you want and before you commit it will fix the formatting automatically.