### PR TITLE
tests: added download tests and linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,10 @@ jobs:
         pip install -r local-requirements.txt
         pip install .
     - name: Lint
-      run: black --check .
+      run: |
+        black --check .
+        mypy .
+        flake8  playwright tests
     - name: Build driver
       run: python build_driver.py
       env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,7 @@ repos:
     rev: v0.782
     hooks:
     -   id: mypy
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 'a7be77f761a4c29121d6bb6f61c11902281f9105'
+    hooks:
+    -   id: flake8

--- a/local-requirements.txt
+++ b/local-requirements.txt
@@ -9,3 +9,4 @@ twisted==20.3.0
 wheel==0.34.2
 black==19.10b0
 pre-commit==2.6.0
+flake8==3.8.3

--- a/playwright/accessibility.py
+++ b/playwright/accessibility.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from playwright.connection import Channel
-from playwright.helper import locals_to_params
 from playwright.element_handle import ElementHandle
 from typing import Dict
 

--- a/playwright/browser.py
+++ b/playwright/browser.py
@@ -14,11 +14,11 @@
 
 import sys
 from playwright.browser_context import BrowserContext
-from playwright.connection import Channel, ChannelOwner, ConnectionScope, from_channel
+from playwright.connection import ChannelOwner, ConnectionScope, from_channel
 from playwright.helper import locals_to_params, ColorScheme
 from playwright.page import Page
 from types import SimpleNamespace
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Union
 
 if sys.version_info >= (3, 8):
     from typing import Literal

