### PR TITLE
fix(devops): use correct tag when publishing to dockerhub

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,4 +64,4 @@ jobs:
         ./scripts/tag_image_and_push.sh playwright-python:localbuild playwright.azurecr.io/public/playwright-python:${TAG_NAME}
 
         ./scripts/tag_image_and_push.sh playwright-python:localbuild playwright.azurecr.io/public/playwright-python:focal
-        ./scripts/tag_image_and_push.sh playwright:localbuild-focal playwright.azurecr.io/public/playwright-python:${TAG_NAME}-focal
+        ./scripts/tag_image_and_push.sh playwright-python:localbuild playwright.azurecr.io/public/playwright-python:${TAG_NAME}-focal


### PR DESCRIPTION
Fixes

```
-- tagging: playwright.azurecr.io/public/playwright-python:v0.171.0-focal
Error response from daemon: No such image: playwright:localbuild-focal
```