### PR TITLE
fix: create event loop manually in case of running within non-main thread

### DIFF
--- a/playwright/main.py
+++ b/playwright/main.py
@@ -117,9 +117,7 @@ class AsyncPlaywrightContextManager:
 
 
 if sys.platform == "win32":
-    # Use ProactorEventLoop in 3.7, which is default in 3.8
-    loop = asyncio.ProactorEventLoop()
-    asyncio.set_event_loop(loop)
+    asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
 
 
 def main() -> None:


### PR DESCRIPTION
I believe this fixes what #350 is referring to.