### PR TITLE
fix: multiple Playwright instances

### DIFF
--- a/playwright/main.py
+++ b/playwright/main.py
@@ -25,7 +25,7 @@ from greenlet import greenlet
 
 from playwright.async_api import Playwright as AsyncPlaywright
 from playwright.connection import Connection
-from playwright.helper import not_installed_error
+from playwright.helper import Error, not_installed_error
 from playwright.object_factory import create_remote_object
 from playwright.playwright import Playwright
 from playwright.sync_api import Playwright as SyncPlaywright
@@ -72,7 +72,12 @@ async def run_driver_async() -> Connection:
 
 
 def run_driver() -> Connection:
-    return asyncio.get_event_loop().run_until_complete(run_driver_async())
+    loop = asyncio.get_event_loop()
+    if loop.is_running():
+        raise Error(
+            "Existing event loop is already running. Most likely that you have nested Playwright initialisations."
+        )
+    return loop.run_until_complete(run_driver_async())
 
 
 class SyncPlaywrightContextManager:

--- a/playwright/main.py
+++ b/playwright/main.py
@@ -74,9 +74,7 @@ async def run_driver_async() -> Connection:
 def run_driver() -> Connection:
     loop = asyncio.get_event_loop()
     if loop.is_running():
-        raise Error(
-            "Existing event loop is already running. Most likely that you have nested Playwright initialisations."
-        )
+        raise Error("Can only run one Playwright at a time.")
     return loop.run_until_complete(run_driver_async())
 
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -205,3 +205,15 @@ def test_sync_workers_page_workers(page: Page, server):
 
     page.goto(server.EMPTY_PAGE)
     assert len(page.workers) == 0
+
+
+def test_sync_playwright_multiple_times():
+    with sync_playwright() as pw1:
+        assert pw1.chromium
+        with pytest.raises(Error) as exc:
+            with sync_playwright() as pw2:
+                assert pw1.chromium == pw2.chromium
+        assert (
+            "Most likely that you have nested Playwright initialisations."
+            in exc.value.message
+        )

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -213,7 +213,4 @@ def test_sync_playwright_multiple_times():
         with pytest.raises(Error) as exc:
             with sync_playwright() as pw2:
                 assert pw1.chromium == pw2.chromium
-        assert (
-            "Can only run one Playwright at a time."
-            in exc.value.message
-        )
+        assert "Can only run one Playwright at a time." in exc.value.message

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -214,6 +214,6 @@ def test_sync_playwright_multiple_times():
             with sync_playwright() as pw2:
                 assert pw1.chromium == pw2.chromium
         assert (
-            "Most likely that you have nested Playwright initialisations."
+            "Can only run one Playwright at a time."
             in exc.value.message
         )


### PR DESCRIPTION
Previously it was throwing `This event loop is already running`