### PR TITLE
Add CLI `playwright` as an entry point.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -123,4 +123,9 @@ setuptools.setup(
         "write_to_template": 'version = "{version}"\n',
     },
     setup_requires=["setuptools_scm"],
+    entry_points={
+        "console_scripts": [
+            "playwright=playwright",
+        ],
+    },
 )


### PR DESCRIPTION
After installed with `pip install playwright`, I find there is no CLI. `python3 -m playwright --help` works, but `playwright --help` is better.

My PR add the CLI `playwright` as an setup entry point, which will be created when installing.

Reference: [Command Line Scripts — Python Packaging Tutorial](https://python-packaging.readthedocs.io/en/latest/command-line-scripts.html#the-console-scripts-entry-point)
