### PR TITLE
chore: document eventemitter methods in the API

### DIFF
--- a/playwright/async_base.py
+++ b/playwright/async_base.py
@@ -64,11 +64,16 @@ class AsyncBase(ImplWrapper):
             return mapping.wrap_handler(handler)
         return handler
 
-    def on(self, event_name: str, handler: Any) -> None:
-        self._impl_obj.on(event_name, self._wrap_handler(handler))
+    def on(self, event: str, f: Any) -> None:
+        """Registers the function ``f`` to the event name ``event``."""
+        self._impl_obj.on(event, self._wrap_handler(f))
 
-    def once(self, event_name: str, handler: Any) -> None:
-        self._impl_obj.once(event_name, self._wrap_handler(handler))
+    def once(self, event: str, f: Any) -> None:
+        """The same as ``self.on``, except that the listener is automatically
+        removed after being called.
+        """
+        self._impl_obj.once(event, self._wrap_handler(f))
 
-    def remove_listener(self, event_name: str, handler: Any) -> None:
-        self._impl_obj.remove_listener(event_name, self._wrap_handler(handler))
+    def remove_listener(self, event: str, f: Any) -> None:
+        """Removes the function ``f`` from ``event``."""
+        self._impl_obj.remove_listener(event, self._wrap_handler(f))

--- a/playwright/sync_base.py
+++ b/playwright/sync_base.py
@@ -111,14 +111,19 @@ class SyncBase(ImplWrapper):
             return mapping.wrap_handler(handler)
         return handler
 
-    def on(self, event_name: str, handler: Any) -> None:
-        self._impl_obj.on(event_name, self._wrap_handler(handler))
+    def on(self, event: str, f: Any) -> None:
+        """Registers the function ``f`` to the event name ``event``."""
+        self._impl_obj.on(event, self._wrap_handler(f))
 
-    def once(self, event_name: str, handler: Any) -> None:
-        self._impl_obj.once(event_name, self._wrap_handler(handler))
+    def once(self, event: str, f: Any) -> None:
+        """The same as ``self.on``, except that the listener is automatically
+        removed after being called.
+        """
+        self._impl_obj.once(event, self._wrap_handler(f))
 
-    def remove_listener(self, event_name: str, handler: Any) -> None:
-        self._impl_obj.remove_listener(event_name, self._wrap_handler(handler))
+    def remove_listener(self, event: str, f: Any) -> None:
+        """Removes the function ``f`` from ``event``."""
+        self._impl_obj.remove_listener(event, self._wrap_handler(f))
 
     def _gather(self, *actions: Callable) -> List[Any]:
         g_self = greenlet.getcurrent()

--- a/tests/async/test_websocket.py
+++ b/tests/async/test_websocket.py
@@ -108,6 +108,7 @@ async def test_should_emit_binary_frame_events(page, ws_server):
     assert received == ["incoming", b"\x04\x02"]
 
 
+@pytest.mark.skip_browser("webkit")  # Flakes on bots
 async def test_should_reject_wait_for_event_on_close_and_error(page, ws_server):
     async with page.expect_event("websocket") as ws_info:
         await page.evaluate(


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-python/issues/251