### PR TITLE
chore: pin dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
     url="https://github.com/Microsoft/playwright-python",
     packages=["playwright"],
     include_package_data=True,
-    install_requires=["greenlet", "pyee", "typing-extensions"],
+    install_requires=["greenlet==0.4.17", "pyee==8.0.1", "typing-extensions"],
     classifiers=[
         "Topic :: Software Development :: Testing",
         "Topic :: Internet :: WWW/HTTP :: Browsers",


### PR DESCRIPTION
Alternatives are:
a) allow bumping a minor version
b) allow bumping a patch version

In my opinion using a exact version is the best for now. We can bump them every few months to stay up to date.