### PR TITLE
fix(stderr): remove the stderr patching hacks

### DIFF
--- a/playwright/main.py
+++ b/playwright/main.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import asyncio
-import io
 import os
 import subprocess
 import sys
@@ -43,22 +42,12 @@ def compute_driver_executable() -> Path:
 async def run_driver_async() -> Connection:
     driver_executable = compute_driver_executable()
 
-    # Sourced from: https://github.com/pytest-dev/pytest/blob/824e9cf67abcfc47df25a59bf32ebd8c25fbd02a/src/_pytest/faulthandler.py#L70-L77
-    def _get_stderr_fileno() -> int:
-        try:
-            return sys.stderr.fileno()
-        except (AttributeError, io.UnsupportedOperation):
-            # pytest-xdist monkeypatches sys.stderr with an object that is not an actual file.
-            # https://docs.python.org/3/library/faulthandler.html#issue-with-file-descriptors
-            # This is potentially dangerous, but the best we can do.
-            return sys.__stderr__.fileno()
-
     proc = await asyncio.create_subprocess_exec(
         str(driver_executable),
         "run-driver",
         stdin=asyncio.subprocess.PIPE,
         stdout=asyncio.subprocess.PIPE,
-        stderr=_get_stderr_fileno(),
+        stderr=sys.stderr,
         limit=32768,
     )
     assert proc.stdout


### PR DESCRIPTION
A fix for https://github.com/microsoft/playwright-python/issues/310

Will this make any bots fail? I am running it locally with `-n 4` and things work, is that not xdist?
