### PR TITLE
cleanup: use [] and {} instead classes

### DIFF
--- a/playwright/browser.py
+++ b/playwright/browser.py
@@ -37,7 +37,7 @@ class Browser(ChannelOwner):
         self._is_connected = True
         self._is_closed_or_closing = False
 
-        self._contexts: List[BrowserContext] = list()
+        self._contexts: List[BrowserContext] = []
         self._channel.on("close", lambda _: self._on_close())
 
     def _on_close(self) -> None:

--- a/playwright/browser_context.py
+++ b/playwright/browser_context.py
@@ -43,10 +43,10 @@ class BrowserContext(ChannelOwner):
 
     def __init__(self, scope: ConnectionScope, guid: str, initializer: Dict) -> None:
         super().__init__(scope, guid, initializer, True)
-        self._pages: List[Page] = list()
-        self._routes: List[RouteHandlerEntry] = list()
-        self._bindings: Dict[str, Any] = dict()
-        self._pending_wait_for_events: List[PendingWaitEvent] = list()
+        self._pages: List[Page] = []
+        self._routes: List[RouteHandlerEntry] = []
+        self._bindings: Dict[str, Any] = {}
+        self._pending_wait_for_events: List[PendingWaitEvent] = []
         self._timeout_settings = TimeoutSettings(None)
         self._browser: Optional["Browser"] = None
         self._owner_page: Optional[Page] = None
@@ -106,7 +106,7 @@ class BrowserContext(ChannelOwner):
 
     async def cookies(self, urls: Union[str, List[str]]) -> List[Cookie]:
         if urls is None:
-            urls = list()
+            urls = []
         return await self._channel.send("cookies", dict(urls=urls))
 
     async def addCookies(self, cookies: List[Cookie]) -> None:

--- a/playwright/connection.py
+++ b/playwright/connection.py
@@ -32,7 +32,7 @@ class Channel(BaseEventEmitter):
 
     async def send(self, method: str, params: dict = None) -> Any:
         if params is None:
-            params = dict()
+            params = {}
         result = await self._scope.send_message_to_server(self._guid, method, params)
         # Protocol now has named return values, assume result is one level deeper unless
         # there is explicit ambiguity.
@@ -47,7 +47,7 @@ class Channel(BaseEventEmitter):
 
     def send_no_reply(self, method: str, params: dict = None) -> None:
         if params is None:
-            params = dict()
+            params = {}
         self._scope.send_message_to_server_no_reply(self._guid, method, params)
 
 
@@ -74,8 +74,8 @@ class ConnectionScope:
         self._connection: "Connection" = connection
         self._loop: asyncio.AbstractEventLoop = connection._loop
         self._guid: str = guid
-        self._children: List["ConnectionScope"] = list()
-        self._objects: Dict[str, ChannelOwner] = dict()
+        self._children: List["ConnectionScope"] = []
+        self._objects: Dict[str, ChannelOwner] = {}
         self._parent = parent
 
     def create_child(self, guid: str) -> "ConnectionScope":
@@ -138,12 +138,12 @@ class Connection:
     ) -> None:
         self._transport = Transport(input, output, loop)
         self._transport.on_message = lambda msg: self._dispatch(msg)
-        self._waiting_for_object: Dict[str, Any] = dict()
+        self._waiting_for_object: Dict[str, Any] = {}
         self._last_id = 0
         self._loop = loop
-        self._objects: Dict[str, ChannelOwner] = dict()
-        self._scopes: Dict[str, ConnectionScope] = dict()
-        self._callbacks: Dict[int, ProtocolCallback] = dict()
+        self._objects: Dict[str, ChannelOwner] = {}
+        self._scopes: Dict[str, ConnectionScope] = {}
+        self._callbacks: Dict[int, ProtocolCallback] = {}
         self._root_scope = self.create_scope("", None)
         self._object_factory = object_factory
 
@@ -212,7 +212,7 @@ class Connection:
         if isinstance(payload, Channel):
             return dict(guid=payload._guid)
         if isinstance(payload, dict):
