### PR TITLE
feat: accept pathlib in the API

### DIFF
--- a/build_driver.py
+++ b/build_driver.py
@@ -17,9 +17,10 @@ import os
 import re
 import shutil
 import subprocess
-from pathlib import Path
 
-_dirname = Path(os.path.dirname(os.path.abspath(__file__)))
+from playwright.path_utils import get_file_dirname
+
+_dirname = get_file_dirname()
 
 driver_path = _dirname / "driver"
 package_path = _dirname / "playwright"

--- a/build_package.py
+++ b/build_package.py
@@ -12,16 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import shutil
 import subprocess
 
-folder = os.path.dirname(os.path.abspath(__file__))
-if os.path.exists(os.path.join(folder, "build")):
-    shutil.rmtree(os.path.join(folder, "build"))
-if os.path.exists(os.path.join(folder, "dist")):
-    shutil.rmtree(os.path.join(folder, "dist"))
-if os.path.exists(os.path.join(folder, "playwright.egg-info")):
-    shutil.rmtree(os.path.join(folder, "playwright.egg-info"))
+from playwright.path_utils import get_file_dirname
+
+_dirname = get_file_dirname()
+_build_dir = _dirname / "build"
+if _build_dir.exists():
+    shutil.rmtree(_build_dir)
+_dist_dir = _dirname / "dist"
+if _dist_dir.exists():
+    shutil.rmtree(_dist_dir)
+_egg_dir = _dirname / "playwright.egg-info"
+if _egg_dir.exists():
+    shutil.rmtree(_egg_dir)
 
 subprocess.run("python setup.py sdist bdist_wheel", shell=True)

--- a/playwright/async_api.py
+++ b/playwright/async_api.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import pathlib
 import sys
 import typing
 
