### PR TITLE
feat: Download.createReadStream()

### DIFF
--- a/playwright/async_api.py
+++ b/playwright/async_api.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import io
 import pathlib
 import sys
 import typing
@@ -2761,6 +2761,7 @@ class Selectors(AsyncBase):
             Name that is used in selectors as a prefix, e.g. `{name: 'foo'}` enables `foo=myselectorbody` selectors. May only contain `[a-zA-Z0-9_]` characters.
         source : Optional[str]
             Script that evaluates to a selector engine instance.
+        path : Optional[str]
         contentScript : Optional[bool]
             Whether to run this selector engine in isolated JavaScript environment. This environment has access to the same DOM, but not any JavaScript objects from the frame's scripts. Defaults to `false`. Note that running as a content script is not guaranteed when this engine is used together with other registered engines.
         """
@@ -2950,6 +2951,26 @@ class Download(AsyncBase):
             Path where the download should be saved.
         """
         return mapping.from_maybe_impl(await self._impl_obj.saveAs(path=path))
+
+    async def createReadStream(
+        self, fp: io.BytesIO = None, size: int = None
+    ) -> typing.Union[io.BytesIO, NoneType]:
+        """Download.createReadStream
+
+        Returns readable stream for current download or `null` if download failed.
+
+        Parameters
+        ----------
+        fp : Optional[io.BytesIO]
+        size : Optional[int]
+
+        Returns
+        -------
+        Optional[io.BytesIO]
+        """
+        return mapping.from_maybe_impl(
+            await self._impl_obj.createReadStream(fp=fp, size=size)
+        )
 
 
 mapping.register(DownloadImpl, Download)
@@ -3708,6 +3729,7 @@ class Page(AsyncBase):
         ----------
         url : Union[str, Pattern, typing.Callable[[str], bool], NoneType]
             Request URL string, regex or predicate receiving Request object.
+        predicate : Optional[typing.Callable[[playwright.network.Request], bool]]
         timeout : Optional[int]
             Maximum wait time in milliseconds, defaults to 30 seconds, pass `0` to disable the timeout. The default value can be changed by using the page.setDefaultTimeout(timeout) method.
 
@@ -3737,6 +3759,7 @@ class Page(AsyncBase):
         ----------
         url : Union[str, Pattern, typing.Callable[[str], bool], NoneType]
             Request URL string, regex or predicate receiving Response object.
+        predicate : Optional[typing.Callable[[playwright.network.Response], bool]]
         timeout : Optional[int]
             Maximum wait time in milliseconds, defaults to 30 seconds, pass `0` to disable the timeout. The default value can be changed by using the browserContext.setDefaultTimeout(timeout) or page.setDefaultTimeout(timeout) methods.
 
@@ -3768,6 +3791,8 @@ class Page(AsyncBase):
         ----------
         event : str
             Event name, same one would pass into `page.on(event)`.
+        predicate : Optional[typing.Callable[[typing.Any], bool]]
+        timeout : Optional[int]
 
         Returns
         -------
@@ -3907,6 +3932,7 @@ class Page(AsyncBase):
         ----------
         source : Optional[str]
             Script to be evaluated in the page.
