### PR TITLE
chore: Add py.typed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include playwright/drivers/browsers.json
 include playwright/*.py
+include playwright/py.typed
 include README.md
 include SECURITY.md
 include LICENSE


### PR DESCRIPTION
This will allow type checkers to collect type information from this package.

See [PEP 561](https://www.python.org/dev/peps/pep-0561/).