### PR TITLE
devops: separate wheels for OS/drivers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
     - name: Test Sync generation script
       run: bash buildbots/test-sync-generation.sh
   build:
+    name: Build
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -87,3 +88,29 @@ jobs:
         path: junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.browser }}.xml
       # Use always() to always run this step to publish test results when there are test failures
       if: ${{ always() }}
+  test-package-installations:
+    name: Test package installations
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v2
+    - uses: microsoft/playwright-github-action@v1
+    - name: Set up Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r local-requirements.txt
+        pip install -e .
+    - name: Build driver
+      run: python build_driver.py
+    - name: Build package
+      run: python build_package.py
+    - name: Test package installation
+      run: bash buildbots/test-package-installations.sh

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,5 @@
-recursive-include playwright/drivers *
+include playwright/drivers/browsers.json
+include playwright/*.py
+include README.md
+include SECURITY.md
+include LICENSE

--- a/build_driver.py
+++ b/build_driver.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import gzip
 import os
 import re
 import shutil
@@ -33,17 +32,8 @@ if (driver_path / "node_modules").exists():
 if (driver_path / "out").exists():
     shutil.rmtree(driver_path / "out")
 
-subprocess.run("npm i", cwd=driver_path, shell=True)
-subprocess.run("npm run bake", cwd=driver_path, shell=True)
-
-for driver in ["driver-linux", "driver-macos", "driver-win.exe"]:
-    if (package_path / driver).exists():
-        os.remove((package_path / driver))
-
-    in_path = driver_path / "out" / driver
-    out_path = drivers_path / (driver + ".gz")
-    with open(in_path, "rb") as f_in, gzip.open(out_path, "wb") as f_out:
-        shutil.copyfileobj(f_in, f_out)
+subprocess.check_call("npm i", cwd=driver_path, shell=True)
+subprocess.check_call("npm run bake", cwd=driver_path, shell=True)
 
 node_modules_playwright = driver_path / "node_modules" / "playwright"
 

--- a/buildbots/assets/stub.py
+++ b/buildbots/assets/stub.py
@@ -1,0 +1,9 @@
+from playwright import sync_playwright
+
+with sync_playwright() as p:
+    for browser_type in [p.chromium, p.firefox, p.webkit]:
+        browser = browser_type.launch()
+        page = browser.newPage()
+        page.setContent("<h1>Test 123</h1>")
+        page.screenshot(path=f"{browser_type.name}.png")
+        browser.close()

--- a/buildbots/test-package-installations.sh
+++ b/buildbots/test-package-installations.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+tmpdir=$(mktemp -d)
+base_dir=$(pwd)
+set -e
+
+# Cleanup to ensure we start fresh
+echo "Deleting driver and browsers from base installation"
+rm -rf driver
+rm -rf playwright
+rm -rf ~/.cache/ms-playwright
+
+cp buildbots/assets/stub.py "$tmpdir/main.py"
+
+cd $tmpdir
+echo "Creating virtual environment"
+virtualenv env
+source env/bin/activate
+echo "Installing Playwright Python via Wheel"
+pip install "$(echo $base_dir/dist/playwright*manylinux1*.whl)"
+echo "Installing browsers"
+python -m playwright install
+echo "Running basic tests"
+python "main.py"
+cd -
+
+test -f "$tmpdir/chromium.png"
+test -f "$tmpdir/firefox.png"
+test -f "$tmpdir/webkit.png"
+echo "Passed package installation tests successfully"

--- a/driver/main.js
+++ b/driver/main.js
@@ -18,7 +18,7 @@ const path = require('path');
 
 (async() => {
   if (process.argv.includes('install')) {
-    await require('playwright/lib/install/installer').installBrowsersWithProgressBar(path.join(path.dirname(process.argv[0]), 'drivers'));
+    await require('playwright/lib/install/installer').installBrowsersWithProgressBar(path.dirname(process.argv[0]));
     return;
   }
 


### PR DESCRIPTION
Closes #117

Before:
```
(env) ➜  playwright-python git:(devops/publish-os-specific) du -sh dist/*
 89M    dist/playwright-0.0.4.post9+g875b380-py3-none-any.whl
 81M    dist/playwright-0.0.4.post9+g875b380.tar.gz
```
After:
```
(env) ➜  playwright-python git:(devops/publish-os-specific) ✗ du -sh dist/*          
 24M    dist/playwright-0.0.4.post9+g875b380.d20200801-py3-none-macosx_10_13_x86_64.whl
 26M    dist/playwright-0.0.4.post9+g875b380.d20200801-py3-none-manylinux1_x86_64.whl
 24M    dist/playwright-0.0.4.post9+g875b380.d20200801-py3-none-win_amd64.whl
300K    dist/playwright-0.0.4.post9+g875b380.d20200801.tar.gz
```

PIP will automatically in the end install the correct wheel since all were uploaded to the PyPi registry.