### PR TITLE
fix: wheel integrity by using generated wheel

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include playwright/drivers/browsers.json
+include-recursive playwright/drivers/
 include playwright/*.py
 include README.md
 include SECURITY.md

--- a/build_package.py
+++ b/build_package.py
@@ -12,11 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import glob
-import os
 import shutil
 import subprocess
-import zipfile
 
 from playwright.path_utils import get_file_dirname
 
@@ -32,21 +29,3 @@ if _egg_dir.exists():
     shutil.rmtree(_egg_dir)
 
 subprocess.check_call("python setup.py sdist bdist_wheel", shell=True)
-
-base_wheel_location = glob.glob("dist/*.whl")[0]
-without_platform = base_wheel_location[:-7]
-
-pack_wheel_drivers = [
-    ("driver-linux", "manylinux1_x86_64.whl"),
-    ("driver-macos", "macosx_10_13_x86_64.whl"),
-    ("driver-win.exe", "win_amd64.whl"),
-]
-
-for driver, wheel in pack_wheel_drivers:
-    wheel_location = without_platform + wheel
-    shutil.copy(base_wheel_location, wheel_location)
-    from_location = f"driver/out/{driver}"
-    to_location = f"playwright/drivers/{driver}"
-    with zipfile.ZipFile(wheel_location, "a") as zipf:
-        zipf.write(from_location, to_location)
-os.remove(base_wheel_location)

--- a/buildbots/test-package-installations.sh
+++ b/buildbots/test-package-installations.sh
@@ -17,7 +17,7 @@ echo "Creating virtual environment"
 virtualenv env
 source env/bin/activate
 echo "Installing Playwright Python via Wheel"
-pip install "$(echo $base_dir/dist/playwright*manylinux1*.whl)"
+pip install "$(echo $base_dir/dist/playwright*.whl)"
 echo "Installing browsers"
 python -m playwright install
 echo "Running basic tests"


### PR DESCRIPTION
Reverts the old change which probably messed up the package integrity.

Relates to #140