### PR TITLE
chore: fix test server to disable cache

### DIFF
--- a/tests/async/test_navigation.py
+++ b/tests/async/test_navigation.py
@@ -864,7 +864,6 @@ async def test_wait_for_load_state_should_resolve_after_popup_load(context, serv
     assert popup.url == server.PREFIX + "/one-style.html"
 
 
-@pytest.mark.skip_browser("firefox")
 async def test_go_back_should_work(page, server):
     assert await page.goBack() is None
 

--- a/tests/server.py
+++ b/tests/server.py
@@ -114,8 +114,9 @@ class Server:
                     ).read_bytes()
                 except (FileNotFoundError, IsADirectoryError):
                     request.setResponseCode(HTTPStatus.NOT_FOUND)
+                request.setHeader("Content-Type", mimetypes.guess_type(uri)[0])
+                request.setHeader("Cache-Control", "no-cache, no-store")
                 if file_content:
-                    request.setHeader("Content-Type", mimetypes.guess_type(uri)[0])
                     if uri in gzip_routes:
                         request.setHeader("Content-Encoding", "gzip")
                         request.write(gzip.compress(file_content))

--- a/tests/server.py
+++ b/tests/server.py
@@ -114,8 +114,8 @@ class Server:
                     ).read_bytes()
                 except (FileNotFoundError, IsADirectoryError):
                     request.setResponseCode(HTTPStatus.NOT_FOUND)
-                request.setHeader("Content-Type", mimetypes.guess_type(uri)[0])
-                request.setHeader("Cache-Control", "no-cache, no-store")
+                request.setHeader(b"Content-Type", mimetypes.guess_type(uri)[0])
+                request.setHeader(b"Cache-Control", "no-cache, no-store")
                 if file_content:
                     if uri in gzip_routes:
                         request.setHeader("Content-Encoding", "gzip")

--- a/tests/server.py
+++ b/tests/server.py
@@ -112,10 +112,10 @@ class Server:
                     file_content = (
                         static_path / request.path.decode()[1:]
                     ).read_bytes()
+                    request.setHeader(b"Content-Type", mimetypes.guess_type(uri)[0])
+                    request.setHeader(b"Cache-Control", "no-cache, no-store")
                 except (FileNotFoundError, IsADirectoryError):
                     request.setResponseCode(HTTPStatus.NOT_FOUND)
-                request.setHeader(b"Content-Type", mimetypes.guess_type(uri)[0])
-                request.setHeader(b"Cache-Control", "no-cache, no-store")
                 if file_content:
                     if uri in gzip_routes:
                         request.setHeader("Content-Encoding", "gzip")

--- a/tests/server.py
+++ b/tests/server.py
@@ -114,15 +114,14 @@ class Server:
                     ).read_bytes()
                     request.setHeader(b"Content-Type", mimetypes.guess_type(uri)[0])
                     request.setHeader(b"Cache-Control", "no-cache, no-store")
-                except (FileNotFoundError, IsADirectoryError):
-                    request.setResponseCode(HTTPStatus.NOT_FOUND)
-                if file_content:
                     if uri in gzip_routes:
                         request.setHeader("Content-Encoding", "gzip")
                         request.write(gzip.compress(file_content))
                     else:
                         request.write(file_content)
                     self.setResponseCode(HTTPStatus.OK)
+                except (FileNotFoundError, IsADirectoryError):
+                    request.setResponseCode(HTTPStatus.NOT_FOUND)
                 self.finish()
 
         class MyHttp(http.HTTPChannel):


### PR DESCRIPTION
If pages are cached, then Firefox uses back-forward cache aggressively
to serve the history navigations.

Fixes https://github.com/microsoft/playwright/issues/3693
Fixes #279