### PR TITLE
chore: remove expect_dialog context manager from the sync api

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Playwright is a Python library to automate [Chromium](https://www.chromium.org/H
 
 |          | Linux | macOS | Windows |
 |   :---   | :---: | :---: | :---:   |
-| Chromium <!-- GEN:chromium-version -->88.0.4324.0<!-- GEN:stop --> | ✅ | ✅ | ✅ |
+| Chromium <!-- GEN:chromium-version -->88.0.4316.0<!-- GEN:stop --> | ✅ | ✅ | ✅ |
 | WebKit <!-- GEN:webkit-version -->14.0<!-- GEN:stop --> | ✅ | ✅ | ✅ |
 | Firefox <!-- GEN:firefox-version -->83.0<!-- GEN:stop --> | ✅ | ✅ | ✅ |
 

--- a/playwright/sync_api.py
+++ b/playwright/sync_api.py
@@ -5498,16 +5498,6 @@ class Page(SyncBase):
             self._loop, self._impl_obj.waitForEvent(event, predicate, timeout)
         )
 
-    def expect_dialog(
-        self,
-        predicate: typing.Union[typing.Callable[["Dialog"], bool]] = None,
-        timeout: int = None,
-    ) -> EventContextManager["Dialog"]:
-        event = "dialog"
-        return EventContextManager(
-            self._loop, self._impl_obj.waitForEvent(event, predicate, timeout)
-        )
-
     def expect_download(
         self,
         predicate: typing.Union[typing.Callable[["Download"], bool]] = None,

--- a/scripts/generate_sync_api.py
+++ b/scripts/generate_sync_api.py
@@ -74,6 +74,8 @@ def generate(t: Any) -> None:
             prefix = "        return " + prefix + f"self._impl_obj.{name}"
             print(f"{prefix}{arguments(value, len(prefix))}{suffix}")
     for [name, value] in t.__dict__.items():
+        if name in ["expect_dialog"]:
+            continue
         if (
             not name.startswith("_")
             and isinstance(value, FunctionType)


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-python/issues/253