### PR TITLE
fix(error): display correct message

### DIFF
--- a/playwright/helper.py
+++ b/playwright/helper.py
@@ -232,6 +232,7 @@ class Error(Exception):
     def __init__(self, message: str, stack: str = None) -> None:
         self.message = message
         self.stack = stack
+        super().__init__(message)
 
 
 class TimeoutError(Error):


### PR DESCRIPTION
Like we do in upstream:

https://github.com/microsoft/playwright/blob/d4c466868b4a82c3be7ebd697698dd9c129af98d/src/errors.ts#L18-L24

Before

```
>>> message = '''Timeout 30000ms exceeded.\n=========================== logs ===========================\n[api] waiting for selector "[data-testid=dnb-table] tbody tr:nth-child(1):not(.ant-table-placeholder)"\n============================================================\nNote: use DEBUG=pw:api environment variable and rerun to capture Playwright logs.'''
>>> 

stack='''TimeoutError: Timeout 30000ms exceeded.\n=========================== logs ===========================\n[api] waiting for selector "[data-testid=dnb-table] tbody tr:nth-child(1):not(.ant-table-placeholder)"\n============================================================\nNote: use DEBUG=pw:api environment variable and rerun to capture Playwright logs.\n    at ProgressController.run (/snapshot/driver/node_modules/playwright/lib/progress.js:71:30)\n    at Object.runAbortableTask (/snapshot/driver/node_modules/playwright/lib/progress.js:24:23)\n    at Page._runAbortableTask (/snapshot/driver/node_modules/playwright/lib/page.js:89:27)\n    at Frame.waitForSelector (/snapshot/driver/node_modules/playwright/lib/frames.js:443:27)\n    at Frame.waitForSelector (/snapshot/driver/node_modules/playwright/lib/helper.js:80:31)\n    at FrameDispatcher.waitForSelector (
>>> from playwright import Error
>>> 
>>> x = Error(message, stack)
>>> raise(x)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
playwright.helper.Error: ('Timeout 30000ms exceeded.\n=========================== logs ===========================\n[api] waiting for selector "[data-testid=dnb-table] tbody tr:nth-child(1):not(.ant-table-placeholder)"\n============================================================\nNote: use DEBUG=pw:api environment variable and rerun to capture Playwright logs.', 'TimeoutError: Timeout 30000ms exceeded.\n=========================== logs ===========================\n[api] waiting for selector "[data-testid=dnb-table] tbody tr:nth-child(1):not(.ant-table-placeholder)"\n============================================================\nNote: use DEBUG=pw:api environment variable and rerun to capture Playwright logs.\n    at ProgressController.run (/snapshot/driver/node_modules/playwright/lib/progress.js:71:30)\n    at Object.runAbortableTask (/snapshot/driver/node_modules/playwright/lib/progress.js:24:23)\n    at Page._runAbortableTask (/snapshot/driver/node_modules/playwright/lib/page.js:89:27)\n    at Frame.waitForSelector (/snapshot/driver/node_modules/playwright/lib/frames.js:443:27)\n    at Frame.waitForSelector (/snapshot/driver/node_modules/playwright/lib/helper.js:80:31)\n    at FrameDispatcher.waitForSelector (/snapshot/driver/node_modules/playwright/lib/rpc/server/frameDispatcher.js:66:124)\n    at DispatcherConnection.dispatch (/snapshot/driver/node_modules/playwright/lib/rpc/server/dispatcher.js:137:52)\n    at Transport.onmessage (/snapshot/driver/node_modules/playwright/lib/rpc/server.js:35:55)\n    at Immediate.<anonymous> (/snapshot/driver/node_modules/playwright/lib/rpc/transport.js:64:26)\n    at processImmediate (internal/timers.js:456:21)')
```

After

```
>>> message = '''Timeout 30000ms exceeded.\n=========================== logs ===========================\n[api] waiting for selector "[data-testid=dnb-table] tbody tr:nth-child(1):not(.ant-table-placeholder)"\n============================================================\nNote: use DEBUG=pw:api environment variable and rerun to capture Playwright logs.'''
>>> 

stack='''TimeoutError: Timeout 30000ms exceeded.\n=========================== logs ===========================\n[api] waiting for selector "[data-testid=dnb-table] tbody tr:nth-child(1):not(.ant-table-placeholder)"\n============================================================\nNote: use DEBUG=pw:api environment variable and rerun to capture Playwright logs.\n    at ProgressController.run (/snapshot/driver/node_modules/playwright/lib/progress.js:71:30)\n    at Object.runAbortableTask (/snapshot/driver/node_modules/playwright/lib/progress.js:24:23)\n    at Page._runAbortableTask (/snapshot/driver/node_modules/playwright/lib/page.js:89:27)\n    at Frame.waitForSelector (/snapshot/driver/node_modules/playwright/lib/frames.js:443:27)\n    at Frame.waitForSelector (/snapshot/driver/node_modules/playwright/lib/helper.js:80:31)\n    at FrameDispatcher.waitForSelector (/snapshot/driver/node_modules/playwright/lib/rpc/server/frameDispatcher.js:66:124)\n    at DispatcherConnection.dispatch (/snapshot/driver/node_modules
... '''
>>> from playwright import Error
>>> 
>>> x = Error(message, stack)
>>> raise(x)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
playwright.helper.Error: Timeout 30000ms exceeded.
=========================== logs ===========================
[api] waiting for selector "[data-testid=dnb-table] tbody tr:nth-child(1):not(.ant-table-placeholder)"
============================================================
Note: use DEBUG=pw:api environment variable and rerun to capture Playwright logs.
>>> 
```