+        path : Optional[str]
         """
         return mapping.from_maybe_impl(
             await self._impl_obj.addInitScript(source=source, path=path)
@@ -5033,6 +5059,7 @@ class BrowserContext(AsyncBase):
         ----------
         source : Optional[str]
             Script to be evaluated in all pages in the browser context.
+        path : Optional[str]
         """
         return mapping.from_maybe_impl(
             await self._impl_obj.addInitScript(source=source, path=path)
@@ -5149,6 +5176,8 @@ class BrowserContext(AsyncBase):
         ----------
         event : str
             Event name, same one would pass into `browserContext.on(event)`.
+        predicate : Optional[typing.Callable[[typing.Any], bool]]
+        timeout : Optional[int]
 
         Returns
         -------

--- a/playwright/async_api.py
+++ b/playwright/async_api.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import io
 import pathlib
 import sys
 import typing
@@ -65,6 +64,8 @@ from playwright.page import Page as PageImpl
 from playwright.page import Worker as WorkerImpl
 from playwright.playwright import Playwright as PlaywrightImpl
 from playwright.selectors import Selectors as SelectorsImpl
+from playwright.stream import Stream as StreamImpl
+from playwright.stream import StreamIO as StreamIOImpl
 
 NoneType = type(None)
 
@@ -2883,6 +2884,49 @@ class Dialog(AsyncBase):
 mapping.register(DialogImpl, Dialog)
 
 
+class StreamIO(AsyncBase):
+    def __init__(self, obj: StreamIOImpl):
+        super().__init__(obj)
+
+    async def read(self, size: int = None) -> typing.Union[bytes, NoneType]:
+        """StreamIO.read
+
+        Reads from the download bytes
+
+        Parameters
+        ----------
+        size : Optional[int]
+            Size in bytes how much should be read.
+
+        Returns
+        -------
+        Optional[bytes]
+        """
+        return mapping.from_maybe_impl(await self._impl_obj.read(size=size))
+
+
+mapping.register(StreamIOImpl, StreamIO)
+
+
+class Stream(AsyncBase):
+    def __init__(self, obj: StreamImpl):
+        super().__init__(obj)
+
+    async def stream(self) -> "StreamIO":
+        """Stream.stream
+
+        Returns the file stream
+
+        Returns
+        -------
+        StreamIO
+        """
+        return mapping.from_impl(await self._impl_obj.stream())
+
+
+mapping.register(StreamImpl, Stream)
+
+
 class Download(AsyncBase):
     def __init__(self, obj: DownloadImpl):
         super().__init__(obj)
@@ -2952,25 +2996,16 @@ class Download(AsyncBase):
         """
         return mapping.from_maybe_impl(await self._impl_obj.saveAs(path=path))
 
-    async def createReadStream(
-        self, fp: io.BytesIO = None, size: int = None
-    ) -> typing.Union[io.BytesIO, NoneType]:
+    async def createReadStream(self) -> typing.Union["StreamIO", NoneType]:
         """Download.createReadStream
 
         Returns readable stream for current download or `null` if download failed.
 
-        Parameters
-        ----------
-        fp : Optional[io.BytesIO]
-        size : Optional[int]
-
         Returns
         -------
-        Optional[io.BytesIO]
+        Optional[StreamIO]
         """
-        return mapping.from_maybe_impl(
-            await self._impl_obj.createReadStream(fp=fp, size=size)
-        )
+        return mapping.from_impl_nullable(await self._impl_obj.createReadStream())
 
 
 mapping.register(DownloadImpl, Download)

--- a/playwright/browser_context.py
+++ b/playwright/browser_context.py
@@ -189,7 +189,7 @@ class BrowserContext(ChannelOwner):
             timeout = self._timeout_settings.timeout()
         wait_helper = WaitHelper(self._loop)
         wait_helper.reject_on_timeout(
-            timeout, f'Timeout while waiting for event "${event}"'
+            timeout, f'Timeout while waiting for event "{event}"'
         )
         if event != BrowserContext.Events.Close:
             wait_helper.reject_on_event(

--- a/playwright/download.py
+++ b/playwright/download.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Dict, Optional, Union
 
 from playwright.connection import ChannelOwner, from_channel
+from playwright.stream import StreamIO
 
 
 class Download(ChannelOwner):
@@ -46,10 +47,8 @@ class Download(ChannelOwner):
         path = str(Path(path))
         return await self._channel.send("saveAs", dict(path=path))
 
-    async def createReadStream(
-        self, fp: Optional[io.BytesIO], size: int = None
-    ) -> Optional[io.BytesIO]:
+    async def createReadStream(self) -> Optional[StreamIO]:
         stream = await self._channel.send("stream")
         if not stream:
             return None
-        return await from_channel(stream).stream(fp, size)
+        return await from_channel(stream).stream()

--- a/playwright/download.py
+++ b/playwright/download.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 from pathlib import Path
 from typing import Dict, Optional, Union
 
-from playwright.connection import ChannelOwner
+from playwright.connection import ChannelOwner, from_channel
 
 
 class Download(ChannelOwner):
@@ -44,3 +45,11 @@ class Download(ChannelOwner):
     async def saveAs(self, path: Union[Path, str]) -> None:
         path = str(Path(path))
         return await self._channel.send("saveAs", dict(path=path))
+
+    async def createReadStream(
+        self, fp: Optional[io.BytesIO], size: int = None
+    ) -> Optional[io.BytesIO]:
+        stream = await self._channel.send("stream")
+        if not stream:
+            return None
+        return await from_channel(stream).stream(fp, size)

--- a/playwright/object_factory.py
+++ b/playwright/object_factory.py
@@ -31,6 +31,7 @@ from playwright.network import Request, Response, Route
 from playwright.page import BindingCall, Page, Worker
 from playwright.playwright import Playwright
 from playwright.selectors import Selectors
+from playwright.stream import Stream
 
 
 class DummyObject(ChannelOwner):
@@ -88,4 +89,6 @@ def create_remote_object(
         return Worker(parent, type, guid, initializer)
     if type == "Selectors":
         return Selectors(parent, type, guid, initializer)
+    if type == "Stream":
+        return Stream(parent, type, guid, initializer)
     return DummyObject(parent, type, guid, initializer)

--- a/playwright/page.py
+++ b/playwright/page.py
@@ -461,7 +461,7 @@ class Page(ChannelOwner):
             timeout = self._timeout_settings.timeout()
         wait_helper = WaitHelper(self._loop)
         wait_helper.reject_on_timeout(
-            timeout, f'Timeout while waiting for event "${event}"'
+            timeout, f'Timeout while waiting for event "{event}"'
         )
         if event != Page.Events.Crash:
             wait_helper.reject_on_event(self, Page.Events.Crash, Error("Page crashed"))

--- a/playwright/stream.py
+++ b/playwright/stream.py
@@ -1,0 +1,39 @@
+# Copyright (c) Microsoft Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+import io
+from typing import Dict, Optional
+
+from playwright.connection import ChannelOwner
+
+
+class Stream(ChannelOwner):
+    def __init__(
+        self, parent: ChannelOwner, type: str, guid: str, initializer: Dict
+    ) -> None:
+        super().__init__(parent, type, guid, initializer)
+
+    async def stream(self, fp: io.BytesIO, size: Optional[int]) -> io.BytesIO:
+        if not fp:
+            fp = io.BytesIO()
+        if not size:
+            size = 16384  # default 16kb in Node.js
+
+        while True:
+            result = await self._channel.send("read", dict(size=size))
+            if not result:
+                fp.seek(0)
+                return fp
+            fp.write(base64.b64decode(result))

--- a/playwright/sync_api.py
+++ b/playwright/sync_api.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import io
 import pathlib
 import sys
 import typing
@@ -2885,6 +2885,7 @@ class Selectors(SyncBase):
             Name that is used in selectors as a prefix, e.g. `{name: 'foo'}` enables `foo=myselectorbody` selectors. May only contain `[a-zA-Z0-9_]` characters.
         source : Optional[str]
             Script that evaluates to a selector engine instance.
+        path : Optional[str]
         contentScript : Optional[bool]
             Whether to run this selector engine in isolated JavaScript environment. This environment has access to the same DOM, but not any JavaScript objects from the frame's scripts. Defaults to `false`. Note that running as a content script is not guaranteed when this engine is used together with other registered engines.
         """
@@ -3076,6 +3077,26 @@ class Download(SyncBase):
             Path where the download should be saved.
         """
         return mapping.from_maybe_impl(self._sync(self._impl_obj.saveAs(path=path)))
+
+    def createReadStream(
+        self, fp: io.BytesIO = None, size: int = None
+    ) -> typing.Union[io.BytesIO, NoneType]:
+        """Download.createReadStream
+
+        Returns readable stream for current download or `null` if download failed.
+
+        Parameters
+        ----------
+        fp : Optional[io.BytesIO]
+        size : Optional[int]
+
+        Returns
+        -------
+        Optional[io.BytesIO]
+        """
+        return mapping.from_maybe_impl(
+            self._sync(self._impl_obj.createReadStream(fp=fp, size=size))
+        )
 
 
 mapping.register(DownloadImpl, Download)
@@ -3862,6 +3883,7 @@ class Page(SyncBase):
         ----------
         url : Union[str, Pattern, typing.Callable[[str], bool], NoneType]
             Request URL string, regex or predicate receiving Request object.
+        predicate : Optional[typing.Callable[[playwright.network.Request], bool]]
         timeout : Optional[int]
             Maximum wait time in milliseconds, defaults to 30 seconds, pass `0` to disable the timeout. The default value can be changed by using the page.setDefaultTimeout(timeout) method.
 
@@ -3893,6 +3915,7 @@ class Page(SyncBase):
         ----------
         url : Union[str, Pattern, typing.Callable[[str], bool], NoneType]
             Request URL string, regex or predicate receiving Response object.
+        predicate : Optional[typing.Callable[[playwright.network.Response], bool]]
         timeout : Optional[int]
             Maximum wait time in milliseconds, defaults to 30 seconds, pass `0` to disable the timeout. The default value can be changed by using the browserContext.setDefaultTimeout(timeout) or page.setDefaultTimeout(timeout) methods.
 
@@ -3926,6 +3949,8 @@ class Page(SyncBase):
         ----------
         event : str
             Event name, same one would pass into `page.on(event)`.
+        predicate : Optional[typing.Callable[[typing.Any], bool]]
+        timeout : Optional[int]
 
         Returns
         -------
@@ -4071,6 +4096,7 @@ class Page(SyncBase):
         ----------
         source : Optional[str]
             Script to be evaluated in the page.
+        path : Optional[str]
         """
         return mapping.from_maybe_impl(
             self._sync(self._impl_obj.addInitScript(source=source, path=path))
@@ -5247,6 +5273,7 @@ class BrowserContext(SyncBase):
         ----------
         source : Optional[str]
             Script to be evaluated in all pages in the browser context.
+        path : Optional[str]
         """
         return mapping.from_maybe_impl(
             self._sync(self._impl_obj.addInitScript(source=source, path=path))
@@ -5371,6 +5398,8 @@ class BrowserContext(SyncBase):
         ----------
         event : str
             Event name, same one would pass into `browserContext.on(event)`.
+        predicate : Optional[typing.Callable[[typing.Any], bool]]
+        timeout : Optional[int]
 
         Returns
         -------

--- a/playwright/sync_api.py
+++ b/playwright/sync_api.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import io
 import pathlib
 import sys
 import typing
@@ -64,6 +63,8 @@ from playwright.page import Page as PageImpl
 from playwright.page import Worker as WorkerImpl
 from playwright.playwright import Playwright as PlaywrightImpl
 from playwright.selectors import Selectors as SelectorsImpl
+from playwright.stream import Stream as StreamImpl
+from playwright.stream import StreamIO as StreamIOImpl
 from playwright.sync_base import EventContextManager, SyncBase, mapping
 
 NoneType = type(None)
@@ -3009,6 +3010,49 @@ class Dialog(SyncBase):
 mapping.register(DialogImpl, Dialog)
 
 
+class StreamIO(SyncBase):
+    def __init__(self, obj: StreamIOImpl):
+        super().__init__(obj)
+
+    def read(self, size: int = None) -> typing.Union[bytes, NoneType]:
+        """StreamIO.read
+
+        Reads from the download bytes
+
+        Parameters
+        ----------
+        size : Optional[int]
+            Size in bytes how much should be read.
+
+        Returns
+        -------
+        Optional[bytes]
+        """
+        return mapping.from_maybe_impl(self._sync(self._impl_obj.read(size=size)))
+
+
+mapping.register(StreamIOImpl, StreamIO)
+
+
+class Stream(SyncBase):
+    def __init__(self, obj: StreamImpl):
+        super().__init__(obj)
+
+    def stream(self) -> "StreamIO":
+        """Stream.stream
+
+        Returns the file stream
+
+        Returns
+        -------
+        StreamIO
+        """
+        return mapping.from_impl(self._sync(self._impl_obj.stream()))
+
+
+mapping.register(StreamImpl, Stream)
+
+
 class Download(SyncBase):
     def __init__(self, obj: DownloadImpl):
         super().__init__(obj)
@@ -3078,25 +3122,16 @@ class Download(SyncBase):
         """
         return mapping.from_maybe_impl(self._sync(self._impl_obj.saveAs(path=path)))
 
-    def createReadStream(
-        self, fp: io.BytesIO = None, size: int = None
-    ) -> typing.Union[io.BytesIO, NoneType]:
+    def createReadStream(self) -> typing.Union["StreamIO", NoneType]:
         """Download.createReadStream
 
         Returns readable stream for current download or `null` if download failed.
 
-        Parameters
-        ----------
-        fp : Optional[io.BytesIO]
-        size : Optional[int]
-
         Returns
         -------
-        Optional[io.BytesIO]
+        Optional[StreamIO]
         """
-        return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.createReadStream(fp=fp, size=size))
-        )
+        return mapping.from_impl_nullable(self._sync(self._impl_obj.createReadStream()))
 
 
 mapping.register(DownloadImpl, Download)

