### PR TITLE
fix: Use urllib instead of curl

### DIFF
--- a/build_package.py
+++ b/build_package.py
@@ -18,6 +18,7 @@ import shutil
 import stat
 import subprocess
 import sys
+import urllib.request
 import zipfile
 
 from playwright.path_utils import get_file_dirname
@@ -40,7 +41,7 @@ for platform in ["mac", "linux", "win32", "win32_x64"]:
     if not os.path.exists("driver/" + zip_file):
         url = "https://playwright.azureedge.net/builds/cli/next/" + zip_file
         print("Fetching ", url)
-        subprocess.check_call(["curl", url, "-o", "driver/" + zip_file])
+        urllib.request.urlretrieve(url, "driver/" + zip_file)
 
 _dirname = get_file_dirname()
 _build_dir = _dirname / "build"


### PR DESCRIPTION
Fixes #301 
Use urllib instead of curl for downloading zip files.