### PR TITLE
fix: forward driver stderr to main stderr

### DIFF
--- a/playwright/main.py
+++ b/playwright/main.py
@@ -49,7 +49,7 @@ async def run_driver_async() -> Connection:
         str(driver_executable),
         stdin=asyncio.subprocess.PIPE,
         stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
+        stderr=sys.stderr,
         limit=32768,
     )
     assert proc.stdout


### PR DESCRIPTION
Fixes #143

For pytest `-s` is needed.