### PR TITLE
feat(expect): add typed expectations into the page & browser context.

### DIFF
--- a/client.py
+++ b/client.py
@@ -22,9 +22,9 @@ def main() -> None:
         "<button id=button onclick=\"window.open('http://webkit.org', '_blank')\">Click me</input>"
     )
 
-    with page.expect_event("popup") as popup:
+    with page.expect_popup() as popup_info:
         page.click("#button")
-    print(popup.value)
+    print(popup_info.value)
 
     print("Contexts in browser: %d" % len(browser.contexts))
     print("Creating context...")

--- a/playwright/browser_context.py
+++ b/playwright/browser_context.py
@@ -17,6 +17,7 @@ from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 from playwright.connection import ChannelOwner, ConnectionScope, from_channel
+from playwright.event_context_manager import AsyncEventContextManager
 from playwright.helper import (
     Cookie,
     Error,
@@ -212,3 +213,13 @@ class BrowserContext(ChannelOwner):
             return
         self._is_closed_or_closing = True
         await self._channel.send("close")
+
+    def expect_event(
+        self, event: str, predicate: Callable[[Any], bool] = None, timeout: int = None,
+    ) -> AsyncEventContextManager:
+        return AsyncEventContextManager(self, event, predicate, timeout)
+
+    def expect_page(
+        self, predicate: Callable[[Page], bool] = None, timeout: int = None,
+    ) -> AsyncEventContextManager[Page]:
+        return AsyncEventContextManager(self, "page", predicate, timeout)

--- a/playwright/event_context_manager.py
+++ b/playwright/event_context_manager.py
@@ -1,0 +1,62 @@
+# Copyright (c) Microsoft Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from typing import Any, Callable, Generic, Optional, TypeVar, cast
+
+from playwright.connection import ChannelOwner
+from playwright.wait_helper import WaitHelper
+
+T = TypeVar("T")
+
+
+class AsyncEventInfo(Generic[T]):
+    def __init__(
+        self,
+        channel_owner: ChannelOwner,
+        event: str,
+        predicate: Callable[[T], bool] = None,
+        timeout: int = None,
+    ) -> None:
+        self._value: Optional[T] = None
+        wait_helper = WaitHelper()
+        wait_helper.reject_on_timeout(
+            timeout or 30000, f'Timeout while waiting for event "${event}"'
+        )
+        self._future = asyncio.get_event_loop().create_task(
+            wait_helper.wait_for_event(channel_owner, event, predicate)
+        )
+
+    @property
+    async def value(self) -> T:
+        if not self._value:
+            self._value = await self._future
+        return cast(T, self._value)
+
+
+class AsyncEventContextManager(Generic[T]):
+    def __init__(
+        self,
+        channel_owner: ChannelOwner,
+        event: str,
+        predicate: Callable[[T], bool] = None,
+        timeout: int = None,
+    ) -> None:
+        self._event = AsyncEventInfo(channel_owner, event, predicate, timeout)
+
+    async def __aenter__(self) -> AsyncEventInfo[T]:
+        return self._event
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        await self._event.value

--- a/playwright/file_chooser.py
+++ b/playwright/file_chooser.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, List, Union
+from typing import TYPE_CHECKING, Any, List, Union
 
 from playwright.helper import FilePayload
 
@@ -25,6 +25,7 @@ class FileChooser:
     def __init__(
         self, page: "Page", element_handle: "ElementHandle", is_multiple: bool
     ) -> None:
+        self._sync_owner: Any = None
         self._page = page
         self._element_handle = element_handle
         self._is_multiple = is_multiple

--- a/playwright/sync.py
+++ b/playwright/sync.py
@@ -15,7 +15,7 @@
 import sys
 import typing
 
-from playwright.sync_base import SyncBase, mapping
+from playwright.sync_base import EventContextManager, SyncBase, mapping
 
 if sys.version_info >= (3, 8):  # pragma: no cover
     from typing import Literal
@@ -31,6 +31,7 @@ from playwright.console_message import ConsoleMessage as ConsoleMessageAsync
 from playwright.dialog import Dialog as DialogAsync
 from playwright.download import Download as DownloadAsync
 from playwright.element_handle import ElementHandle as ElementHandleAsync
+from playwright.file_chooser import FileChooser as FileChooserAsync
 from playwright.frame import Frame as FrameAsync
 from playwright.helper import (
     ConsoleMessageLocation,
@@ -768,6 +769,67 @@ class Accessibility(SyncBase):
 
 
 mapping.register(AccessibilityAsync, Accessibility)
+
+
+class FileChooser(SyncBase):
+    def __init__(self, obj: FileChooserAsync):
+        super().__init__(obj)
+
+    def as_async(self) -> FileChooserAsync:
+        return self._async_obj
+
+    @classmethod
+    def _from_async(cls, obj: FileChooserAsync) -> "FileChooser":
+        if not obj._sync_owner:
+            obj._sync_owner = cls(obj)
+        return obj._sync_owner
+
+    @classmethod
+    def _from_async_nullable(
+        cls, obj: FileChooserAsync = None
+    ) -> typing.Optional["FileChooser"]:
+        return FileChooser._from_async(obj) if obj else None
+
+    @classmethod
+    def _from_async_list(
+        cls, items: typing.List[FileChooserAsync]
+    ) -> typing.List["FileChooser"]:
+        return list(map(lambda a: FileChooser._from_async(a), items))
+
+    @classmethod
+    def _from_async_dict(
+        cls, map: typing.Dict[str, FileChooserAsync]
+    ) -> typing.Dict[str, "FileChooser"]:
+        return {name: FileChooser._from_async(value) for name, value in map.items()}
+
+    @property
+    def page(self) -> "Page":
+        return Page._from_async(self._async_obj.page)
+
+    @property
+    def element(self) -> "ElementHandle":
+        return ElementHandle._from_async(self._async_obj.element)
+
+    @property
+    def isMultiple(self) -> bool:
+        return self._async_obj.isMultiple
+
+    def setFiles(
+        self,
+        files: typing.Union[
+            str, FilePayload, typing.List[str], typing.List[FilePayload]
+        ],
+        timeout: int = None,
+        noWaitAfter: bool = None,
+    ) -> NoneType:
+        return self._sync(
+            self._async_obj.setFiles(
+                files=files, timeout=timeout, noWaitAfter=noWaitAfter
+            )
+        )
+
+
+mapping.register(FileChooserAsync, FileChooser)
 
 
 class Frame(SyncBase):
@@ -2119,6 +2181,62 @@ class Page(SyncBase):
             )
         )
 
