### PR TITLE
devops(tests): added timeout on tests on bots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Install
       run: python -m playwright install
     - name: Test
-      run: pytest -vv --browser=${{ matrix.browser }} --junitxml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.browser }}.xml --cov=playwright --cov=scripts --cov-report xml
+      run: pytest -vv --browser=${{ matrix.browser }} --junitxml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.browser }}.xml --cov=playwright --cov=scripts --cov-report xml --timeout 30
     - name: Coveralls
       run: coveralls
       env:

--- a/local-requirements.txt
+++ b/local-requirements.txt
@@ -3,6 +3,7 @@ pytest-asyncio==0.14.0
 pytest-cov==2.10.0
 pytest-sugar==0.9.4
 pytest-xdist==1.33.0
+pytest-timeout==1.4.2
 pixelmatch==0.2.1
 Pillow==7.2.0
 mypy==0.782


### PR DESCRIPTION
By that we should see easier tests which error by terminating them instead of letting them hang forever.