### PR TITLE
[DO NOT LAND]: test python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
         browser: [chromium, firefox, webkit]
     runs-on: ${{ matrix.os }}
     steps:

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setuptools.setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.6",
     use_scm_version={
         "version_scheme": "post-release",
         "write_to": "playwright/_repo_version.py",


### PR DESCRIPTION
Request came via Slack: https://playwright.slack.com/archives/C0182HLNSJV/p1598274240005300?thread_ts=1598273198.003900&cid=C0182HLNSJV

Around 10% of the users are using 3.6 so not sure if it would be worth to support 3.6. ([source](https://www.jetbrains.com/lp/python-developers-survey-2019/))