### PR TITLE
chore: only publish wheels package on Pypi

### DIFF
--- a/build_package.py
+++ b/build_package.py
@@ -49,7 +49,7 @@ _egg_dir = _dirname / "playwright.egg-info"
 if _egg_dir.exists():
     shutil.rmtree(_egg_dir)
 
-subprocess.check_call("python setup.py sdist bdist_wheel", shell=True)
+subprocess.check_call("python setup.py bdist_wheel", shell=True)
 
 base_wheel_location = glob.glob("dist/*.whl")[0]
 without_platform = base_wheel_location[:-7]


### PR DESCRIPTION
Fixes #312

The failing CI is not related.