### PR TITLE
fix get_file_dirname for pyinstaller (fix #342)

### DIFF
--- a/playwright/path_utils.py
+++ b/playwright/path_utils.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 import inspect
+import sys
 from pathlib import Path
 
 
 def get_file_dirname() -> Path:
     """Returns the callee (`__file__`) directory name"""
-    frame = inspect.stack()[1]
-    module = inspect.getmodule(frame[0])
+    frame = inspect.currentframe()
+    module_name = frame.f_back.f_globals["__name__"]
+    module = sys.modules[module_name]
     assert module
     return Path(module.__file__).parent.absolute()


### PR DESCRIPTION
fix [get_file_dirname](https://github.com/microsoft/playwright-python/blob/master/playwright/path_utils.py#L19) so that playwright can function when freezed with pyinstaller