--- a/playwright/browser_context.py
+++ b/playwright/browser_context.py
@@ -14,11 +14,9 @@
 
 import asyncio
 from playwright.connection import (
-    Channel,
     ChannelOwner,
     ConnectionScope,
     from_channel,
-    from_nullable_channel,
 )
 from playwright.helper import (
     Cookie,
@@ -31,7 +29,7 @@ from playwright.helper import (
     URLMatch,
     URLMatcher,
 )
-from playwright.network import Request, Response, Route
+from playwright.network import Request, Route
 from playwright.page import BindingCall, Page
 from types import SimpleNamespace
 from typing import Any, Callable, Dict, List, Optional, Union, TYPE_CHECKING

--- a/playwright/browser_server.py
+++ b/playwright/browser_server.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from playwright.connection import Channel, ChannelOwner, ConnectionScope
+from playwright.connection import ChannelOwner, ConnectionScope
 from types import SimpleNamespace
 from typing import Dict
 

--- a/playwright/browser_type.py
+++ b/playwright/browser_type.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from playwright.connection import Channel, ChannelOwner, ConnectionScope, from_channel
+from playwright.connection import ChannelOwner, ConnectionScope, from_channel
 from playwright.browser import Browser
 from playwright.browser_context import BrowserContext
 from playwright.helper import locals_to_params, ColorScheme
-from typing import Awaitable, Dict, List
+from typing import Dict, List
 
 
 class BrowserType(ChannelOwner):

--- a/playwright/connection.py
+++ b/playwright/connection.py
@@ -16,7 +16,7 @@ import asyncio
 from playwright.helper import parse_error, ParsedMessagePayload
 from playwright.transport import Transport
 from pyee import BaseEventEmitter
-from typing import Any, Awaitable, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 
 class Channel(BaseEventEmitter):

--- a/playwright/console_message.py
+++ b/playwright/console_message.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from playwright.connection import Channel, ChannelOwner, ConnectionScope, from_channel
+from playwright.connection import ChannelOwner, ConnectionScope, from_channel
 from playwright.helper import ConsoleMessageLocation
 from playwright.js_handle import JSHandle
 from typing import Dict, List

--- a/playwright/dialog.py
+++ b/playwright/dialog.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from playwright.connection import Channel, ChannelOwner, ConnectionScope
+from playwright.connection import ChannelOwner, ConnectionScope
 from typing import Dict
 
 

--- a/playwright/download.py
+++ b/playwright/download.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from playwright.connection import Channel, ChannelOwner, ConnectionScope
+from playwright.connection import ChannelOwner, ConnectionScope
 from typing import Dict, Optional
 
 

--- a/playwright/element_handle.py
+++ b/playwright/element_handle.py
@@ -15,13 +15,10 @@
 import base64
 import sys
 from playwright.connection import (
-    Channel,
-    ChannelOwner,
     ConnectionScope,
     from_nullable_channel,
 )
 from playwright.helper import (
-    ConsoleMessageLocation,
     FilePayload,
     SelectOption,
     locals_to_params,

--- a/playwright/file_chooser.py
+++ b/playwright/file_chooser.py
@@ -14,7 +14,7 @@
 
 from playwright.helper import FilePayload
 
-from typing import Dict, List, Union, TYPE_CHECKING
+from typing import List, Union, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from playwright.page import Page

--- a/playwright/frame.py
+++ b/playwright/frame.py
@@ -15,7 +15,6 @@
 import asyncio
 import sys
 from playwright.connection import (
-    Channel,
     ChannelOwner,
     ConnectionScope,
     from_channel,
@@ -27,9 +26,7 @@ from playwright.element_handle import (
     ValuesToSelect,
 )
 from playwright.helper import (
-    ConsoleMessageLocation,
     FilePayload,
-    SelectOption,
     is_function_body,
     locals_to_params,
     KeyboardModifier,
@@ -37,7 +34,7 @@ from playwright.helper import (
     DocumentLoadState,
 )
 from playwright.js_handle import JSHandle, parse_result, serialize_argument
-from playwright.network import Request, Response, Route
+from playwright.network import Response
 from playwright.serializers import normalize_file_payloads
 from typing import Any, Awaitable, Dict, List, Optional, Union, TYPE_CHECKING, cast
 

--- a/playwright/helper.py
+++ b/playwright/helper.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import asyncio
-import collections
 import fnmatch
 import re
 
@@ -23,7 +22,6 @@ from typing import (
     Dict,
     List,
     Optional,
-    Tuple,
     Union,
     TYPE_CHECKING,
     Pattern,
@@ -160,7 +158,7 @@ def locals_to_params(args: Dict) -> Dict:
     for key in args:
         if key == "self":
             continue
-        if args[key] != None:
+        if args[key] is not None:
             copy[key] = args[key]
     return copy
 

--- a/playwright/input.py
+++ b/playwright/input.py
@@ -14,7 +14,6 @@
 
 from playwright.connection import Channel
 from playwright.helper import locals_to_params, MouseButton
-from typing import Awaitable, Dict
 
 
 class Keyboard:

--- a/playwright/js_handle.py
+++ b/playwright/js_handle.py
@@ -15,8 +15,8 @@
 import math
 
 from datetime import datetime
-from playwright.connection import Channel, ChannelOwner, ConnectionScope, from_channel
-from playwright.helper import ConsoleMessageLocation, Error, is_function_body
+from playwright.connection import ChannelOwner, ConnectionScope, from_channel
+from playwright.helper import Error, is_function_body
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/playwright/main.py
+++ b/playwright/main.py
@@ -23,7 +23,6 @@ import subprocess
 from playwright.connection import Connection
 from playwright.object_factory import create_remote_object
 from playwright.playwright import Playwright
-from typing import Dict
 
 playwright_object: Playwright
 

--- a/playwright/network.py
+++ b/playwright/network.py
@@ -15,14 +15,13 @@
 import base64
 import json
 from playwright.connection import (
-    Channel,
     ChannelOwner,
     ConnectionScope,
     from_nullable_channel,
     from_channel,
 )
 from playwright.helper import Error, ContinueParameters
-from typing import Any, Awaitable, Dict, List, Optional, Union, TYPE_CHECKING, cast
+from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from playwright.frame import Frame

--- a/playwright/object_factory.py
+++ b/playwright/object_factory.py
@@ -27,7 +27,7 @@ from playwright.network import Request, Response, Route
 from playwright.page import BindingCall, Page
 from playwright.playwright import Playwright
 from playwright.worker import Worker
-from typing import Any, Awaitable, Dict, List
+from typing import Any, Dict
 
 
 def create_remote_object(

--- a/playwright/page.py
+++ b/playwright/page.py
@@ -17,15 +17,11 @@ import base64
 import sys
 from playwright.accessibility import Accessibility
 from playwright.connection import (
-    Channel,
     ChannelOwner,
     ConnectionScope,
     from_channel,
     from_nullable_channel,
 )
-from playwright.console_message import ConsoleMessage
-from playwright.dialog import Dialog
-from playwright.download import Download
 from playwright.element_handle import ElementHandle, ValuesToSelect
 from playwright.file_chooser import FileChooser
 from playwright.helper import locals_to_params
@@ -43,7 +39,6 @@ from playwright.helper import (
     PendingWaitEvent,
     RouteHandler,
     RouteHandlerEntry,
-    SelectOption,
     TimeoutSettings,
     URLMatch,
     URLMatcher,

--- a/playwright/playwright.py
+++ b/playwright/playwright.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from playwright.connection import Channel, ChannelOwner, ConnectionScope, from_channel
+from playwright.connection import ChannelOwner, ConnectionScope, from_channel
 from playwright.browser_type import BrowserType
 from typing import Dict
 

--- a/playwright/serializers.py
+++ b/playwright/serializers.py
@@ -1,11 +1,5 @@
-from typing import Any, Awaitable, Dict, List, Optional, Union, TYPE_CHECKING
-from playwright.helper import (
-    ConsoleMessageLocation,
-    FilePayload,
-    SelectOption,
-    is_function_body,
-    locals_to_params,
-)
+from typing import List, Union
+from playwright.helper import FilePayload
 from os import path
 import mimetypes
 import base64

--- a/playwright/transport.py
+++ b/playwright/transport.py
@@ -15,8 +15,7 @@
 import asyncio
 import json
 import os
-import sys
-from typing import Awaitable, Dict
+from typing import Dict
 
 
 class Transport:

--- a/playwright/worker.py
+++ b/playwright/worker.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from playwright.connection import Channel, ChannelOwner, ConnectionScope, from_channel
+from playwright.connection import ChannelOwner, ConnectionScope, from_channel
 from playwright.js_handle import JSHandle, parse_result, serialize_argument
 from typing import Any, Dict
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,8 @@ markers =
     only_browser
 [mypy]
 ignore_missing_imports = True
+[flake8]
+ignore =
+    E501
+    W503
+    E302

--- a/tests/assets/download-blob.html
+++ b/tests/assets/download-blob.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Blob Download Example</title>
+  </head>
+  <body>
+    <script>
+      const download = (data, filename) => {
+      const a = document.createElement("a");
+      a.style = "display: none";
+      document.body.appendChild(a);
+      a.style = "display: none";
+
+      const blob = new Blob([data], { type: "octet/stream" });
+      const url = window.URL.createObjectURL(blob);
+      a.href = url;
+      a.download = filename;
+      a.click();
+      window.URL.revokeObjectURL(url);
+      document.body.removeChild(a);
+    };
+
+    const downloadIt = () => {
+      download("Hello world", "example.txt");
+    }
+    </script>
+    <a onclick="javascipt:downloadIt();">Download</a>
+  </body>
+</html>

--- a/tests/server.py
+++ b/tests/server.py
@@ -18,7 +18,6 @@ from contextlib import closing
 import os
 import socket
 import threading
-import os
 import binascii
 
 from twisted.internet import reactor
@@ -32,6 +31,12 @@ def find_free_port():
         s.bind(("", 0))
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         return s.getsockname()[1]
+
+
+class NoResponseClass:
+    @staticmethod
+    def render(request):
+        return b""
 
 
 class UnauthorizedResource(resource.ErrorPage):
@@ -51,8 +56,10 @@ class Server:
     def start(self):
         request_subscribers = {}
         auth = {}
+        routes = {}
         self.request_subscribers = request_subscribers
         self.auth = auth
+        self.routes = routes
 
         class CustomFileServer(File):
             def getChild(self, path, request):
@@ -76,6 +83,9 @@ class Server:
                             b"www-authenticate", b'Basic realm="Secure Area"'
                         )
                         return UnauthorizedResource()
+                if routes.get(uri_path):
+                    routes[uri_path](request)
+                    return NoResponseClass()
 
                 return super().getChild(path, request)
 
@@ -104,6 +114,9 @@ class Server:
     def reset(self):
         self.request_subscribers.clear()
         self.auth.clear()
+
+    def set_route(self, path, callback):
+        self.routes[path] = callback
 
 
 server = Server()

--- a/tests/server.py
+++ b/tests/server.py
@@ -33,7 +33,7 @@ def find_free_port():
         return s.getsockname()[1]
 
 
-class NoResponseClass:
+class NoResponseResource:
     @staticmethod
     def render(request):
         return b""
@@ -85,7 +85,7 @@ class Server:
                         return UnauthorizedResource()
                 if routes.get(uri_path):
                     routes[uri_path](request)
-                    return NoResponseClass()
+                    return NoResponseResource()
 
                 return super().getChild(path, request)
 

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -28,13 +28,13 @@ async def test_not_check_the_checked_box(page):
 async def test_uncheck_the_box(page):
     await page.setContent('<input id="checkbox" type="checkbox" checked></input>')
     await page.uncheck("input")
-    assert await page.evaluate("checkbox.checked") == False
+    assert await page.evaluate("checkbox.checked") is False
 
 
 async def test_not_uncheck_the_unchecked_box(page):
     await page.setContent('<input id="checkbox" type="checkbox"></input>')
     await page.uncheck("input")
-    assert await page.evaluate("checkbox.checked") == False
+    assert await page.evaluate("checkbox.checked") is False
 
 
 async def test_check_the_box_by_label(page):

--- a/tests/test_click.py
+++ b/tests/test_click.py
@@ -72,7 +72,7 @@ async def test_click_not_throw_when_page_closes(browser, server):
         await asyncio.gather(
             page.close(), page.mouse.click(1, 2),
         )
-    except Error as e:
+    except Error:
         pass
     await context.close()
 
@@ -265,7 +265,7 @@ async def test_click_wrapped_links(page, server):
 
 async def test_click_on_checkbox_input_and_toggle(page, server):
     await page.goto(server.PREFIX + "/input/checkbox.html")
-    assert await page.evaluate("() => result.check") == None
+    assert await page.evaluate("() => result.check") is None
     await page.click("input#agree")
     assert await page.evaluate("result.check")
     assert await page.evaluate("result.events") == [
@@ -279,12 +279,12 @@ async def test_click_on_checkbox_input_and_toggle(page, server):
         "change",
     ]
     await page.click("input#agree")
-    assert await page.evaluate("result.check") == False
+    assert await page.evaluate("result.check") is False
 
 
 async def test_click_on_checkbox_label_and_toggle(page, server):
     await page.goto(server.PREFIX + "/input/checkbox.html")
-    assert await page.evaluate("result.check") == None
+    assert await page.evaluate("result.check") is None
     await page.click('label[for="agree"]')
     assert await page.evaluate("result.check")
     assert await page.evaluate("result.events") == [
@@ -293,7 +293,7 @@ async def test_click_on_checkbox_label_and_toggle(page, server):
         "change",
     ]
     await page.click('label[for="agree"]')
-    assert await page.evaluate("result.check") == False
+    assert await page.evaluate("result.check") is False
 
 
 async def test_not_hang_with_touch_enabled_viewports(server, browser):
@@ -759,16 +759,16 @@ async def test_update_modifiers_correctly(page, server):
     await page.click("button", modifiers=["Shift"])
     assert await page.evaluate("shiftKey")
     await page.click("button", modifiers=[])
-    assert await page.evaluate("shiftKey") == False
+    assert await page.evaluate("shiftKey") is False
 
     await page.keyboard.down("Shift")
     await page.click("button", modifiers=[])
-    assert await page.evaluate("shiftKey") == False
+    assert await page.evaluate("shiftKey") is False
     await page.click("button")
     assert await page.evaluate("shiftKey")
     await page.keyboard.up("Shift")
     await page.click("button")
-    assert await page.evaluate("shiftKey") == False
+    assert await page.evaluate("shiftKey") is False
 
 
 async def test_click_an_offscreen_element_when_scroll_behavior_is_smooth(page):
@@ -970,13 +970,13 @@ async def test_not_check_the_checked_box(page):
 async def test_uncheck_the_box(page):
     await page.setContent('<input id="checkbox" type="checkbox" checked></input>')
     await page.uncheck("input")
-    assert await page.evaluate("checkbox.checked") == False
+    assert await page.evaluate("checkbox.checked") is False
 
 
 async def test_not_uncheck_the_unchecked_box(page):
     await page.setContent('<input id="checkbox" type="checkbox"></input>')
     await page.uncheck("input")
-    assert await page.evaluate("checkbox.checked") == False
+    assert await page.evaluate("checkbox.checked") is False
 
 
 async def test_check_the_box_by_label(page):

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,0 +1,217 @@
+# Copyright (c) Microsoft Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from asyncio.futures import Future
+from typing import Optional
+from playwright.browser import Browser
+from playwright.page import Page
+from playwright.helper import Error as PlaywrightError
+import pytest
+import asyncio
+import os
+
+
+def assert_file_content(path, content):
+    with open(path, "r") as fd:
+        assert fd.read() == content
+
+
+@pytest.fixture(autouse=True)
+def after_each_hook(server):
+    def handle_download(request):
+        request.setHeader(b"Content-Type", "application/octet-stream")
+        request.setHeader(b"Content-Disposition", "attachment")
+        request.write(b"Hello world")
+
+    def handle_download_with_file_name(request):
+        request.setHeader(b"Content-Type", "application/octet-stream")
+        request.setHeader(b"Content-Disposition", "attachment; filename=file.txt")
+        request.write(b"Hello world")
+
+    server.set_route("/download", handle_download)
+    server.set_route("/downloadWithFilename", handle_download_with_file_name)
+    yield
+
+
+async def test_should_report_downloads_with_acceptDownloads_false(page: Page, server):
+    await page.setContent(
+        f'<a href="{server.PREFIX}/downloadWithFilename">download</a>'
+    )
+    download = (await asyncio.gather(page.waitForEvent("download"), page.click("a")))[0]
+    assert download.url == f"{server.PREFIX}/downloadWithFilename"
+    assert download.suggestedFilename == "file.txt"
+    error: Optional[PlaywrightError] = None
+    try:
+        await download.path()
+    except PlaywrightError as exc:
+        error = exc
+    assert "acceptDownloads" in await download.failure()
+    assert error
+    assert "acceptDownloads: true" in error.message
+
+
+async def test_should_report_downloads_with_acceptDownloads_true(browser, server):
+    page = await browser.newPage(acceptDownloads=True)
+    await page.setContent(f'<a href="{server.PREFIX}/download">download</a>')
+    download = (await asyncio.gather(page.waitForEvent("download"), page.click("a")))[0]
+    path = await download.path()
+    assert os.path.isfile(path)
+    assert_file_content(path, "Hello world")
+    await page.close()
+
+
+async def test_should_report_non_navigation_downloads(browser, server):
+    # Mac WebKit embedder does not download in this case, although Safari does.
+    def handle_download(request):
+        request.setHeader(b"Content-Type", "application/octet-stream")
+        request.write(b"Hello world")
+
+    server.set_route("/download", handle_download)
+
+    page = await browser.newPage(acceptDownloads=True)
+    await page.goto(server.EMPTY_PAGE)
+    await page.setContent(
+        f'<a download="file.txt" href="{server.PREFIX}/download">download</a>'
+    )
+    download = (await asyncio.gather(page.waitForEvent("download"), page.click("a")))[0]
+    assert download.suggestedFilename == "file.txt"
+    path = await download.path()
+    assert os.path.exists(path)
+    assert_file_content(path, "Hello world")
+    await page.close()
+
+
+async def test_report_download_path_within_page_on_download_handler_for_files(
+    browser: Browser, server
+):
+    page = await browser.newPage(acceptDownloads=True)
+    on_download_path: Future[str] = asyncio.Future()
+
+    async def on_download(download):
+        on_download_path.set_result(await download.path())
+
+    page.once(
+        "download", lambda res: asyncio.ensure_future(on_download(res)),
+    )
+    await page.setContent(f'<a href="{server.PREFIX}/download">download</a>')
+    await page.click("a")
+    path = await on_download_path
+    assert_file_content(path, "Hello world")
+    await page.close()
+
+
+async def test_download_report_download_path_within_page_on_handle_for_blobs(
+    browser, server
+):
+    page = await browser.newPage(acceptDownloads=True)
+    on_download_path = asyncio.Future()
+
+    async def on_download(download):
+        on_download_path.set_result(await download.path())
+
+    page.once(
+        "download", lambda res: asyncio.ensure_future(on_download(res)),
+    )
+
+    await page.goto(server.PREFIX + "/download-blob.html")
+    await page.click("a")
+    path = await on_download_path
+    assert_file_content(path, "Hello world")
+    await page.close()
+
+
+@pytest.mark.only_browser("chromium")
+async def test_should_report_alt_click_downloads(browser, server):
+    # Firefox does not download on alt-click by default.
+    # Our WebKit embedder does not download on alt-click, although Safari does.
+    def handle_download(request):
+        request.setHeader(b"Content-Type", "application/octet-stream")
+        request.write(b"Hello world")
+
+    server.set_route("/download", handle_download)
+
+    page = await browser.newPage(acceptDownloads=True)
+    await page.goto(server.EMPTY_PAGE)
+    await page.setContent(f'<a href="{server.PREFIX}/download">download</a>')
+    download = (
+        await asyncio.gather(
+            page.waitForEvent("download"), page.click("a", modifiers=["Alt"])
+        )
+    )[0]
+    path = await download.path()
+    assert os.path.exists(path)
+    assert_file_content(path, "Hello world")
+    await page.close()
+
+
+async def test_should_report_new_window_downloads(browser, server):
+    # TODO: - the test fails in headful Chromium as the popup page gets closed along
+    # with the session before download completed event arrives.
+    # - WebKit doesn't close the popup page
+    page = await browser.newPage(acceptDownloads=True)
+    await page.setContent(
+        f'<a target=_blank href="{server.PREFIX}/download">download</a>'
+    )
+    download = (await asyncio.gather(page.waitForEvent("download"), page.click("a")))[0]
+    path = await download.path()
+    assert os.path.exists(path)
+    await page.close()
+
+
+async def test_should_delete_file(browser, server):
+    page = await browser.newPage(acceptDownloads=True)
+    await page.setContent(f'<a href="{server.PREFIX}/download">download</a>')
+    download = (await asyncio.gather(page.waitForEvent("download"), page.click("a")))[0]
+    path = await download.path()
+    assert os.path.exists(path)
+    await download.delete()
+    assert os.path.exists(path) is False
+    await page.close()
+
+
+async def test_should_delete_downloads_on_context_destruction(browser, server):
+    page = await browser.newPage(acceptDownloads=True)
+    await page.setContent(f'<a href="{server.PREFIX}/download">download</a>')
+    download1 = (await asyncio.gather(page.waitForEvent("download"), page.click("a")))[
+        0
+    ]
+    download2 = (await asyncio.gather(page.waitForEvent("download"), page.click("a")))[
+        0
+    ]
+    path1 = await download1.path()
+    path2 = await download2.path()
+    assert os.path.exists(path1)
+    assert os.path.exists(path2)
+    await page.context.close()
+    assert os.path.exists(path1) is False
+    assert os.path.exists(path2) is False
+
+
+async def test_should_delete_downloads_on_browser_gone(browser_factory, server):
+    browser = await browser_factory()
+    page = await browser.newPage(acceptDownloads=True)
+    await page.setContent(f'<a href="{server.PREFIX}/download">download</a>')
+    download1 = (await asyncio.gather(page.waitForEvent("download"), page.click("a")))[
+        0
+    ]
+    download2 = (await asyncio.gather(page.waitForEvent("download"), page.click("a")))[
+        0
+    ]
+    path1 = await download1.path()
+    path2 = await download2.path()
+    assert os.path.exists(path1)
+    assert os.path.exists(path2)
+    await browser.close()
+    assert os.path.exists(path1) is False
+    assert os.path.exists(path2) is False
+    assert os.path.exists(os.path.join(path1, "..")) is False

--- a/tests/test_element_handle.py
+++ b/tests/test_element_handle.py
@@ -117,12 +117,13 @@ async def test_bounding_box_when_inline_box_child_is_outside_of_viewport(page, s
         }"""
     )
 
-    roundbox = lambda b: {
-        "x": round(b["x"] * 100),
-        "y": round(b["y"] * 100),
-        "width": round(b["width"] * 100),
-        "height": round(b["height"] * 100),
-    }
+    def roundbox(b):
+        return {
+            "x": round(b["x"] * 100),
+            "y": round(b["y"] * 100),
+            "width": round(b["width"] * 100),
+            "height": round(b["height"] * 100),
+        }
 
     assert roundbox(box) == roundbox(web_bounding_box)
 
@@ -588,7 +589,7 @@ async def test_uncheck_the_box(page):
     await page.setContent('<input id="checkbox" type="checkbox" checked></input>')
     input = await page.querySelector("input")
     await input.uncheck()
-    assert await page.evaluate("checkbox.checked") == False
+    assert await page.evaluate("checkbox.checked") is False
 
 
 async def test_select_single_option(page, server):
@@ -602,6 +603,6 @@ async def test_select_single_option(page, server):
 async def test_focus_a_button(page, server):
     await page.goto(server.PREFIX + "/input/button.html")
     button = await page.querySelector("button")
-    assert await button.evaluate("button => document.activeElement === button") == False
+    assert await button.evaluate("button => document.activeElement === button") is False
     await button.focus()
     assert await button.evaluate("button => document.activeElement === button")

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -34,7 +34,7 @@ async def test_frame_element(page, server, utils):
     frame3handle2 = await frame3.frameElement()
     assert await frame1handle1.evaluate("(a, b) => a === b", frame1handle2)
     assert await frame3handle1.evaluate("(a, b) => a === b", frame3handle2)
-    assert await frame1handle1.evaluate("(a, b) => a === b", frame3handle1) == False
+    assert await frame1handle1.evaluate("(a, b) => a === b", frame3handle1) is False
 
 
 async def test_frame_element_with_content_frame(page, server, utils):
@@ -250,5 +250,5 @@ async def test_should_report_different_frame_instance_when_frame_re_attaches(
         page.waitForEvent("frameattached"),
         page.evaluate("() => document.body.appendChild(window.frame)"),
     )
-    assert frame2.isDetached() == False
+    assert frame2.isDetached() is False
     assert frame1 != frame2

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -13,11 +13,9 @@
 # limitations under the License.
 
 import asyncio
-from asyncio.futures import Future
 import os
 
 from playwright.page import Page
-from playwright.file_chooser import FileChooser
 
 FILE_TO_UPLOAD = os.path.join(
     os.path.dirname(os.path.realpath(__file__)), "assets/file-to-upload.txt"
@@ -208,7 +206,7 @@ async def test_should_not_accept_multiple_files_for_single_file_input(page, serv
         )
     except Exception as exc:
         error = exc
-    assert error != None
+    assert error is not None
 
 
 async def test_should_emit_input_and_change_events(page, server):
@@ -234,7 +232,7 @@ async def test_should_work_for_single_file_pick(page, server):
     file_chooser = (
         await asyncio.gather(page.waitForEvent("filechooser"), page.click("input"),)
     )[0]
-    assert file_chooser.isMultiple == False
+    assert file_chooser.isMultiple is False
 
 
 async def test_should_work_for_multiple(page, server):

--- a/tests/test_popup.py
+++ b/tests/test_popup.py
@@ -111,7 +111,7 @@ async def test_should_inherit_offline_from_browser_context(context, server):
         }""",
         server.PREFIX + "/dummy.html",
     )
-    assert online == False
+    assert online is False
 
 
 async def test_should_inherit_http_credentials_from_browser_context(
@@ -276,7 +276,7 @@ async def test_should_work(context):
             page.evaluate('window.__popup = window.open("about:blank")'),
         )
     )[0]
-    assert await page.evaluate("!!window.opener") == False
+    assert await page.evaluate("!!window.opener") is False
     assert await popup.evaluate("!!window.opener")
 
 
@@ -291,7 +291,7 @@ async def test_should_work_with_window_features(context, server):
             ),
         )
     )[0]
-    assert await page.evaluate("!!window.opener") == False
+    assert await page.evaluate("!!window.opener") is False
     assert await popup.evaluate("!!window.opener")
 
 
@@ -354,7 +354,7 @@ async def test_should_work_with_empty_url(context):
             page.evaluate('() => window.__popup = window.open("")'),
         )
     )[0]
