### PR TITLE
devops: Migrate isort pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     rev: '3.8.3'
     hooks:
     -   id: flake8
--   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.5.4
+-   repo: https://github.com/pycqa/isort
+    rev: 5.5.4
     hooks:
     -   id: isort


### PR DESCRIPTION
Isort 5.x includes a pre-commit configuration (see [docs](https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0/#migrating-pre-commit)).
The isort mirror is now deprecated (see [README](https://github.com/pre-commit/mirrors-isort/blob/master/README.md))