### PR TITLE
chore: add missing methods and use a set for it

### DIFF
--- a/playwright/async_api.py
+++ b/playwright/async_api.py
@@ -810,6 +810,15 @@ class ElementHandle(JSHandle):
     def __init__(self, obj: ElementHandleImpl):
         super().__init__(obj)
 
+    def toString(self) -> str:
+        """ElementHandle.toString
+
+        Returns
+        -------
+        str
+        """
+        return mapping.from_maybe_impl(self._impl_obj.toString())
+
     def asElement(self) -> typing.Union["ElementHandle", NoneType]:
         """ElementHandle.asElement
 

--- a/playwright/element_handle.py
+++ b/playwright/element_handle.py
@@ -51,6 +51,9 @@ class ElementHandle(JSHandle):
     ) -> None:
         super().__init__(parent, type, guid, initializer)
 
+    def toString(self) -> str:
+        return self._preview
+
     def asElement(self) -> Optional["ElementHandle"]:
         return self
 

--- a/playwright/sync_api.py
+++ b/playwright/sync_api.py
@@ -830,6 +830,15 @@ class ElementHandle(JSHandle):
     def __init__(self, obj: ElementHandleImpl):
         super().__init__(obj)
 
+    def toString(self) -> str:
+        """ElementHandle.toString
+
+        Returns
+        -------
+        str
+        """
+        return mapping.from_maybe_impl(self._impl_obj.toString())
+
     def asElement(self) -> typing.Union["ElementHandle", NoneType]:
         """ElementHandle.asElement
 

--- a/scripts/documentation_provider.py
+++ b/scripts/documentation_provider.py
@@ -371,6 +371,7 @@ class DocumentationProvider:
         return name
 
     def print_remainder(self) -> None:
+        remainders = set()
         for [class_name, value] in self.api.items():
             class_name = re.sub(r"Chromium(.*)", r"\1", class_name)
             class_name = re.sub(r"WebKit(.*)", r"\1", class_name)
@@ -380,7 +381,9 @@ class DocumentationProvider:
                     continue
                 entry = f"{class_name}.{method_name}"
                 if entry not in self.printed_entries:
-                    print(f"Method not implemented: {entry}", file=stderr)
+                    remainders.add(f"Method not implemented: {entry}")
+        for remainder in remainders:
+            print(remainder, file=stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/documentation_provider.py
+++ b/scripts/documentation_provider.py
@@ -43,6 +43,29 @@ exceptions = {
     },
 }
 
+expected_mismatches = [
+    "Download.createReadStream",
+    "Browser.startTracing",
+    "Browser.stopTracing",
+    "Logger.log",
+    "BrowserContext.setHTTPCredentials",  # deprecated
+    "BrowserContext.serviceWorkers",  # CR only (and the following)
+    "BrowserContext.backgroundPages",
+    "Browser.newBrowserCDPSession",
+    "Page.coverage",
+    "Coverage.startCSSCoverage",
+    "Coverage.stopCSSCoverage",
+    "Coverage.startJSCoverage",
+    "Coverage.stopJSCoverage",
+    "BrowserContext.newCDPSession",
+    "Logger.isEnabled",
+    "BrowserServer.kill",  # not relevant for RPC clients (and the following)
+    "BrowserType.launchServer",
+    "BrowserServer.close",
+    "BrowserServer.process",
+    "BrowserServer.wsEndpoint",
+]
+
 
 class DocumentationProvider:
     def __init__(self) -> None:
@@ -380,10 +403,15 @@ class DocumentationProvider:
                 if method["kind"] == "event":
                     continue
                 entry = f"{class_name}.{method_name}"
-                if entry not in self.printed_entries:
+                if (
+                    entry not in self.printed_entries
+                    and entry not in expected_mismatches
+                ):
                     remainders.add(f"Method not implemented: {entry}")
         for remainder in remainders:
             print(remainder, file=stderr)
+        if len(remainders) > 0:
+            exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/generate_async_api.py
+++ b/scripts/generate_async_api.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # Copyright (c) Microsoft Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/generate_sync_api.py
+++ b/scripts/generate_sync_api.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # Copyright (c) Microsoft Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
I went through them, let me know if you are okay with that. In my mind there is no need for now to land more methods since they are almost only CR specific.

```
Method not implemented: Download.createReadStream <- PR open

Method not implemented: BrowserContext.serviceWorkers <- CR specific
Method not implemented: BrowserContext.backgroundPages <- CR specific
Method not implemented: Browser.newBrowserCDPSession <- important?

Method not implemented: BrowserType.launchServer <- decided to not land this in RPC clients. By that also the following methods

Method not implemented: BrowserServer.close
Method not implemented: BrowserServer.process
Method not implemented: BrowserServer.kill
Method not implemented: BrowserServer.wsEndpoint

Method not implemented: BrowserContext.newCDPSession <- its there but on the CR browser context
Method not implemented: Logger.isEnabled
Method not implemented: Logger.log
Method not implemented: Browser.stopTracing
Method not implemented: Browser.startTracing
Method not implemented: Page.coverage <- CR only
Method not implemented: Coverage.stopCSSCoverage
Method not implemented: Coverage.startCSSCoverage
Method not implemented: Coverage.startJSCoverage
Method not implemented: Coverage.stopJSCoverage
Method not implemented: BrowserContext.setHTTPCredentials <- deprecated

```