### PR TITLE
ft: allow async callbacks with Page.on calls

### DIFF
--- a/playwright/connection.py
+++ b/playwright/connection.py
@@ -18,14 +18,14 @@ import traceback
 from typing import Any, Callable, Dict, Optional, Union
 
 from greenlet import greenlet
-from pyee import EventEmitter
+from pyee import AsyncIOEventEmitter
 
 from playwright.helper import ParsedMessagePayload, parse_error
 from playwright.sync_base import dispatcher_fiber
 from playwright.transport import Transport
 
 
-class Channel(EventEmitter):
+class Channel(AsyncIOEventEmitter):
     def __init__(self, connection: "Connection", guid: str) -> None:
         super().__init__()
         self._connection: Connection = connection
@@ -64,7 +64,7 @@ class Channel(EventEmitter):
         self._connection._send_message_to_server(self._guid, method, params)
 
 
-class ChannelOwner(EventEmitter):
+class ChannelOwner(AsyncIOEventEmitter):
     def __init__(
         self,
         parent: Union["ChannelOwner", "Connection"],
@@ -72,7 +72,7 @@ class ChannelOwner(EventEmitter):
         guid: str,
         initializer: Dict,
     ) -> None:
-        super().__init__()
+        super().__init__(loop=parent._loop)
         self._loop: asyncio.AbstractEventLoop = parent._loop
         self._type = type
         self._guid = guid

--- a/tests/async/test_browsercontext.py
+++ b/tests/async/test_browsercontext.py
@@ -728,7 +728,7 @@ async def test_page_event_should_fire_page_lifecycle_events(context, server):
         events.append("CREATED: " + page.url)
         page.on("close", lambda: events.append("DESTROYED: " + page.url))
 
-    context.on("page", lambda page: handle_page(page))
+    context.on("page", handle_page)
 
     page = await context.newPage()
     await page.goto(server.EMPTY_PAGE)

--- a/tests/async/test_dialog.py
+++ b/tests/async/test_dialog.py
@@ -22,12 +22,12 @@ from playwright.async_api import Dialog, Page
 async def test_should_fire(page: Page, server):
     result = []
 
-    def on_dialog(dialog: Dialog):
+    async def on_dialog(dialog: Dialog):
         result.append(True)
         assert dialog.type == "alert"
         assert dialog.defaultValue == ""
         assert dialog.message == "yo"
-        asyncio.create_task(dialog.accept())
+        await dialog.accept()
 
     page.on("dialog", on_dialog)
     await page.evaluate("alert('yo')")
@@ -37,12 +37,12 @@ async def test_should_fire(page: Page, server):
 async def test_should_allow_accepting_prompts(page: Page, server):
     result = []
 
-    def on_dialog(dialog: Dialog):
+    async def on_dialog(dialog: Dialog):
         result.append(True)
         assert dialog.type == "prompt"
         assert dialog.defaultValue == "yes."
         assert dialog.message == "question?"
-        asyncio.create_task(dialog.accept("answer!"))
+        await dialog.accept("answer!")
 
     page.on("dialog", on_dialog)
     assert await page.evaluate("prompt('question?', 'yes.')") == "answer!"
@@ -52,9 +52,9 @@ async def test_should_allow_accepting_prompts(page: Page, server):
 async def test_should_dismiss_the_prompt(page: Page, server):
     result = []
 
-    def on_dialog(dialog: Dialog):
+    async def on_dialog(dialog: Dialog):
         result.append(True)
-        asyncio.create_task(dialog.dismiss())
+        await dialog.dismiss()
 
     page.on("dialog", on_dialog)
     assert await page.evaluate("prompt('question?')") is None
@@ -64,9 +64,9 @@ async def test_should_dismiss_the_prompt(page: Page, server):
 async def test_should_accept_the_confirm_prompt(page: Page, server):
     result = []
 
-    def on_dialog(dialog: Dialog):
+    async def on_dialog(dialog: Dialog):
         result.append(True)
-        asyncio.create_task(dialog.accept())
+        await dialog.accept()
 
     page.on("dialog", on_dialog)
     assert await page.evaluate("confirm('boolean?')") is True
@@ -76,9 +76,9 @@ async def test_should_accept_the_confirm_prompt(page: Page, server):
 async def test_should_dismiss_the_confirm_prompt(page: Page, server):
     result = []
 
-    def on_dialog(dialog: Dialog):
+    async def on_dialog(dialog: Dialog):
         result.append(True)
-        asyncio.create_task(dialog.dismiss())
+        await dialog.dismiss()
 
     page.on("dialog", on_dialog)
     assert await page.evaluate("confirm('boolean?')") is False


### PR DESCRIPTION
This allows for async callback functions as an argument to `Page.on`. Relevant [pyee documentation](https://pyee.readthedocs.io/en/latest/#pyee.AsyncIOEventEmitter):

>An event emitter class which can run asyncio coroutines in addition to synchronous blocking functions. For example:
> 
>     @ee.on('event')
>     async def async_handler(*args, **kwargs):
>         await returns_a_future()
> 
>On emit, the event emitter will automatically schedule the coroutine using asyncio.ensure_future and the configured event loop (defaults to asyncio.get_event_loop()).
> 
>Unlike the case with the BaseEventEmitter, all exceptions raised by event handlers are automatically emitted on the error event. This is important for asyncio coroutines specifically but is also handled for synchronous functions for consistency.
> 
>When loop is specified, the supplied event loop will be used when scheduling work with ensure_future. Otherwise, the default asyncio event loop is used.
> 
>For asyncio coroutine event handlers, calling emit is non-blocking. In other words, you do not have to await any results from emit, and the coroutine is scheduled in a fire-and-forget fashion.

