### PR TITLE
devops: added coveralls as coverage provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install coveralls
         pip install -r local-requirements.txt
         pip install .
     - name: Build driver
@@ -70,10 +71,14 @@ jobs:
       if: ${{ matrix.os == 'windows-latest' }}
       # pytest-xdist does not exit on Windows
       # https://github.com/pytest-dev/pytest-xdist/issues/60
-      run: pytest -vv --browser=${{ matrix.browser }} --junitxml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.browser }}.xml
+      run: pytest -vv --browser=${{ matrix.browser }} --junitxml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.browser }}.xml --cov=playwright --cov-report xml
     - name: Test
       if: ${{ matrix.os != 'windows-latest' }}
-      run: pytest -vv --browser=${{ matrix.browser }} -n auto --junitxml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.browser }}.xml
+      run: pytest -vv --browser=${{ matrix.browser }} -n auto --junitxml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.browser }}.xml --cov=playwright --cov-report xml
+    - name: Coveralls
+      run: coveralls
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Upload pytest test results
       uses: actions/upload-artifact@v1
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ htmlcov/
 .vscode/
 .eggs
 _repo_version.py
+coverage.xml
+junit/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
+# 🎭 Playwright for Python
+
 [![PyPI version](https://badge.fury.io/py/playwright.svg)](https://pypi.python.org/pypi/playwright/) [![Join Slack](https://img.shields.io/badge/join-slack-infomational)](https://join.slack.com/t/playwright/shared_invite/enQtOTEyMTUxMzgxMjIwLThjMDUxZmIyNTRiMTJjNjIyMzdmZDA3MTQxZWUwZTFjZjQwNGYxZGM5MzRmNzZlMWI5ZWUyOTkzMjE5Njg1NDg) <!-- GEN:chromium-version-badge -->[![Chromium version](https://img.shields.io/badge/chromium-85.0.4182.0-blue.svg?logo=google-chrome)](https://www.chromium.org/Home)<!-- GEN:stop --> <!-- GEN:firefox-version-badge -->[![Firefox version](https://img.shields.io/badge/firefox-78.0b5-blue.svg?logo=mozilla-firefox)](https://www.mozilla.org/en-US/firefox/new/)<!-- GEN:stop --> [![WebKit version](https://img.shields.io/badge/webkit-14.0-blue.svg?logo=safari)](https://webkit.org/)
+[![Coverage Status](https://coveralls.io/repos/github/microsoft/playwright-python/badge.svg?branch=master)](https://coveralls.io/github/microsoft/playwright-python?branch=master)
 
 ##### [Docs](https://github.com/microsoft/playwright/blob/master/docs/README.md) | [API reference](https://github.com/microsoft/playwright/blob/master/docs/api.md)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ markers =
     only_browser
     skip_platform
     only_platform
+junit_family=xunit2
 [mypy]
 ignore_missing_imports = True
 python_version = 3.7


### PR DESCRIPTION
Is the `junit_family=xunit2` change for you okay? Will suppress the warning, that the format will change in pytest 6.0. 

See an example coveralls result page here which is actually already from this PR: https://coveralls.io/jobs/65053338
In further PRs (if merged) it should also be persistent as a Status check down below with the +/- percentage.