### PR TITLE
devops: fixed docs deployment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -17,9 +17,9 @@ jobs:
         pip install -r local-requirements.txt
         pip install -e .
     - name: Generate docs
-      run: pdoc3 --html -o docs playwright
+      run: pdoc3 --html -o htmldocs playwright
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./docs
+        publish_dir: ./htmldocs/playwright

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@ htmlcov/
 _repo_version.py
 coverage.xml
 junit/
-docs/
+htmldocs/


### PR DESCRIPTION
- use htmldocs instead of docs because it clashes with the existing docs folder
- use //playwright folder inside of the output folder since it was nested inside