-            result = dict()
+            result = {}
             for key in payload:
                 result[key] = self._replace_channels_with_guids(payload[key])
             return result
@@ -226,7 +226,7 @@ class Connection:
         if isinstance(payload, dict):
             if payload.get("guid") in self._objects:
                 return self._objects[payload["guid"]]._channel
-            result = dict()
+            result = {}
             for key in payload:
                 result[key] = self._replace_guids_with_channels(payload[key])
             return result

--- a/playwright/element_handle.py
+++ b/playwright/element_handle.py
@@ -227,10 +227,10 @@ ValuesToSelect = Union[
 
 def convert_select_option_values(arg: ValuesToSelect) -> Any:
     if arg is None:
-        return dict()
+        return {}
     arg_list = arg if isinstance(arg, list) else [arg]
     if not len(arg_list):
-        return dict()
+        return {}
     if isinstance(arg_list[0], ElementHandle):
         element_list = cast(List[ElementHandle], arg_list)
         return dict(elements=list(map(lambda e: e._channel, element_list)))

--- a/playwright/frame.py
+++ b/playwright/frame.py
@@ -64,7 +64,7 @@ class Frame(ChannelOwner):
         self._name = initializer["name"]
         self._url = initializer["url"]
         self._detached = False
-        self._child_frames: List[Frame] = list()
+        self._child_frames: List[Frame] = []
         self._page: "Page"
         self._load_states: Set[str] = set()
         self._event_emitter = BaseEventEmitter()

--- a/playwright/helper.py
+++ b/playwright/helper.py
@@ -211,7 +211,7 @@ def is_function_body(expression: str) -> bool:
 
 
 def locals_to_params(args: Dict) -> Dict:
-    copy = dict()
+    copy = {}
     for key in args:
         if key == "self":
             continue

--- a/playwright/js_handle.py
+++ b/playwright/js_handle.py
@@ -134,7 +134,7 @@ def serialize_value(value: Any, handles: List[JSHandle], depth: int) -> Any:
 
 
 def serialize_argument(arg: Any) -> Any:
-    handles: List[JSHandle] = list()
+    handles: List[JSHandle] = []
     value = serialize_value(arg, handles, 0)
     return dict(value=value, handles=handles)
 

--- a/playwright/network.py
+++ b/playwright/network.py
@@ -99,7 +99,7 @@ class Route(ChannelOwner):
     async def fulfill(
         self,
         status: int = 200,
-        headers: Dict[str, str] = dict(),
+        headers: Dict[str, str] = {},
         body: Union[str, bytes] = None,
         contentType: str = None,
     ) -> None:
@@ -120,7 +120,7 @@ class Route(ChannelOwner):
         headers: Dict[str, str] = None,
         postData: Union[str, bytes] = None,
     ) -> None:
-        overrides: ContinueParameters = dict()
+        overrides: ContinueParameters = {}
         if method:
             overrides["method"] = method
         if headers:

--- a/playwright/page.py
+++ b/playwright/page.py
@@ -105,10 +105,10 @@ class Page(ChannelOwner):
         self._frames = [self._main_frame]
         self._viewport_size = initializer.get("viewportSize")
         self._is_closed = False
-        self._workers: List[Worker] = list()
-        self._bindings: Dict[str, Any] = dict()
-        self._pending_wait_for_events: List[PendingWaitEvent] = list()
-        self._routes: List[RouteHandlerEntry] = list()
+        self._workers: List[Worker] = []
+        self._bindings: Dict[str, Any] = {}
+        self._pending_wait_for_events: List[PendingWaitEvent] = []
+        self._routes: List[RouteHandlerEntry] = []
         self._owned_context: Optional["BrowserContext"] = None
         self._timeout_settings = TimeoutSettings(None)
 


### PR DESCRIPTION
Thought about replacing `dict(foo=foo)` with `{"foo": foo}` too but keeping that seems cleaner.