### PR TITLE
fix: added querySelectorAll to Frame

### DIFF
--- a/playwright/frame.py
+++ b/playwright/frame.py
@@ -134,7 +134,7 @@ class Frame(ChannelOwner):
     async def querySelectorAll(self, selector: str) -> List[ElementHandle]:
         return list(
             map(
-                cast(ElementHandle, from_nullable_channel),
+                cast(ElementHandle, from_channel),
                 await self._channel.send("querySelectorAll", dict(selector=selector)),
             )
         )

--- a/playwright/frame.py
+++ b/playwright/frame.py
@@ -131,6 +131,14 @@ class Frame(ChannelOwner):
             await self._channel.send("querySelector", dict(selector=selector))
         )
 
+    async def querySelectorAll(self, selector: str) -> List[ElementHandle]:
+        return list(
+            map(
+                cast(ElementHandle, from_nullable_channel),
+                await self._channel.send("querySelectorAll", dict(selector=selector)),
+            )
+        )
+
     async def waitForSelector(
         self,
         selector: str,


### PR DESCRIPTION
`Page.querySelectorAll` called `Frame.querySelectorAll` which was not existing. Tests will follow in the future.