### PR TITLE
chore: minor cleanup for coverage

### DIFF
--- a/playwright/async_api.py
+++ b/playwright/async_api.py
@@ -4664,6 +4664,7 @@ class Page(AsyncBase):
 
     def expect_request(
         self,
+        url: typing.Union[str, typing.Pattern, typing.Callable[[str], bool]] = None,
         predicate: typing.Union[typing.Callable[["Request"], bool]] = None,
         timeout: int = None,
     ) -> AsyncEventContextManager["Request"]:
@@ -4671,6 +4672,7 @@ class Page(AsyncBase):
 
     def expect_response(
         self,
+        url: typing.Union[str, typing.Pattern, typing.Callable[[str], bool]] = None,
         predicate: typing.Union[typing.Callable[["Response"], bool]] = None,
         timeout: int = None,
     ) -> AsyncEventContextManager["Response"]:

--- a/playwright/event_context_manager.py
+++ b/playwright/event_context_manager.py
@@ -58,5 +58,5 @@ class EventContextManagerImpl(Generic[T]):
     async def __aenter__(self) -> EventInfoImpl[T]:
         return self._event
 
-    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+    async def __aexit__(self, *args: Any) -> None:
         await self._event.value

--- a/playwright/network.py
+++ b/playwright/network.py
@@ -53,7 +53,7 @@ class Request(ChannelOwner):
         b64_content = self._initializer.get("postData")
         if not b64_content:
             return None
-        return base64.b64decode(bytes(b64_content, "utf-8")).decode()
+        return base64.b64decode(b64_content.encode()).decode()
 
     @property
     def headers(self) -> Dict[str, str]:
@@ -130,7 +130,7 @@ class Route(ChannelOwner):
         if headers:
             overrides["headers"] = serialize_headers(headers)
         if isinstance(postData, str):
-            overrides["postData"] = base64.b64encode(bytes(postData, "utf-8")).decode()
+            overrides["postData"] = base64.b64encode(postData.encode()).decode()
         elif isinstance(postData, bytes):
             overrides["postData"] = base64.b64encode(postData).decode()
         await self._channel.send("continue", cast(Any, overrides))
@@ -173,7 +173,7 @@ class Response(ChannelOwner):
 
     async def text(self) -> str:
         content = await self.body()
-        return content.decode("utf-8")
+        return content.decode()
 
     async def json(self) -> Union[Dict, List]:
         return json.loads(await self.text())

--- a/playwright/network.py
+++ b/playwright/network.py
@@ -53,7 +53,7 @@ class Request(ChannelOwner):
         b64_content = self._initializer.get("postData")
         if not b64_content:
             return None
-        return base64.b64decode(b64_content.encode()).decode()
+        return base64.b64decode(b64_content).decode()
 
     @property
     def headers(self) -> Dict[str, str]:

--- a/playwright/sync_api.py
+++ b/playwright/sync_api.py
@@ -4866,6 +4866,7 @@ class Page(SyncBase):
 
     def expect_request(
         self,
+        url: typing.Union[str, typing.Pattern, typing.Callable[[str], bool]] = None,
         predicate: typing.Union[typing.Callable[["Request"], bool]] = None,
         timeout: int = None,
     ) -> EventContextManager["Request"]:
@@ -4873,6 +4874,7 @@ class Page(SyncBase):
 
     def expect_response(
         self,
+        url: typing.Union[str, typing.Pattern, typing.Callable[[str], bool]] = None,
         predicate: typing.Union[typing.Callable[["Response"], bool]] = None,
         timeout: int = None,
     ) -> EventContextManager["Response"]:

--- a/playwright/transport.py
+++ b/playwright/transport.py
@@ -53,11 +53,10 @@ class Transport:
                     data = await self._input.readexactly(to_read)
                     length -= to_read
                     if len(buffer):
-                        buffer = b"".join([buffer, data])
+                        buffer = buffer + data
                     else:
                         buffer = data
-                msg = buffer.decode("utf-8")
-                obj = json.loads(msg)
+                obj = json.loads(buffer)
 
                 if "DEBUGP" in os.environ:  # pragma: no cover
                     print("\x1b[33mRECV>\x1b[0m", json.dumps(obj, indent=2))
@@ -70,7 +69,7 @@ class Transport:
         msg = json.dumps(message)
         if "DEBUGP" in os.environ:  # pragma: no cover
             print("\x1b[32mSEND>\x1b[0m", json.dumps(message, indent=2))
-        data = bytes(msg, "utf-8")
+        data = msg.encode()
         self._output.write(
             len(data).to_bytes(4, byteorder="little", signed=False) + data
         )

--- a/scripts/generate_api.py
+++ b/scripts/generate_api.py
@@ -18,7 +18,9 @@ from types import FunctionType
 from typing import (  # type: ignore
     Any,
     List,
+    Match,
     Union,
+    cast,
     get_args,
     get_origin,
     get_type_hints,
@@ -81,10 +83,6 @@ def signature(func: FunctionType, indent: int) -> str:
             else:
                 raise ValueError(f"value {default_value} not recognized")
             tokens.append(f"{name}: {processed} = {default_value}")
-        elif name == "contentScript":
-            tokens.append(f"{name}: {processed} = False")
-        elif name == "arg":
-            tokens.append(f"{name}: typing.Any")
         else:
             tokens.append(f"{name}: {processed}")
     return split.join(tokens)
@@ -113,10 +111,8 @@ def return_type(func: FunctionType) -> str:
 
 
 def short_name(t: Any) -> str:
-    match = re.compile(r"playwright\.[^.]+\.([^']+)").search(str(t))
-    if match:
-        return match.group(1)
-    return str(t)
+    match = cast(Match[str], re.compile(r"playwright\.[^.]+\.([^']+)").search(str(t)))
+    return match.group(1)
 
 
 def return_value(value: Any) -> List[str]:

--- a/scripts/generate_async_api.py
+++ b/scripts/generate_async_api.py
@@ -135,5 +135,5 @@ def main() -> None:
     documentation_provider.print_remainder()
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/scripts/generate_sync_api.py
+++ b/scripts/generate_sync_api.py
@@ -118,5 +118,5 @@ def main() -> None:
     documentation_provider.print_remainder()
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/tests/server.py
+++ b/tests/server.py
@@ -106,9 +106,9 @@ class Server:
                     return
                 file_content = None
                 try:
-                    file_content = open(
-                        static_path / request.path.decode()[1:], "rb"
-                    ).read()
+                    file_content = (
+                        static_path / request.path.decode()[1:]
+                    ).read_bytes()
                 except (FileNotFoundError, IsADirectoryError):
                     request.setResponseCode(HTTPStatus.NOT_FOUND)
                 if file_content:


### PR DESCRIPTION
> By default, Python uses utf-8 encoding.

Fixed also in the web server the unclosed file handlers.