### PR TITLE
ci: Removed pytest timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,16 +81,16 @@ jobs:
       run: python -m playwright install
     - name: Test Sync API
       if: matrix.os != 'ubuntu-latest'
-      run: pytest -vv tests/sync --browser=${{ matrix.browser }} --timeout 90
+      run: pytest -vv tests/sync --browser=${{ matrix.browser }}
     - name: Test Sync API
       if: matrix.os == 'ubuntu-latest'
-      run: xvfb-run pytest -vv tests/sync --browser=${{ matrix.browser }} --timeout 90
+      run: xvfb-run pytest -vv tests/sync --browser=${{ matrix.browser }}
     - name: Test Async API
       if: matrix.os != 'ubuntu-latest'
-      run: pytest -vv tests/async --browser=${{ matrix.browser }} --timeout 90
+      run: pytest -vv tests/async --browser=${{ matrix.browser }}
     - name: Test Async API
       if: matrix.os == 'ubuntu-latest'
-      run: xvfb-run pytest -vv tests/async --browser=${{ matrix.browser }} --timeout 90
+      run: xvfb-run pytest -vv tests/async --browser=${{ matrix.browser }}
 
   test-package-installations:
     name: Test package installations

--- a/local-requirements.txt
+++ b/local-requirements.txt
@@ -4,7 +4,6 @@ pytest-asyncio==0.14.0
 pytest-cov==2.10.1
 pytest-sugar==0.9.4
 pytest-xdist==2.1.0
-pytest-timeout==1.4.2
 flaky==3.7.0
 pixelmatch==0.2.1
 Pillow==8.0.0


### PR DESCRIPTION
Removed pytest timeout as it causes random test fails especially of video tests as the total test time is already limited by github `    timeout-minutes: 30` 