### PR TITLE
test: add test_navigation.py (part 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,12 +128,12 @@ async def run():
   browser = await chromium.launch()
   page = await browser.newPage()
 
-  async def log_and_continue_request(route, request):
+  def log_and_continue_request(route, request):
     print(request.url)
-    await route.continue_()
+    await asyncio.create_task(route.continue_())
 
   # Log and continue all network requests
-  await page.route('**', lambda route, request: asyncio.ensure_future(log_and_continue_request(route, request)))
+  await page.route('**', lambda route, request: log_and_continue_request(route, request))
 
   await page.goto('http://todomvc.com')
   await browser.close()

--- a/playwright/browser_context.py
+++ b/playwright/browser_context.py
@@ -76,27 +76,23 @@ class BrowserContext(ChannelOwner):
             if handler_entry.matcher.matches(request.url):
                 handler_entry.handler(route, request)
                 return
-        asyncio.ensure_future(route.continue_())
+        asyncio.create_task(route.continue_())
 
     def _on_binding(self, binding_call: BindingCall) -> None:
         func = self._bindings.get(binding_call._initializer["name"])
         if func is None:
             return
-        asyncio.ensure_future(binding_call.call(func))
+        asyncio.create_task(binding_call.call(func))
 
     def setDefaultNavigationTimeout(self, timeout: int) -> None:
         self._timeout_settings.set_navigation_timeout(timeout)
-        asyncio.ensure_future(
-            self._channel.send(
-                "setDefaultNavigationTimeoutNoReply", dict(timeout=timeout)
-            )
+        self._channel.send_no_reply(
+            "setDefaultNavigationTimeoutNoReply", dict(timeout=timeout)
         )
 
     def setDefaultTimeout(self, timeout: int) -> None:
         self._timeout_settings.set_timeout(timeout)
-        asyncio.ensure_future(
-            self._channel.send("setDefaultTimeoutNoReply", dict(timeout=timeout))
-        )
+        self._channel.send_no_reply("setDefaultTimeoutNoReply", dict(timeout=timeout))
 
     @property
     def pages(self) -> List[Page]:

--- a/playwright/sync_base.py
+++ b/playwright/sync_base.py
@@ -34,7 +34,7 @@ class Event:
         wait_helper.reject_on_timeout(
             timeout or 30000, f'Timeout while waiting for event "${event}"'
         )
-        self._future = asyncio.ensure_future(
+        self._future = asyncio.create_task(
             wait_helper.wait_for_event(sync_base._async_obj, event, predicate)
         )
 

--- a/playwright/wait_helper.py
+++ b/playwright/wait_helper.py
@@ -37,7 +37,7 @@ class WaitHelper:
         if timeout == 0:
             return
         self.reject_on(
-            asyncio.ensure_future(asyncio.sleep(timeout / 1000)), TimeoutError(message)
+            asyncio.create_task(asyncio.sleep(timeout / 1000)), TimeoutError(message)
         )
 
     def reject_on(self, future: asyncio.Future, error: Error) -> None:
@@ -45,7 +45,7 @@ class WaitHelper:
             await future
             return error
 
-        result = asyncio.ensure_future(future_wrapper())
+        result = asyncio.create_task(future_wrapper())
         result.add_done_callback(lambda f: future.cancel())
         self._failures.append(result)
 

--- a/tests/assets/historyapi.html
+++ b/tests/assets/historyapi.html
@@ -1,0 +1,5 @@
+<script>
+window.addEventListener('DOMContentLoaded', () => {
+  history.pushState({}, '', '#1');
+});
+</script>

--- a/tests/assets/self-request.html
+++ b/tests/assets/self-request.html
@@ -1,0 +1,5 @@
+<script>
+var req = new XMLHttpRequest();
+req.open('GET', '/self-request.html');
+req.send(null);
+</script>

--- a/tests/test_click.py
+++ b/tests/test_click.py
@@ -187,7 +187,7 @@ async def test_wait_for_display_none_to_be_gone(page, server):
         await page.click("button", timeout=0)
         done.append(True)
 
-    clicked = asyncio.ensure_future(click())
+    clicked = asyncio.create_task(click())
     await give_it_a_chance_to_click(page)
     assert await page.evaluate("result") == "Was not clicked"
     assert done == []
@@ -206,7 +206,7 @@ async def test_wait_for_visibility_hidden_to_be_gone(page, server):
         await page.click("button", timeout=0)
         done.append(True)
 
-    clicked = asyncio.ensure_future(click())
+    clicked = asyncio.create_task(click())
     await give_it_a_chance_to_click(page)
     assert await page.evaluate("result") == "Was not clicked"
     assert done == []
@@ -249,7 +249,7 @@ async def test_waitFor_visible_when_parent_is_hidden(page, server):
         await page.click("button", timeout=0)
         done.append(True)
 
-    clicked = asyncio.ensure_future(click())
+    clicked = asyncio.create_task(click())
     await give_it_a_chance_to_click(page)
     assert done == []
     await page.evalOnSelector("button", "b => b.parentElement.style.display = 'block'")
@@ -561,7 +561,7 @@ async def test_wait_for_becoming_hit_target(page, server):
         await page.click("button")
         clicked.append(True)
 
-    click_promise = asyncio.ensure_future(click())
+    click_promise = asyncio.create_task(click())
     assert clicked == [False]
 
     await page.evalOnSelector(".flyover", "flyOver => flyOver.style.left = '0'")
@@ -628,7 +628,7 @@ async def test_wait_for_button_to_be_enabled(page, server):
         await page.click("text=Click target")
         done.append(True)
 
-    click_promise = asyncio.ensure_future(click())
+    click_promise = asyncio.create_task(click())
     await give_it_a_chance_to_click(page)
     assert await page.evaluate("() => window.__CLICKED") is None
     assert done == []
@@ -661,7 +661,7 @@ async def test_wait_for_input_to_be_enabled(page, server):
         await page.click("input")
         done.append(True)
 
-    click_promise = asyncio.ensure_future(click())
+    click_promise = asyncio.create_task(click())
     await give_it_a_chance_to_click(page)
     assert await page.evaluate("window.__CLICKED") is None
     assert done == []
@@ -680,7 +680,7 @@ async def test_wait_for_select_to_be_enabled(page, server):
         await page.click("select")
         done.append(True)
 
-    click_promise = asyncio.ensure_future(click())
+    click_promise = asyncio.create_task(click())
     await give_it_a_chance_to_click(page)
     assert await page.evaluate("window.__CLICKED") is None
     assert done == []
@@ -725,7 +725,7 @@ async def test_wait_for_BUTTON_to_be_clickable_when_it_has_pointer_events_none(
         await page.click("text=Click target")
         done.append(True)
 
-    click_promise = asyncio.ensure_future(click())
+    click_promise = asyncio.create_task(click())
     await give_it_a_chance_to_click(page)
     assert await page.evaluate("window.__CLICKED") is None
     assert done == []
@@ -742,7 +742,7 @@ async def test_wait_for_LABEL_to_be_clickable_when_it_has_pointer_events_none(
     await page.setContent(
         '<label onclick="javascript:window.__CLICKED=true;" style="pointer-events:none"><span>Click target</span></label>'
     )
-    click_promise = asyncio.ensure_future(page.click("text=Click target"))
+    click_promise = asyncio.create_task(page.click("text=Click target"))
     #  Do a few roundtrips to the page.
     for _ in range(5):
         assert await page.evaluate("window.__CLICKED") is None
@@ -803,7 +803,8 @@ async def test_fail_when_element_detaches_after_animation(page, server):
     await page.goto(server.PREFIX + "/input/animating-button.html")
     await page.evaluate("addButton()")
     handle = await page.querySelector("button")
-    promise = asyncio.ensure_future(handle.click())
+    promise = asyncio.create_task(handle.click())
+    await asyncio.sleep(0)  # execute scheduled tasks, but don't await them
     await page.evaluate("stopButton(true)")
     error = None
     try:
@@ -823,7 +824,8 @@ async def test_retry_when_element_detaches_after_animation(page, server):
         await page.click("button")
         clicked.append(True)
 
-    promise = asyncio.ensure_future(click())
+    promise = asyncio.create_task(click())
+    await asyncio.sleep(0)  # execute scheduled tasks, but don't await them
     assert clicked == []
     assert await page.evaluate("window.clicked") is None
     await page.evaluate("stopButton(true)")
@@ -864,7 +866,8 @@ async def test_retry_when_element_is_animating_from_outside_the_viewport(page, s
         """
     )
     handle = await page.querySelector("button")
-    promise = asyncio.ensure_future(handle.click())
+    promise = asyncio.create_task(handle.click())
+    await asyncio.sleep(0)  # execute scheduled tasks, but don't await them
     await handle.evaluate("button => button.className = 'animated'")
     await promise
     assert await page.evaluate("window.clicked")
@@ -896,7 +899,8 @@ async def test_fail_when_element_is_animating_from_outside_the_viewport_with_for
         """
     )
     handle = await page.querySelector("button")
-    promise = asyncio.ensure_future(handle.click(force=True))
+    promise = asyncio.create_task(handle.click(force=True))
+    await asyncio.sleep(0)  # execute scheduled tasks, but don't await them
     await handle.evaluate("button => button.className = 'animated'")
     error = None
     try:
@@ -943,7 +947,8 @@ async def test_click_the_button_when_window_inner_width_is_corrupted(page, serve
 
 
 async def test_timeout_when_click_opens_alert(page, server):
-    dialog_promise = asyncio.ensure_future(page.waitForEvent("dialog"))
+    dialog_promise = asyncio.create_task(page.waitForEvent("dialog"))
+    await asyncio.sleep(0)  # execute scheduled tasks, but don't await them
     await page.setContent('<div onclick="window.alert(123)">Click me</div>')
     error = None
     try:

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -106,7 +106,7 @@ async def test_report_download_path_within_page_on_download_handler_for_files(
         on_download_path.set_result(await download.path())
 
     page.once(
-        "download", lambda res: asyncio.ensure_future(on_download(res)),
+        "download", lambda res: asyncio.create_task(on_download(res)),
     )
     await page.setContent(f'<a href="{server.PREFIX}/download">download</a>')
     await page.click("a")
@@ -125,7 +125,7 @@ async def test_download_report_download_path_within_page_on_handle_for_blobs(
         on_download_path.set_result(await download.path())
 
     page.once(
-        "download", lambda res: asyncio.ensure_future(on_download(res)),
+        "download", lambda res: asyncio.create_task(on_download(res)),
     )
 
     await page.goto(server.PREFIX + "/download-blob.html")

--- a/tests/test_element_handle.py
+++ b/tests/test_element_handle.py
@@ -394,7 +394,8 @@ async def waiting_helper(page, after):
         await div.scrollIntoViewIfNeeded()
         done.append(True)
 
-    promise = asyncio.ensure_future(scroll())
+    promise = asyncio.create_task(scroll())
+    await asyncio.sleep(0)  # execute scheduled tasks, but don't await them
     await page.evaluate("() => new Promise(f => setTimeout(f, 1000))")
     assert done == [False]
     await div.evaluate(after)
@@ -512,7 +513,8 @@ async def test_select_text_wait_for_visible(page, server):
         await textarea.selectText(timeout=3000)
         done.append(True)
 
-    promise = asyncio.ensure_future(select_text())
+    promise = asyncio.create_task(select_text())
+    await asyncio.sleep(0)  # execute scheduled tasks, but don't await them
     await page.evaluate("() => new Promise(f => setTimeout(f, 1000))")
     await textarea.evaluate('e => e.style.display = "block"')
     await promise

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -81,7 +81,8 @@ async def test_should_emit_event(page: Page, server):
 
 async def test_should_work_when_file_input_is_attached_to_DOM(page: Page, server):
     await page.setContent("<input type=file>")
-    file_chooser = asyncio.ensure_future(page.waitForEvent("filechooser"))
+    file_chooser = asyncio.create_task(page.waitForEvent("filechooser"))
+    await asyncio.sleep(0)  # execute scheduled tasks, but don't await them
     await page.click("input")
     assert await file_chooser
 
@@ -127,9 +128,7 @@ async def test_should_accept_single_file(page: Page, server):
 async def test_should_be_able_to_read_selected_file(page: Page, server):
     page.once(
         "filechooser",
-        lambda file_chooser: asyncio.ensure_future(
-            file_chooser.setFiles(FILE_TO_UPLOAD)
-        ),
+        lambda file_chooser: asyncio.create_task(file_chooser.setFiles(FILE_TO_UPLOAD)),
     )
     await page.setContent("<input type=file>")
     content = await page.evalOnSelector(
@@ -152,9 +151,7 @@ async def test_should_be_able_to_reset_selected_files_with_empty_file_list(
     await page.setContent("<input type=file>")
     page.once(
         "filechooser",
-        lambda file_chooser: asyncio.ensure_future(
-            file_chooser.setFiles(FILE_TO_UPLOAD)
-        ),
+        lambda file_chooser: asyncio.create_task(file_chooser.setFiles(FILE_TO_UPLOAD)),
     )
     file_length_1 = (
         await asyncio.gather(
@@ -173,7 +170,7 @@ async def test_should_be_able_to_reset_selected_files_with_empty_file_list(
 
     page.once(
         "filechooser",
-        lambda file_chooser: asyncio.ensure_future(file_chooser.setFiles([])),
+        lambda file_chooser: asyncio.create_task(file_chooser.setFiles([])),
     )
     file_length_2 = (
         await asyncio.gather(

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -1,0 +1,471 @@
+# Copyright (c) Microsoft Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import os
+import pathlib
+import sys
+
+import pytest
+
+from playwright import Error
+from playwright.helper import TimeoutError
+from playwright.network import Request
+
+__dirname = os.path.dirname(os.path.realpath(__file__))
+
+
+async def test_goto_should_work(page, server):
+    await page.goto(server.EMPTY_PAGE)
+    assert page.url == server.EMPTY_PAGE
+
+
+async def test_goto_should_work_with_file_URL(page, server):
+    fileurl = pathlib.Path(
+        os.path.join(__dirname, "assets", "frames", "two-frames.html")
+    ).as_uri()
+    await page.goto(fileurl)
+    assert page.url.lower() == fileurl.lower()
+    assert len(page.frames) == 3
+
+
+async def test_goto_should_use_http_for_no_protocol(page, server):
+    await page.goto(server.EMPTY_PAGE[7:])
+    assert page.url == server.EMPTY_PAGE
+
+
+async def test_goto_should_work_cross_process(page, server):
+    await page.goto(server.EMPTY_PAGE)
+    assert page.url == server.EMPTY_PAGE
+
+    url = server.CROSS_PROCESS_PREFIX + "/empty.html"
+    request_frames = []
+
+    def on_request(r: Request) -> None:
+        if r.url == url:
+            request_frames.append(r.frame)
+
+    page.on("request", on_request)
+
+    response = await page.goto(url)
+    assert page.url == url
+    assert response.frame == page.mainFrame
+    assert request_frames[0] == page.mainFrame
+    assert response.url == url
+
+
+async def test_goto_should_capture_iframe_navigation_request(page, server):
+    await page.goto(server.EMPTY_PAGE)
+    assert page.url == server.EMPTY_PAGE
+
+    request_frames = []
+
+    def on_request(r: Request) -> None:
+        if r.url == server.PREFIX + "/frames/frame.html":
+            request_frames.append(r.frame)
+
+    page.on("request", on_request)
+
+    response = await page.goto(server.PREFIX + "/frames/one-frame.html")
+    assert page.url == server.PREFIX + "/frames/one-frame.html"
+    assert response.frame == page.mainFrame
+    assert response.url == server.PREFIX + "/frames/one-frame.html"
+
+    assert len(page.frames) == 2
+    assert request_frames[0] == page.frames[1]
+
+
+async def test_goto_should_capture_cross_process_iframe_navigation_request(
+    page, server
+):
+    await page.goto(server.EMPTY_PAGE)
+    assert page.url == server.EMPTY_PAGE
+
+    request_frames = []
+
+    def on_request(r: Request) -> None:
+        if r.url == server.CROSS_PROCESS_PREFIX + "/frames/frame.html":
+            request_frames.append(r.frame)
+
+    page.on("request", on_request)
+
+    response = await page.goto(server.CROSS_PROCESS_PREFIX + "/frames/one-frame.html")
+    assert page.url == server.CROSS_PROCESS_PREFIX + "/frames/one-frame.html"
+    assert response.frame == page.mainFrame
+    assert response.url == server.CROSS_PROCESS_PREFIX + "/frames/one-frame.html"
+
+    assert len(page.frames) == 2
+    assert request_frames[0] == page.frames[1]
+
+
+async def test_goto_should_work_with_anchor_navigation(page, server):
+    await page.goto(server.EMPTY_PAGE)
+    assert page.url == server.EMPTY_PAGE
+    await page.goto(server.EMPTY_PAGE + "#foo")
+    assert page.url == server.EMPTY_PAGE + "#foo"
+    await page.goto(server.EMPTY_PAGE + "#bar")
+    assert page.url == server.EMPTY_PAGE + "#bar"
+
+
+async def test_goto_should_work_with_redirects(page, server):
+    server.set_redirect("/redirect/1.html", "/redirect/2.html")
+    server.set_redirect("/redirect/2.html", "/empty.html")
+    response = await page.goto(server.PREFIX + "/redirect/1.html")
+    assert response.status == 200
+    assert page.url == server.EMPTY_PAGE
+
+
+async def test_goto_should_navigate_to_about_blank(page, server):
+    response = await page.goto("about:blank")
+    assert response is None
+
+
+async def test_goto_should_return_response_when_page_changes_its_URL_after_load(
+    page, server
+):
+    response = await page.goto(server.PREFIX + "/historyapi.html")
+    assert response.status == 200
+
+
+async def test_goto_should_work_with_subframes_return_204(page, server):
+    def handle(request):
+        request.setResponseCode(204)
+        request.finish()
+
+    server.set_route("/frames/frame.html", handle)
+
+    await page.goto(server.PREFIX + "/frames/one-frame.html")
+
+
+async def test_goto_should_fail_when_server_returns_204(
+    page, server, is_chromium, is_webkit
+):
+    # WebKit just loads an empty page.
+    def handle(request):
+        request.setResponseCode(204)
+        request.finish()
+
+    server.set_route("/empty.html", handle)
+
+    with pytest.raises(Error) as exc_info:
+        await page.goto(server.EMPTY_PAGE)
+    assert exc_info.value
+    if is_chromium:
+        assert "net::ERR_ABORTED" in exc_info.value.message
+    elif is_webkit:
+        assert "Aborted: 204 No Content" in exc_info.value.message
+    else:
+        assert "NS_BINDING_ABORTED" in exc_info.value.message
+
+
+async def test_goto_should_navigate_to_empty_page_with_domcontentloaded(page, server):
+    response = await page.goto(server.EMPTY_PAGE, waitUntil="domcontentloaded")
+    assert response.status == 200
+
+
+async def test_goto_should_work_when_page_calls_history_API_in_beforeunload(
+    page, server
+):
+    await page.goto(server.EMPTY_PAGE)
+    await page.evaluate(
+        """() => {
+        window.addEventListener('beforeunload', () => history.replaceState(null, 'initial', window.location.href), false)
+    }"""
+    )
+
+    response = await page.goto(server.PREFIX + "/grid.html")
+    assert response.status == 200
+
+
+async def test_goto_should_fail_when_navigating_to_bad_url(
+    page, server, is_chromium, is_webkit
+):
+    with pytest.raises(Error) as exc_info:
+        await page.goto("asdfasdf")
+    if is_chromium or is_webkit:
+        assert "Cannot navigate to invalid URL" in exc_info.value.message
+    else:
+        assert "Invalid url" in exc_info.value.message
+
+
+async def test_goto_should_fail_when_navigating_to_bad_ssl(
+    page, https_server, browser_name
+):
+    with pytest.raises(Error) as exc_info:
+        await page.goto(https_server.EMPTY_PAGE)
+    expect_ssl_error(exc_info.value.message, browser_name)
+
+
+async def test_goto_should_fail_when_navigating_to_bad_ssl_after_redirects(
+    page, server, https_server, browser_name
+):
+    server.set_redirect("/redirect/1.html", "/redirect/2.html")
+    server.set_redirect("/redirect/2.html", "/empty.html")
+    with pytest.raises(Error) as exc_info:
+        await page.goto(https_server.PREFIX + "/redirect/1.html")
+    expect_ssl_error(exc_info.value.message, browser_name)
+
+
+async def test_goto_should_not_crash_when_navigating_to_bad_ssl_after_a_cross_origin_navigation(
+    page, server, https_server, browser_name
+):
+    await page.goto(server.CROSS_PROCESS_PREFIX + "/empty.html")
+    with pytest.raises(Error):
+        await page.goto(https_server.EMPTY_PAGE)
+
+
+async def test_goto_should_not_throw_if_networkidle0_is_passed_as_an_option(
+    page, server
+):
+    await page.goto(server.EMPTY_PAGE, waitUntil="networkidle0")
+
+
+async def test_goto_should_throw_if_networkidle2_is_passed_as_an_option(page, server):
+    with pytest.raises(Error) as exc_info:
+        await page.goto(server.EMPTY_PAGE, waitUntil="networkidle2")
+    assert "Unsupported waitUntil option" in exc_info.value.message
+
+
+async def test_goto_should_fail_when_main_resources_failed_to_load(
+    page, server, is_chromium, is_webkit, is_win
+):
+    with pytest.raises(Error) as exc_info:
+        await page.goto("http://localhost:44123/non-existing-url")
+    if is_chromium:
+        assert "net::ERR_CONNECTION_REFUSED" in exc_info.value.message
+    elif is_webkit and is_win:
+        assert "Couldn't connect to server" in exc_info.value.message
+    elif is_webkit:
+        assert "Could not connect" in exc_info.value.message
+    else:
+        assert "NS_ERROR_CONNECTION_REFUSED" in exc_info.value.message
+
+
+async def test_goto_should_fail_when_exceeding_maximum_navigation_timeout(page, server):
+    # Hang for request to the empty.html
+    server.set_route("/empty.html", lambda request: None)
+    with pytest.raises(Error) as exc_info:
+        await page.goto(server.PREFIX + "/empty.html", timeout=1)
+    assert "Timeout 1ms exceeded" in exc_info.value.message
+    assert server.PREFIX + "/empty.html" in exc_info.value.message
+    assert isinstance(exc_info.value, TimeoutError)
+
+
+async def test_goto_should_fail_when_exceeding_default_maximum_navigation_timeout(
+    page, server
+):
+    # Hang for request to the empty.html
+    server.set_route("/empty.html", lambda request: None)
+    page.context.setDefaultNavigationTimeout(2)
+    page.setDefaultNavigationTimeout(1)
+    with pytest.raises(Error) as exc_info:
+        await page.goto(server.PREFIX + "/empty.html")
+    assert "Timeout 1ms exceeded" in exc_info.value.message
+    assert server.PREFIX + "/empty.html" in exc_info.value.message
+    assert isinstance(exc_info.value, TimeoutError)
+
+
+async def test_goto_should_fail_when_exceeding_browser_context_navigation_timeout(
+    page, server
+):
+    # Hang for request to the empty.html
+    server.set_route("/empty.html", lambda request: None)
+    page.context.setDefaultNavigationTimeout(2)
+    with pytest.raises(Error) as exc_info:
+        await page.goto(server.PREFIX + "/empty.html")
+    assert "Timeout 2ms exceeded" in exc_info.value.message
+    assert server.PREFIX + "/empty.html" in exc_info.value.message
+    assert isinstance(exc_info.value, TimeoutError)
+
+
+async def test_goto_should_fail_when_exceeding_default_maximum_timeout(page, server):
+    # Hang for request to the empty.html
+    server.set_route("/empty.html", lambda request: None)
+    page.context.setDefaultTimeout(2)
+    page.setDefaultTimeout(1)
+    with pytest.raises(Error) as exc_info:
+        await page.goto(server.PREFIX + "/empty.html")
+    assert "Timeout 1ms exceeded" in exc_info.value.message
+    assert server.PREFIX + "/empty.html" in exc_info.value.message
+    assert isinstance(exc_info.value, TimeoutError)
+
+
+async def test_goto_should_fail_when_exceeding_browser_context_timeout(page, server):
+    # Hang for request to the empty.html
+    server.set_route("/empty.html", lambda request: None)
+    page.context.setDefaultTimeout(2)
+    with pytest.raises(Error) as exc_info:
+        await page.goto(server.PREFIX + "/empty.html")
+    assert "Timeout 2ms exceeded" in exc_info.value.message
+    assert server.PREFIX + "/empty.html" in exc_info.value.message
+    assert isinstance(exc_info.value, TimeoutError)
+
+
+async def test_goto_should_prioritize_default_navigation_timeout_over_default_timeout(
+    page, server
+):
+    # Hang for request to the empty.html
+    server.set_route("/empty.html", lambda request: None)
+    page.setDefaultTimeout(0)
+    page.setDefaultNavigationTimeout(1)
+    with pytest.raises(Error) as exc_info:
+        await page.goto(server.PREFIX + "/empty.html")
+    assert "Timeout 1ms exceeded" in exc_info.value.message
+    assert server.PREFIX + "/empty.html" in exc_info.value.message
+    assert isinstance(exc_info.value, TimeoutError)
+
+
+async def test_goto_should_disable_timeout_when_its_set_to_0(page, server):
+    loaded = []
+    page.once("load", lambda: loaded.append(True))
+    await page.goto(server.PREFIX + "/grid.html", timeout=0, waitUntil="load")
+    assert loaded == [True]
+
+
+async def test_goto_should_work_when_navigating_to_valid_url(page, server):
+    response = await page.goto(server.EMPTY_PAGE)
+    assert response.ok
+
+
+async def test_goto_should_work_when_navigating_to_data_url(page, server):
+    response = await page.goto("data:text/html,hello")
+    assert response is None
+
+
+async def test_goto_should_work_when_navigating_to_404(page, server):
+    response = await page.goto(server.PREFIX + "/not-found")
+    assert response.ok is False
+    assert response.status == 404
+
+
+async def test_goto_should_return_last_response_in_redirect_chain(page, server):
+    server.set_redirect("/redirect/1.html", "/redirect/2.html")
+    server.set_redirect("/redirect/2.html", "/redirect/3.html")
+    server.set_redirect("/redirect/3.html", server.EMPTY_PAGE)
+    response = await page.goto(server.PREFIX + "/redirect/1.html")
+    assert response.ok
+    assert response.url == server.EMPTY_PAGE
+
+
+async def test_goto_should_navigate_to_data_url_and_not_fire_dataURL_requests(
+    page, server
+):
+    requests = []
+    page.on("request", lambda request: requests.append(request))
+    dataURL = "data:text/html,<div>yo</div>"
+    response = await page.goto(dataURL)
+    assert response is None
+    assert requests == []
+
+
+async def test_goto_should_navigate_to_url_with_hash_and_fire_requests_without_hash(
+    page, server
+):
+    requests = []
+    page.on("request", lambda request: requests.append(request))
+    response = await page.goto(server.EMPTY_PAGE + "#hash")
+    assert response.status == 200
+    assert response.url == server.EMPTY_PAGE
+    assert len(requests) == 1
+    assert requests[0].url == server.EMPTY_PAGE
+
+
+async def test_goto_should_work_with_self_requesting_page(page, server):
+    response = await page.goto(server.PREFIX + "/self-request.html")
+    assert response.status == 200
+    assert "self-request.html" in response.url
+
+
+async def test_goto_should_fail_when_navigating_and_show_the_url_at_the_error_message(
+    page, server, https_server
+):
+    url = https_server.PREFIX + "/redirect/1.html"
+    with pytest.raises(Error) as exc_info:
+        await page.goto(url)
+    assert url in exc_info.value.message
+
+
+async def test_goto_should_be_able_to_navigate_to_a_page_controlled_by_service_worker(
+    page, server
+):
+    await page.goto(server.PREFIX + "/serviceworkers/fetch/sw.html")
+    await page.evaluate("window.activationPromise")
+    await page.goto(server.PREFIX + "/serviceworkers/fetch/sw.html")
+
+
+async def test_goto_should_send_referer(page, server):
+    [request1, request2, _] = await asyncio.gather(
+        server.wait_for_request("/grid.html"),
+        server.wait_for_request("/digits/1.png"),
+        page.goto(server.PREFIX + "/grid.html", referer="http://google.com/"),
+    )
+    assert request1.getHeader("referer") == "http://google.com/"
+    # Make sure subresources do not inherit referer.
+    assert request2.getHeader("referer") == server.PREFIX + "/grid.html"
+    assert page.url == server.PREFIX + "/grid.html"
+
+
+async def test_goto_should_reject_referer_option_when_set_extra_http_headers_provides_referer(
+    page, server
+):
+    await page.setExtraHTTPHeaders({"referer": "http://microsoft.com/"})
+    with pytest.raises(Error) as exc_info:
+        await page.goto(server.PREFIX + "/grid.html", referer="http://google.com/")
+    assert (
+        '"referer" is already specified as extra HTTP header' in exc_info.value.message
+    )
+    assert server.PREFIX + "/grid.html" in exc_info.value.message
+
+
+async def test_network_idle_should_navigate_to_empty_page_with_networkidle(
+    page, server
+):
+    response = await page.goto(server.EMPTY_PAGE, waitUntil="networkidle")
+    assert response.status == 200
+
+
+async def test_wait_for_nav_should_work(page, server):
+    await page.goto(server.EMPTY_PAGE)
+    [response, _] = await asyncio.gather(
+        page.waitForNavigation(),
+        page.evaluate(
+            "url => window.location.href = url", server.PREFIX + "/grid.html"
+        ),
+    )
+    assert response.ok
+    assert "grid.html" in response.url
+
+
+async def test_wait_for_nav_should_respect_timeout(page, server):
+    asyncio.create_task(page.goto(server.EMPTY_PAGE))
+    with pytest.raises(Error) as exc_info:
+        await page.waitForNavigation(url="**/frame.html", timeout=5000)
+    assert "Timeout 5000ms exceeded" in exc_info.value.message
+    # TODO: implement logging
+    # assert 'waiting for navigation to "**/frame.html" until "load"' in exc_info.value.message
+    # assert f'navigated to "{server.EMPTY_PAGE}"' in exc_info.value.message
+
+
+def expect_ssl_error(error_message: str, browser_name: str) -> None:
+    if browser_name == "chromium":
+        assert "net::ERR_CERT_AUTHORITY_INVALID" in error_message
+    elif browser_name == "webkit":
+        if sys.platform == "darwin":
+            assert "The certificate for this server is invalid" in error_message
+        elif sys.platform == "win32":
+            assert "SSL connect error" in error_message
+        else:
+            assert "Unacceptable TLS certificate" in error_message
+    else:
+        assert "SSL_ERROR_UNKNOWN" in error_message

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -40,7 +40,7 @@ async def test_request_fulfill(page):
 
     await page.route(
         "**/empty.html",
-        lambda route, request: asyncio.ensure_future(handle_request(route, request)),
+        lambda route, request: asyncio.create_task(handle_request(route, request)),
     )
 
     response = await page.goto("http://www.non-existent.com/empty.html")
@@ -56,7 +56,7 @@ async def test_request_continue(page, server):
     intercepted = list()
     await page.route(
         "**/*",
-        lambda route, request: asyncio.ensure_future(
+        lambda route, request: asyncio.create_task(
             handle_request(route, request, intercepted)
         ),
     )
@@ -170,7 +170,7 @@ async def test_request_headers_should_get_the_same_headers_as_the_server(
 
     server.set_route("/something", handle_something)
 
-    requestPromise = asyncio.ensure_future(page.waitForEvent("request"))
+    requestPromise = asyncio.create_task(page.waitForEvent("request"))
     text = await page.evaluate(
         """async url => {
       const data = await fetch(url);

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -39,7 +39,8 @@ async def test_workers_page_workers(page, server):
 
 
 async def test_workers_should_emit_created_and_destroyed_events(page: Page):
-    worker_createdpromise = asyncio.ensure_future(page.waitForEvent("worker"))
+    worker_createdpromise = asyncio.create_task(page.waitForEvent("worker"))
+    await asyncio.sleep(0)  # execute scheduled tasks, but don't await them
     worker_obj = await page.evaluateHandle(
         "() => new Worker(URL.createObjectURL(new Blob(['1'], {type: 'application/javascript'})))"
     )
@@ -78,7 +79,8 @@ async def test_workers_should_have_JSHandles_for_console_logs(page):
 
 
 async def test_workers_should_evaluate(page):
-    worker_createdpromise = asyncio.ensure_future(page.waitForEvent("worker"))
+    worker_createdpromise = asyncio.create_task(page.waitForEvent("worker"))
+    await asyncio.sleep(0)  # execute scheduled tasks, but don't await them
     await page.evaluate(
         "() => new Worker(URL.createObjectURL(new Blob(['console.log(1)'], {type: 'application/javascript'})))"
     )
@@ -104,7 +106,8 @@ async def test_workers_should_report_errors(page):
 
 async def test_workers_should_clear_upon_navigation(server, page):
     await page.goto(server.EMPTY_PAGE)
-    worker_createdpromise = asyncio.ensure_future(page.waitForEvent("worker"))
+    worker_createdpromise = asyncio.create_task(page.waitForEvent("worker"))
+    await asyncio.sleep(0)  # execute scheduled tasks, but don't await them
     await page.evaluate(
         '() => new Worker(URL.createObjectURL(new Blob(["console.log(1)"], {type: "application/javascript"})))'
     )
@@ -119,7 +122,8 @@ async def test_workers_should_clear_upon_navigation(server, page):
 
 async def test_workers_should_clear_upon_cross_process_navigation(server, page):
     await page.goto(server.EMPTY_PAGE)
-    worker_createdpromise = asyncio.ensure_future(page.waitForEvent("worker"))
+    worker_createdpromise = asyncio.create_task(page.waitForEvent("worker"))
+    await asyncio.sleep(0)  # execute scheduled tasks, but don't await them
     await page.evaluate(
         "() => new Worker(URL.createObjectURL(new Blob(['console.log(1)'], {type: 'application/javascript'})))"
     )
@@ -137,8 +141,9 @@ async def test_workers_should_report_network_activity(page, server):
         page.waitForEvent("worker"), page.goto(server.PREFIX + "/worker/worker.html"),
     )
     url = server.PREFIX + "/one-style.css"
-    request_promise = asyncio.ensure_future(page.waitForRequest(url))
-    response_promise = asyncio.ensure_future(page.waitForResponse(url))
+    request_promise = asyncio.create_task(page.waitForRequest(url))
+    response_promise = asyncio.create_task(page.waitForResponse(url))
+    await asyncio.sleep(0)  # execute scheduled tasks, but don't await them
     await worker.evaluate(
         "url => fetch(url).then(response => response.text()).then(console.log)", url
     )
@@ -153,8 +158,9 @@ async def test_workers_should_report_network_activity_on_worker_creation(page, s
     # Chromium needs waitForDebugger enabled for this one.
     await page.goto(server.EMPTY_PAGE)
     url = server.PREFIX + "/one-style.css"
-    request_promise = asyncio.ensure_future(page.waitForRequest(url))
-    response_promise = asyncio.ensure_future(page.waitForResponse(url))
+    request_promise = asyncio.create_task(page.waitForRequest(url))
+    response_promise = asyncio.create_task(page.waitForResponse(url))
+    await asyncio.sleep(0)  # execute scheduled tasks, but don't await them
     await page.evaluate(
         """url => new Worker(URL.createObjectURL(new Blob([`
       fetch("${url}").then(response => response.text()).then(console.log);


### PR DESCRIPTION
drive-by replacing `asyncio.ensure_future` since "create_task() function is the preferred way for creating new Tasks."