--- a/scripts/documentation_provider.py
+++ b/scripts/documentation_provider.py
@@ -108,15 +108,14 @@ class DocumentationProvider:
                 elif not doc_value and fqname == "Page.setViewportSize":
                     args = args["viewportSize"]["type"]["properties"]
                     doc_value = args.get(name)
+                code_type = self.serialize_python_type(value)
+                print(f"{indent}{original_name} : {code_type}")
                 if not doc_value:
                     print(
                         f"Missing parameter documentation: {fqname}({name}=)",
                         file=stderr,
                     )
                 else:
-                    code_type = self.serialize_python_type(value)
-
-                    print(f"{indent}{original_name} : {code_type}")
                     if doc_value["comment"]:
                         print(
                             f"{indent}    {self.indent_paragraph(doc_value['comment'], f'{indent}    ')}"
@@ -210,6 +209,8 @@ class DocumentationProvider:
 
     def serialize_python_type(self, value: Any) -> str:
         str_value = str(value)
+        if str_value == "<class '_io.BytesIO'>":
+            return "io.BytesIO"
         if str_value == "<class 'playwright.helper.Error'>":
             return "Error"
         match = re.match(r"^<class '((?:pathlib\.)?\w+)'>$", str_value)

--- a/scripts/documentation_provider.py
+++ b/scripts/documentation_provider.py
@@ -50,6 +50,46 @@ class DocumentationProvider:
         self.printed_entries: List[str] = []
         with open("api.json") as json_file:
             self.api = json.load(json_file)
+        self.api["StreamIO"] = {
+            "name": "StreamIO",
+            "members": {
+                "read": {
+                    "kind": "method",
+                    "name": "read",
+                    "type": {"name": "Promise<null|bytes>", "properties": {}},
+                    "comment": "Reads from the download bytes",
+                    "returnComment": "",
+                    "required": True,
+                    "templates": [],
+                    "args": {
+                        "size": {
+                            "kind": "property",
+                            "name": "size",
+                            "type": {"name": "int", "properties": {}},
+                            "comment": "Size in bytes how much should be read.",
+                            "returnComment": "",
+                            "required": False,
+                            "templates": [],
+                        }
+                    },
+                }
+            },
+        }
+        self.api["Stream"] = {
+            "name": "Stream",
+            "members": {
+                "stream": {
+                    "kind": "method",
+                    "name": "stream",
+                    "type": {"name": "Promise<StreamIO>", "properties": {}},
+                    "comment": "Returns the file stream",
+                    "returnComment": "",
+                    "required": True,
+                    "templates": [],
+                    "args": {},
+                }
+            },
+        }
 
     method_name_rewrites: Dict[str, str] = {
         "continue_": "continue",

--- a/scripts/generate_api.py
+++ b/scripts/generate_api.py
@@ -44,6 +44,7 @@ from playwright.network import Request, Response, Route
 from playwright.page import BindingCall, Page, Worker
 from playwright.playwright import Playwright
 from playwright.selectors import Selectors
+from playwright.stream import Stream, StreamIO
 
 
 def process_type(value: Any, param: bool = False) -> str:
@@ -142,7 +143,6 @@ header = """
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import io
 import typing
 import sys
 import pathlib
@@ -172,6 +172,7 @@ from playwright.network import Request as RequestImpl, Response as ResponseImpl,
 from playwright.page import BindingCall as BindingCallImpl, Page as PageImpl, Worker as WorkerImpl
 from playwright.playwright import Playwright as PlaywrightImpl
 from playwright.selectors import Selectors as SelectorsImpl
+from playwright.stream import Stream as StreamImpl, StreamIO as StreamIOImpl
 """
 
 all_types = [
@@ -189,6 +190,8 @@ all_types = [
     Selectors,
     ConsoleMessage,
     Dialog,
+    StreamIO,
+    Stream,
     Download,
     BindingCall,
     Page,
@@ -204,3 +207,7 @@ all_types = [
 api_globals = globals()
 assert ValuesToSelect
 assert Serializable
+
+
+def check_inheritance(base_class):
+    return base_class in ["ChannelOwner", "object", "RawIOBase"]

--- a/scripts/generate_api.py
+++ b/scripts/generate_api.py
@@ -48,6 +48,7 @@ from playwright.selectors import Selectors
 
 def process_type(value: Any, param: bool = False) -> str:
     value = str(value)
+    value = value.replace("_io.BytesIO", "io.BytesIO")
     value = re.sub(r"<class '([^']+)'>", r"\1", value)
     if "playwright.helper" in value:
         value = re.sub(r"playwright\.helper\.", "", value)
@@ -141,7 +142,7 @@ header = """
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import io
 import typing
 import sys
 import pathlib

--- a/scripts/generate_async_api.py
+++ b/scripts/generate_async_api.py
@@ -21,7 +21,7 @@ from scripts.documentation_provider import DocumentationProvider
 from scripts.generate_api import (
     all_types,
     api_globals,
-    arguments,
+    arguments, check_inheritance,
     header,
     process_type,
     return_type,
@@ -39,7 +39,7 @@ def generate(t: Any) -> None:
     base_class = t.__bases__[0].__name__
     base_sync_class = (
         "AsyncBase"
-        if base_class == "ChannelOwner" or base_class == "object"
+        if check_inheritance(base_class)
         else base_class
     )
     print(f"class {class_name}({base_sync_class}):")

--- a/scripts/generate_sync_api.py
+++ b/scripts/generate_sync_api.py
@@ -21,7 +21,7 @@ from scripts.documentation_provider import DocumentationProvider
 from scripts.generate_api import (
     all_types,
     api_globals,
-    arguments,
+    arguments, check_inheritance,
     header,
     process_type,
     return_type,
@@ -39,7 +39,7 @@ def generate(t: Any) -> None:
     base_class = t.__bases__[0].__name__
     base_sync_class = (
         "SyncBase"
-        if base_class == "ChannelOwner" or base_class == "object"
+        if check_inheritance(base_class)
         else base_class
     )
     print(f"class {class_name}({base_sync_class}):")

--- a/scripts/update_api.sh
+++ b/scripts/update_api.sh
@@ -4,7 +4,6 @@ function update_api {
     echo "Generating $1"
     file_name="$1"
     generate_script="$2"
-    git checkout HEAD -- "$file_name"
 
     python "$generate_script" > .x
 
@@ -12,7 +11,10 @@ function update_api {
     pre-commit run --files $file_name
 }
 
-update_api "playwright/sync_api.py" "scripts/generate_sync_api.py"
+git checkout HEAD -- "playwright/async_api.py"
+git checkout HEAD -- "playwright/sync_api.py"
+
 update_api "playwright/async_api.py" "scripts/generate_async_api.py"
+update_api "playwright/sync_api.py" "scripts/generate_sync_api.py"
 
 echo "Regenerated APIs"

--- a/tests/async/test_download.py
+++ b/tests/async/test_download.py
@@ -286,6 +286,26 @@ async def test_should_delete_file(browser, server):
     await page.close()
 
 
+async def test_should_expose_stream_new(browser, server):
+    page = await browser.newPage(acceptDownloads=True)
+    await page.setContent(f'<a href="{server.PREFIX}/download">download</a>')
+    [download, _] = await asyncio.gather(page.waitForEvent("download"), page.click("a"))
+    stream = await download.createReadStream()
+    assert stream.read().decode() == "Hello world"
+    await page.close()
+
+
+async def test_should_expose_stream_to_file(browser, server, tmpdir):
+    page = await browser.newPage(acceptDownloads=True)
+    await page.setContent(f'<a href="{server.PREFIX}/download">download</a>')
+    [download, _] = await asyncio.gather(page.waitForEvent("download"), page.click("a"))
+    tmpfile = tmpdir / "myfile"
+    with open(tmpfile, "wb") as fp:
+        await download.createReadStream(fp)
+    assert tmpfile.read_text("utf-8") == "Hello world"
+    await page.close()
+
+
 async def test_should_delete_downloads_on_context_destruction(browser, server):
     page = await browser.newPage(acceptDownloads=True)
     await page.setContent(f'<a href="{server.PREFIX}/download">download</a>')

--- a/tests/async/test_download.py
+++ b/tests/async/test_download.py
@@ -291,18 +291,7 @@ async def test_should_expose_stream_new(browser, server):
     await page.setContent(f'<a href="{server.PREFIX}/download">download</a>')
     [download, _] = await asyncio.gather(page.waitForEvent("download"), page.click("a"))
     stream = await download.createReadStream()
-    assert stream.read().decode() == "Hello world"
-    await page.close()
-
-
-async def test_should_expose_stream_to_file(browser, server, tmpdir):
-    page = await browser.newPage(acceptDownloads=True)
-    await page.setContent(f'<a href="{server.PREFIX}/download">download</a>')
-    [download, _] = await asyncio.gather(page.waitForEvent("download"), page.click("a"))
-    tmpfile = tmpdir / "myfile"
-    with open(tmpfile, "wb") as fp:
-        await download.createReadStream(fp)
-    assert tmpfile.read_text("utf-8") == "Hello world"
+    assert (await stream.read()).decode() == "Hello world"
     await page.close()
 
 


### PR DESCRIPTION
I think thats the "idiomatic python way" of that. works basically like [`json.dump`](https://docs.python.org/3/library/json.html#json.dump).

The `io` type generation handling was not working as expected, maybe you can take a look? Do I need to replace `_io` by `io` in our generation scripts?

Relates #144