+    def expect_console_message(
+        self,
+        predicate: typing.Union[typing.Callable[["ConsoleMessage"], bool]] = None,
+        timeout: int = None,
+    ) -> EventContextManager["ConsoleMessage"]:
+        return EventContextManager(self, "console", predicate, timeout)
+
+    def expect_dialog(
+        self,
+        predicate: typing.Union[typing.Callable[["Dialog"], bool]] = None,
+        timeout: int = None,
+    ) -> EventContextManager["Dialog"]:
+        return EventContextManager(self, "dialog", predicate, timeout)
+
+    def expect_download(
+        self,
+        predicate: typing.Union[typing.Callable[["Download"], bool]] = None,
+        timeout: int = None,
+    ) -> EventContextManager["Download"]:
+        return EventContextManager(self, "download", predicate, timeout)
+
+    def expect_file_chooser(
+        self,
+        predicate: typing.Union[typing.Callable[["FileChooser"], bool]] = None,
+        timeout: int = None,
+    ) -> EventContextManager["FileChooser"]:
+        return EventContextManager(self, "filechooser", predicate, timeout)
+
+    def expect_request(
+        self,
+        predicate: typing.Union[typing.Callable[["Request"], bool]] = None,
+        timeout: int = None,
+    ) -> EventContextManager["Request"]:
+        return EventContextManager(self, "request", predicate, timeout)
+
+    def expect_response(
+        self,
+        predicate: typing.Union[typing.Callable[["Response"], bool]] = None,
+        timeout: int = None,
+    ) -> EventContextManager["Response"]:
+        return EventContextManager(self, "response", predicate, timeout)
+
+    def expect_popup(
+        self,
+        predicate: typing.Union[typing.Callable[["Page"], bool]] = None,
+        timeout: int = None,
+    ) -> EventContextManager["Page"]:
+        return EventContextManager(self, "popup", predicate, timeout)
+
+    def expect_worker(
+        self,
+        predicate: typing.Union[typing.Callable[["Worker"], bool]] = None,
+        timeout: int = None,
+    ) -> EventContextManager["Worker"]:
+        return EventContextManager(self, "worker", predicate, timeout)
+
 
 mapping.register(PageAsync, Page)
 