@@ -870,7 +871,12 @@ class ElementHandle(JSHandle):
     async def setInputFiles(
         self,
         files: typing.Union[
-            str, FilePayload, typing.List[str], typing.List[FilePayload]
+            str,
+            pathlib.Path,
+            FilePayload,
+            typing.List[str],
+            typing.List[pathlib.Path],
+            typing.List[FilePayload],
         ],
         timeout: int = None,
         noWaitAfter: bool = None,
@@ -1877,7 +1883,12 @@ class Frame(AsyncBase):
         self,
         selector: str,
         files: typing.Union[
-            str, FilePayload, typing.List[str], typing.List[FilePayload]
+            str,
+            pathlib.Path,
+            FilePayload,
+            typing.List[str],
+            typing.List[pathlib.Path],
+            typing.List[FilePayload],
         ],
         timeout: int = None,
         noWaitAfter: bool = None,

--- a/playwright/element_handle.py
+++ b/playwright/element_handle.py
@@ -16,6 +16,7 @@ import base64
 import mimetypes
 import os
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, cast
 
 from playwright.connection import ChannelOwner, from_nullable_channel
@@ -123,7 +124,7 @@ class ElementHandle(JSHandle):
 
     async def setInputFiles(
         self,
-        files: Union[str, FilePayload, List[str], List[FilePayload]],
+        files: Union[str, Path, FilePayload, List[str], List[Path], List[FilePayload]],
         timeout: int = None,
         noWaitAfter: bool = None,
     ) -> None:
@@ -242,16 +243,16 @@ def convert_select_option_values(arg: ValuesToSelect) -> Any:
 
 
 def normalize_file_payloads(
-    files: Union[str, FilePayload, List[str], List[FilePayload]]
+    files: Union[str, Path, FilePayload, List[str], List[Path], List[FilePayload]]
 ) -> List[FilePayload]:
     file_list = files if isinstance(files, list) else [files]
     file_payloads: List[FilePayload] = []
     for item in file_list:
-        if isinstance(item, str):
+        if isinstance(item, str) or isinstance(item, Path):
             with open(item, mode="rb") as fd:
                 file: FilePayload = {
                     "name": os.path.basename(item),
-                    "mimeType": mimetypes.guess_type(item)[0]
+                    "mimeType": mimetypes.guess_type(str(Path(item)))[0]
                     or "application/octet-stream",
                     "buffer": base64.b64encode(fd.read()).decode(),
                 }

--- a/playwright/frame.py
+++ b/playwright/frame.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Awaitable, Dict, List, Optional, Set, Union, cast
 
 from pyee import BaseEventEmitter
@@ -280,7 +281,7 @@ class Frame(ChannelOwner):
         params = locals_to_params(locals())
         if path:
             with open(path, "r") as file:
-                params["content"] = file.read() + "\n//# sourceURL=" + path
+                params["content"] = file.read() + "\n//# sourceURL=" + str(Path(path))
                 del params["path"]
         return from_channel(await self._channel.send("addScriptTag", params))
 
@@ -290,7 +291,9 @@ class Frame(ChannelOwner):
         params = locals_to_params(locals())
         if path:
             with open(path, "r") as file:
-                params["content"] = file.read() + "\n/*# sourceURL=" + path + "*/"
+                params["content"] = (
+                    file.read() + "\n/*# sourceURL=" + str(Path(path)) + "*/"
+                )
                 del params["path"]
         return from_channel(await self._channel.send("addStyleTag", params))
 
@@ -366,7 +369,7 @@ class Frame(ChannelOwner):
     async def setInputFiles(
         self,
         selector: str,
-        files: Union[str, FilePayload, List[str], List[FilePayload]],
+        files: Union[str, Path, FilePayload, List[str], List[Path], List[FilePayload]],
         timeout: int = None,
         noWaitAfter: bool = None,
     ) -> None:

--- a/playwright/main.py
+++ b/playwright/main.py
@@ -27,6 +27,7 @@ from playwright.async_api import Playwright as AsyncPlaywright
 from playwright.connection import Connection
 from playwright.helper import Error, not_installed_error
 from playwright.object_factory import create_remote_object
+from playwright.path_utils import get_file_dirname
 from playwright.playwright import Playwright
 from playwright.sync_api import Playwright as SyncPlaywright
 from playwright.sync_base import dispatcher_fiber, set_dispatcher_fiber
@@ -44,12 +45,12 @@ def compute_driver_name() -> str:
 
 
 async def run_driver_async() -> Connection:
-    package_path = os.path.dirname(os.path.abspath(__file__))
+    package_path = get_file_dirname()
     driver_name = compute_driver_name()
-    driver_executable = os.path.join(package_path, driver_name)
-    archive_name = os.path.join(package_path, "drivers", driver_name + ".gz")
+    driver_executable = package_path / driver_name
+    archive_name = package_path / "drivers" / (driver_name + ".gz")
 
-    if not os.path.exists(driver_executable) or os.path.getmtime(
+    if not driver_executable.exists() or os.path.getmtime(
         driver_executable
     ) < os.path.getmtime(archive_name):
         raise not_installed_error(
@@ -57,7 +58,7 @@ async def run_driver_async() -> Connection:
         )
 
     proc = await asyncio.create_subprocess_exec(
-        driver_executable,
+        str(driver_executable),
         stdin=asyncio.subprocess.PIPE,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
@@ -124,12 +125,12 @@ def main() -> None:
     if "install" not in sys.argv:
         print('Run "python -m playwright install" to complete installation')
         return
-    package_path = os.path.dirname(os.path.abspath(__file__))
+    package_path = get_file_dirname()
     driver_name = compute_driver_name()
-    driver_executable = os.path.join(package_path, driver_name)
-    archive_name = os.path.join(package_path, "drivers", driver_name + ".gz")
+    driver_executable = package_path / driver_name
+    archive_name = package_path / "drivers" / (driver_name + ".gz")
 
-    if not os.path.exists(driver_executable) or os.path.getmtime(
+    if not driver_executable.exists() or os.path.getmtime(
         driver_executable
     ) < os.path.getmtime(archive_name):
         print(f"Extracting {archive_name} into {driver_executable}...")

--- a/playwright/path_utils.py
+++ b/playwright/path_utils.py
@@ -1,0 +1,10 @@
+import inspect
+from pathlib import Path
+
+
+def get_file_dirname() -> Path:
+    """Returns the callee (`__file__`) directory name"""
+    frame = inspect.stack()[1]
+    module = inspect.getmodule(frame[0])
+    assert module
+    return Path(module.__file__).parent.absolute()

--- a/playwright/sync_api.py
+++ b/playwright/sync_api.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import pathlib
 import sys
 import typing
 
@@ -906,7 +907,12 @@ class ElementHandle(JSHandle):
     def setInputFiles(
         self,
         files: typing.Union[
-            str, FilePayload, typing.List[str], typing.List[FilePayload]
+            str,
+            pathlib.Path,
+            FilePayload,
+            typing.List[str],
+            typing.List[pathlib.Path],
+            typing.List[FilePayload],
         ],
         timeout: int = None,
         noWaitAfter: bool = None,
@@ -1968,7 +1974,12 @@ class Frame(SyncBase):
         self,
         selector: str,
         files: typing.Union[
-            str, FilePayload, typing.List[str], typing.List[FilePayload]
+            str,
+            pathlib.Path,
+            FilePayload,
+            typing.List[str],
+            typing.List[pathlib.Path],
+            typing.List[FilePayload],
         ],
         timeout: int = None,
         noWaitAfter: bool = None,

--- a/scripts/documentation_provider.py
+++ b/scripts/documentation_provider.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import re
 import sys
-from pathlib import Path
 from typing import Any, Dict, List, cast
 
-_dirname = Path(os.path.dirname(os.path.abspath(__file__)))
+from playwright.path_utils import get_file_dirname
+
+_dirname = get_file_dirname()
 
 
 class DocumentationProvider:

--- a/scripts/generate_api.py
+++ b/scripts/generate_api.py
@@ -153,6 +153,7 @@ header = """
 
 import typing
 import sys
+import pathlib
 
 if sys.version_info >= (3, 8):  # pragma: no cover
     from typing import Literal

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -186,7 +186,7 @@ def skip_by_browser(request, browser_name):
     )
 
     if browser_name in skip_browsers_names:
-        pytest.skip("skipped for this browser: {}".format(browser_name))
+        pytest.skip(f"skipped for this browser: {browser_name}")
 
 
 @pytest.fixture(autouse=True)
@@ -196,7 +196,7 @@ def skip_by_platform(request):
     )
 
     if sys.platform in skip_platform_names:
-        pytest.skip("skipped on this platform: {}".format(sys.platform))
+        pytest.skip(f"skipped on this platform: {sys.platform}")
 
 
 def pytest_addoption(parser):

--- a/tests/server.py
+++ b/tests/server.py
@@ -16,18 +16,18 @@ import abc
 import asyncio
 import gzip
 import mimetypes
-import os
 import socket
 import threading
 from contextlib import closing
 from http import HTTPStatus
-from pathlib import Path
 
 from OpenSSL import crypto
 from twisted.internet import reactor, ssl
 from twisted.web import http
 
-_dirname = Path(os.path.join(os.path.dirname(__file__)))
+from playwright.path_utils import get_file_dirname
+
+_dirname = get_file_dirname()
 
 
 def _find_free_port():
@@ -107,7 +107,7 @@ class Server:
                 file_content = None
                 try:
                     file_content = open(
-                        os.path.join(static_path, request.path.decode()[1:]), "rb"
+                        static_path / request.path.decode()[1:], "rb"
                     ).read()
                 except (FileNotFoundError, IsADirectoryError):
                     request.setResponseCode(HTTPStatus.NOT_FOUND)

--- a/tests/test_add_init_script.py
+++ b/tests/test_add_init_script.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 from playwright import Error
+from playwright.path_utils import get_file_dirname
+
+_dirname = get_file_dirname()
 
 
 async def test_add_init_script_evaluate_before_anything_else_on_the_page(page):
@@ -24,11 +25,7 @@ async def test_add_init_script_evaluate_before_anything_else_on_the_page(page):
 
 
 async def test_add_init_script_work_with_a_path(page):
-    await page.addInitScript(
-        path=os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), "assets/injectedfile.js"
-        )
-    )
+    await page.addInitScript(path=_dirname / "assets/injectedfile.js")
     await page.goto("data:text/html,<script>window.result = window.injected</script>")
     assert await page.evaluate("window.result") == 123
 
@@ -59,11 +56,7 @@ async def test_add_init_script_work_with_browser_context_scripts(page, context):
 async def test_add_init_script_work_with_browser_context_scripts_with_a_path(
     page, context
 ):
-    await context.addInitScript(
-        path=os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), "assets/injectedfile.js"
-        )
-    )
+    await context.addInitScript(path=_dirname / "assets/injectedfile.js")
     page = await context.newPage()
     await page.goto("data:text/html,<script>window.result = window.injected</script>")
     assert await page.evaluate("window.result") == 123

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -16,12 +16,10 @@ import asyncio
 import os
 
 from playwright.page import Page
+from playwright.path_utils import get_file_dirname
 
-FILE_TO_UPLOAD = os.path.join(
-    os.path.dirname(os.path.realpath(__file__)), "assets/file-to-upload.txt"
-)
-
-__dirname = os.path.dirname(os.path.realpath(__file__))
+_dirname = get_file_dirname()
+FILE_TO_UPLOAD = _dirname / "assets/file-to-upload.txt"
 
 
 async def test_should_upload_the_file(page, server):
@@ -46,9 +44,7 @@ async def test_should_upload_the_file(page, server):
 
 async def test_should_work(page):
     await page.setContent("<input type=file>")
-    await page.setInputFiles(
-        "input", os.path.join(__dirname, "assets/file-to-upload.txt")
-    )
+    await page.setInputFiles("input", _dirname / "assets/file-to-upload.txt")
     assert await page.evalOnSelector("input", "input => input.files.length") == 1
     assert (
         await page.evalOnSelector("input", "input => input.files[0].name")
@@ -197,8 +193,8 @@ async def test_should_not_accept_multiple_files_for_single_file_input(page, serv
     try:
         await file_chooser.setFiles(
             [
-                os.path.realpath(os.path.join(__dirname, "assets/file-to-upload.txt")),
-                os.path.realpath(os.path.join(__dirname, "assets/pptr.png")),
+                os.path.realpath(_dirname / "assets/file-to-upload.txt"),
+                os.path.realpath(_dirname / "assets/pptr.png"),
             ]
         )
     except Exception as exc:

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -19,8 +19,9 @@ import pytest
 
 from playwright.browser_type import BrowserType
 from playwright.helper import Error
+from playwright.path_utils import get_file_dirname
 
-__dirname = os.path.dirname(os.path.abspath(__file__))
+_dirname = get_file_dirname()
 
 
 async def test_browser_type_launch_should_reject_all_promises_when_browser_is_closed(
@@ -51,9 +52,7 @@ async def test_browser_type_launch_should_reject_if_launched_browser_fails_immed
     with pytest.raises(Error):
         await browser_type.launch(
             **launch_arguments,
-            executablePath=os.path.join(
-                __dirname, "assets", "dummy_bad_browser_executable.js"
-            )
+            executablePath=_dirname / "assets" / "dummy_bad_browser_executable.js"
         )
 
 

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import asyncio
-import os
-import pathlib
 import sys
 
 import pytest
@@ -22,8 +20,9 @@ import pytest
 from playwright import Error
 from playwright.helper import TimeoutError
 from playwright.network import Request
+from playwright.path_utils import get_file_dirname
 
-__dirname = os.path.dirname(os.path.realpath(__file__))
+_dirname = get_file_dirname()
 
 
 async def test_goto_should_work(page, server):
@@ -32,9 +31,7 @@ async def test_goto_should_work(page, server):
 
 
 async def test_goto_should_work_with_file_URL(page, server):
-    fileurl = pathlib.Path(
-        os.path.join(__dirname, "assets", "frames", "two-frames.html")
-    ).as_uri()
+    fileurl = (_dirname / "assets" / "frames" / "two-frames.html").as_uri()
     await page.goto(fileurl)
     assert page.url.lower() == fileurl.lower()
     assert len(page.frames) == 3

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -14,7 +14,6 @@
 
 import asyncio
 import json
-import os
 from asyncio.futures import Future
 from typing import Dict, List
 
@@ -23,6 +22,9 @@ import pytest
 from playwright.helper import Error
 from playwright.network import Request
 from playwright.page import Page
+from playwright.path_utils import get_file_dirname
+
+_dirname = get_file_dirname()
 
 
 async def test_request_fulfill(page):
@@ -245,20 +247,14 @@ async def test_response_json_should_work(page, server):
 
 async def test_response_body_should_work(page, server):
     response = await page.goto(server.PREFIX + "/pptr.png")
-    with open(
-        os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets/pptr.png"),
-        "rb",
-    ) as fd:
+    with open(_dirname / "assets/pptr.png", "rb",) as fd:
         assert fd.read() == await response.body()
 
 
 async def test_response_body_should_work_with_compression(page, server):
     server.enable_gzip("/pptr.png")
     response = await page.goto(server.PREFIX + "/pptr.png")
-    with open(
-        os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets/pptr.png"),
-        "rb",
-    ) as fd:
+    with open(_dirname / "assets/pptr.png", "rb",) as fd:
         assert fd.read() == await response.body()
 
 

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -19,8 +19,9 @@ import re
 import pytest
 
 from playwright import Error, TimeoutError
+from playwright.path_utils import get_file_dirname
 
-__dirname = os.path.dirname(os.path.realpath(__file__))
+_dirname = get_file_dirname()
 
 
 async def test_close_should_reject_all_promises(context):
@@ -533,7 +534,7 @@ async def test_add_script_tag_should_work_with_a_url_and_type_module(page, serve
 async def test_add_script_tag_should_work_with_a_path_and_type_module(page, server):
     await page.goto(server.EMPTY_PAGE)
     await page.addScriptTag(
-        path=os.path.join(__dirname, "assets", "es6", "es6pathimport.js"), type="module"
+        path=_dirname / "assets" / "es6" / "es6pathimport.js", type="module"
     )
     await page.waitForFunction("window.__es6injected")
     assert await page.evaluate("__es6injected") == 42
@@ -561,7 +562,7 @@ async def test_add_script_tag_should_throw_an_error_if_loading_from_url_fail(
 async def test_add_script_tag_should_work_with_a_path(page, server):
     await page.goto(server.EMPTY_PAGE)
     script_handle = await page.addScriptTag(
-        path=os.path.join(__dirname, "assets", "injectedfile.js")
+        path=_dirname / "assets" / "injectedfile.js"
     )
     assert script_handle.asElement()
     assert await page.evaluate("__injected") == 42
@@ -573,7 +574,7 @@ async def test_add_script_tag_should_include_source_url_when_path_is_provided(
 ):
     # Lacking sourceURL support in WebKit
     await page.goto(server.EMPTY_PAGE)
-    await page.addScriptTag(path=os.path.join(__dirname, "assets", "injectedfile.js"))
+    await page.addScriptTag(path=_dirname / "assets" / "injectedfile.js")
     result = await page.evaluate("__injectedError.stack")
     assert os.path.join("assets", "injectedfile.js") in result
 
@@ -639,7 +640,7 @@ async def test_add_style_tag_should_throw_an_error_if_loading_from_url_fail(
 async def test_add_style_tag_should_work_with_a_path(page, server):
     await page.goto(server.EMPTY_PAGE)
     style_handle = await page.addStyleTag(
-        path=os.path.join(__dirname, "assets", "injectedstyle.css")
+        path=_dirname / "assets" / "injectedstyle.css"
     )
     assert style_handle.asElement()
     assert (
@@ -654,7 +655,7 @@ async def test_add_style_tag_should_include_source_url_when_path_is_provided(
     page, server
 ):
     await page.goto(server.EMPTY_PAGE)
-    await page.addStyleTag(path=os.path.join(__dirname, "assets", "injectedstyle.css"))
+    await page.addStyleTag(path=_dirname / "assets" / "injectedstyle.css")
     style_handle = await page.querySelector("style")
     style_content = await page.evaluate("style => style.innerHTML", style_handle)
     assert os.path.join("assets", "injectedstyle.css") in style_content

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+from pathlib import Path
 
 import pytest
 
@@ -20,7 +21,7 @@ from playwright.page import Page
 
 
 @pytest.mark.only_browser("chromium")
-async def test_should_be_able_to_save_pdf_file(page: Page, server, tmpdir):
+async def test_should_be_able_to_save_pdf_file(page: Page, server, tmpdir: Path):
     output_file = tmpdir / "foo.png"
     await page.pdf(path=str(output_file))
     assert os.path.getsize(output_file) > 0

--- a/tests/test_queryselector.py
+++ b/tests/test_queryselector.py
@@ -1,10 +1,12 @@
-import os
 from typing import Any, cast
 
 import pytest
 
 from playwright.helper import Error
 from playwright.page import Page
+from playwright.path_utils import get_file_dirname
+
+_dirname = get_file_dirname()
 
 
 async def test_selectors_register_should_work(selectors, page: Page, utils):
@@ -42,12 +44,7 @@ async def test_selectors_register_should_work(selectors, page: Page, utils):
 
 async def test_selectors_register_should_work_with_path(selectors, page: Page, utils):
     await utils.register_selector_engine(
-        selectors,
-        "foo",
-        path=os.path.join(
-            os.path.dirname(os.path.abspath(__file__)),
-            "assets/sectionselectorengine.js",
-        ),
+        selectors, "foo", path=_dirname / "assets/sectionselectorengine.js"
     )
     await page.setContent("<section></section>")
     assert await page.evalOnSelector("foo=whatever", "e => e.nodeName") == "SECTION"


### PR DESCRIPTION
Drive-by standardise the usage of path objects in the project and cleaned up the tests for the `__dirname` usage.

Lesson learned: if `path` is a string just wrap it in `Path()` as usual. It does also work if `path` is already a `Path` object.

https://docs.python.org/3/library/pathlib.html