-    assert await page.evaluate("!!window.opener") == False
+    assert await page.evaluate("!!window.opener") is False
     assert await popup.evaluate("!!window.opener")
 
 
@@ -370,8 +370,8 @@ async def test_should_work_with_noopener_and_no_url(context):
     )[0]
     # Chromium reports 'about:blank#blocked' here.
     assert popup.url.split("#")[0] == "about:blank"
-    assert await page.evaluate("!!window.opener") == False
-    assert await popup.evaluate("!!window.opener") == False
+    assert await page.evaluate("!!window.opener") is False
+    assert await popup.evaluate("!!window.opener") is False
 
 
 async def test_should_work_with_noopener_and_about_blank(context):
@@ -384,8 +384,8 @@ async def test_should_work_with_noopener_and_about_blank(context):
             ),
         )
     )[0]
-    assert await page.evaluate("!!window.opener") == False
-    assert await popup.evaluate("!!window.opener") == False
+    assert await page.evaluate("!!window.opener") is False
+    assert await popup.evaluate("!!window.opener") is False
 
 
 async def test_should_work_with_noopener_and_url(context, server):
@@ -400,8 +400,8 @@ async def test_should_work_with_noopener_and_url(context, server):
             ),
         )
     )[0]
-    assert await page.evaluate("!!window.opener") == False
-    assert await popup.evaluate("!!window.opener") == False
+    assert await page.evaluate("!!window.opener") is False
+    assert await popup.evaluate("!!window.opener") is False
 
 
 async def test_should_work_with_clicking_target__blank(context, server):