@@ -2243,6 +2361,13 @@ class BrowserContext(SyncBase):
 
     def close(self) -> NoneType:
         return self._sync(self._async_obj.close())
+
+    def expect_page(
+        self,
+        predicate: typing.Union[typing.Callable[["Page"], bool]] = None,
+        timeout: int = None,
+    ) -> EventContextManager["Page"]:
+        return EventContextManager(self, "page", predicate, timeout)
 
 
 mapping.register(BrowserContextAsync, BrowserContext)

--- a/tests/test_browsercontext.py
+++ b/tests/test_browsercontext.py
@@ -577,19 +577,17 @@ async def test_offline_should_emulate_navigator_online(context, server):
 
 async def test_page_event_should_have_url(context, server):
     page = await context.newPage()
-    [other_page, _] = await asyncio.gather(
-        context.waitForEvent("page"),
-        page.evaluate("url => window.open(url)", server.EMPTY_PAGE),
-    )
+    async with context.expect_page() as other_page_info:
+        await page.evaluate("url => window.open(url)", server.EMPTY_PAGE)
+    other_page = await other_page_info.value
     assert other_page.url == server.EMPTY_PAGE
 
 
 async def test_page_event_should_have_url_after_domcontentloaded(context, server):
     page = await context.newPage()
-    [other_page, _] = await asyncio.gather(
-        context.waitForEvent("page"),
-        page.evaluate("url => window.open(url)", server.EMPTY_PAGE),
-    )
+    async with context.expect_page() as other_page_info:
+        await page.evaluate("url => window.open(url)", server.EMPTY_PAGE)
+    other_page = await other_page_info.value
     await other_page.waitForLoadState("domcontentloaded")
     assert other_page.url == server.EMPTY_PAGE
 
@@ -598,10 +596,9 @@ async def test_page_event_should_have_about_blank_url_with_domcontentloaded(
     context, server
 ):
     page = await context.newPage()
-    [other_page, _] = await asyncio.gather(
-        context.waitForEvent("page"),
-        page.evaluate("url => window.open(url)", "about:blank"),
-    )
+    async with context.expect_page() as other_page_info:
+        await page.evaluate("url => window.open(url)", "about:blank")
+    other_page = await other_page_info.value
     await other_page.waitForLoadState("domcontentloaded")
     assert other_page.url == "about:blank"
 
@@ -610,9 +607,9 @@ async def test_page_event_should_have_about_blank_for_empty_url_with_domcontentl
     context, server
 ):
     page = await context.newPage()
-    [other_page, _] = await asyncio.gather(
-        context.waitForEvent("page"), page.evaluate("window.open()")
-    )
+    async with context.expect_page() as other_page_info:
+        await page.evaluate("window.open()")
+    other_page = await other_page_info.value
     await other_page.waitForLoadState("domcontentloaded")
     assert other_page.url == "about:blank"
 


### PR DESCRIPTION
As a driver-by, this introduces async context managers that are 100% aligned with the sync ones.