### PR TITLE
devops: Run CI jobs also on Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,16 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [3.7, 3.8]
         browser: [chromium, firefox, webkit]
+        include:
+        - os: ubuntu-latest
+          python-version: 3.9
+          browser: chromium
+        - os: windows-latest
+          python-version: 3.9
+          browser: chromium
+        - os: macos-latest
+          python-version: 3.9
+          browser: chromium
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
@@ -63,7 +73,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip wheel
         pip install -r local-requirements.txt
         pip install -e .
     - name: Build driver

--- a/local-requirements.txt
+++ b/local-requirements.txt
@@ -8,7 +8,8 @@ pixelmatch==0.2.1
 Pillow==8.0.0
 mypy==0.782
 setuptools==50.3.0
-twisted==20.3.0
+# TODO: use PyPi version after >20.3.0 is released
+git+https://github.com/twisted/twisted.git@4ff22287cab3b54f51cee41ea2619e72d1bff2e4
 wheel==0.35.1
 black==20.8b1
 pre-commit==2.7.1

--- a/local-requirements.txt
+++ b/local-requirements.txt
@@ -5,7 +5,7 @@ pytest-sugar==0.9.4
 pytest-xdist==2.1.0
 pytest-timeout==1.4.2
 pixelmatch==0.2.1
-Pillow==7.2.0
+Pillow==8.0.0
 mypy==0.782
 setuptools==50.3.0
 twisted==20.3.0

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],


### PR DESCRIPTION
Blocked by https://github.com/python-pillow/Pillow/issues/4953

The chance that WK or FF is broken on Python 3.9 is not very big. Lets save some bot minutes!