@@ -409,7 +409,7 @@ async def test_should_work_with_clicking_target__blank(context, server):
     await page.goto(server.EMPTY_PAGE)
     await page.setContent('<a target=_blank rel="opener" href="/one-style.html">yo</a>')
     popup = (await asyncio.gather(page.waitForEvent("popup"), page.click("a"),))[0]
-    assert await page.evaluate("!!window.opener") == False
+    assert await page.evaluate("!!window.opener") is False
     assert await popup.evaluate("!!window.opener")
 
 
@@ -424,8 +424,8 @@ async def test_should_work_with_fake_clicking_target__blank_and_rel_noopener(
             page.waitForEvent("popup"), page.evalOnSelector("a", "a => a.click()"),
         )
     )[0]
-    assert await page.evaluate("!!window.opener") == False
-    assert await popup.evaluate("!!window.opener") == False
+    assert await page.evaluate("!!window.opener") is False
+    assert await popup.evaluate("!!window.opener") is False
 
 
 async def test_should_work_with_clicking_target__blank_and_rel_noopener(
@@ -435,8 +435,8 @@ async def test_should_work_with_clicking_target__blank_and_rel_noopener(
     await page.goto(server.EMPTY_PAGE)
     await page.setContent('<a target=_blank rel=noopener href="/one-style.html">yo</a>')
     popup = (await asyncio.gather(page.waitForEvent("popup"), page.click("a"),))[0]
-    assert await page.evaluate("!!window.opener") == False
-    assert await popup.evaluate("!!window.opener") == False
+    assert await page.evaluate("!!window.opener") is False
+    assert await popup.evaluate("!!window.opener") is False
 
 
 async def test_should_not_treat_navigations_as_new_popups(context, server):


### PR DESCRIPTION
Changes:
- Since no typing errors are persistent anymore, I've enforced it in the CI so only valid code will be shipped
- In VSCode you can use flake8 as a formatter (Seems most common) which I also enforced (but disabled a few rules). But will prevent us from doing bad things. Is integrated nicely in VSCode, GitHub Actions and as a pre-commit hook.
- Added tests from the downloads.spec.js