### PR TITLE
fix(driver): crash with VSCode debug terminal

### DIFF
--- a/playwright/__main__.py
+++ b/playwright/__main__.py
@@ -20,5 +20,7 @@ from playwright._impl._driver import compute_driver_executable
 
 driver_executable = compute_driver_executable()
 my_env = os.environ.copy()
+# VSCode's JavaScript Debug Terminal provides it but driver/pkg does not support it
+my_env.pop("NODE_OPTIONS", None)
 my_env["PW_CLI_TARGET_LANG"] = "python"
 subprocess.run([str(driver_executable), *sys.argv[1:]], env=my_env)

--- a/playwright/_impl/_browser_context.py
+++ b/playwright/_impl/_browser_context.py
@@ -215,7 +215,7 @@ class BrowserContext(ChannelOwner):
             timeout = self._timeout_settings.timeout()
         wait_helper = WaitHelper(self._loop)
         wait_helper.reject_on_timeout(
-            timeout, f'Timeout while waiting for event "${event}"'
+            timeout, f'Timeout while waiting for event "{event}"'
         )
         if event != BrowserContext.Events.Close:
             wait_helper.reject_on_event(

--- a/playwright/_impl/_network.py
+++ b/playwright/_impl/_network.py
@@ -301,7 +301,7 @@ class WebSocket(ChannelOwner):
             timeout = cast(Any, self._parent)._timeout_settings.timeout()
         wait_helper = WaitHelper(self._loop)
         wait_helper.reject_on_timeout(
-            timeout, f'Timeout while waiting for event "${event}"'
+            timeout, f'Timeout while waiting for event "{event}"'
         )
         if event != WebSocket.Events.Close:
             wait_helper.reject_on_event(

--- a/playwright/_impl/_page.py
+++ b/playwright/_impl/_page.py
@@ -537,7 +537,7 @@ class Page(ChannelOwner):
             timeout = self._timeout_settings.timeout()
         wait_helper = WaitHelper(self._loop)
         wait_helper.reject_on_timeout(
-            timeout, f'Timeout while waiting for event "${event}"'
+            timeout, f'Timeout while waiting for event "{event}"'
         )
         if event != Page.Events.Crash:
             wait_helper.reject_on_event(self, Page.Events.Crash, Error("Page crashed"))

--- a/playwright/_impl/_transport.py
+++ b/playwright/_impl/_transport.py
@@ -48,11 +48,15 @@ class Transport:
 
     async def run(self) -> None:
         self._loop = asyncio.get_running_loop()
-        driver_executable = self._driver_executable
+
+        driver_env = os.environ.copy()
+        # VSCode's JavaScript Debug Terminal provides it but driver/pkg does not support it
+        driver_env.pop("NODE_OPTIONS", None)
 
         proc = await asyncio.create_subprocess_exec(
-            str(driver_executable),
+            str(self._driver_executable),
             "run-driver",
+            env=driver_env,
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=_get_stderr_fileno(),

--- a/tests/async/test_har.py
+++ b/tests/async/test_har.py
@@ -57,7 +57,6 @@ async def test_should_include_content(browser, server, tmpdir):
         log = data["log"]
 
         content1 = log["entries"][0]["response"]["content"]
-        print(content1)
         assert content1["encoding"] == "base64"
         assert content1["mimeType"] == "text/html"
         s = base64.b64decode(content1["text"]).decode()

--- a/tests/async/test_headful.py
+++ b/tests/async/test_headful.py
@@ -89,7 +89,7 @@ async def test_should_click_background_tab(browser_type, launch_arguments, serve
     browser = await browser_type.launch(**{**launch_arguments, "headless": False})
     page = await browser.new_page()
     await page.set_content(
-        '<button>Hello</button><a target=_blank href="${server.EMPTY_PAGE}">empty.html</a>'
+        f'<button>Hello</button><a target=_blank href="{server.EMPTY_PAGE}">empty.html</a>'
     )
     await page.click("a")
     await page.click("button")

--- a/tests/async/test_page.py
+++ b/tests/async/test_page.py
@@ -478,7 +478,7 @@ async def test_set_content_should_respect_timeout(page, server):
     server.set_route(img_path, lambda request: None)
     with pytest.raises(Error) as exc_info:
         await page.set_content(
-            '<img src="${server.PREFIX + img_path}"></img>', timeout=1
+            f'<img src="{server.PREFIX + img_path}"></img>', timeout=1
         )
     assert exc_info.type is TimeoutError
 


### PR DESCRIPTION
Should also be applied to Java, C#, and [Go](https://github.com/mxschmitt/playwright-go/pull/71) but for them its probably not that a high chance that a VSCode user will this kind of special terminal (debug terminal). I used it unintentionally a few months ago if you remember, so makes probably sense to fix it in all the language providers.
Unfortunately we can't fix it on the driver side afaik.

Contains also some other smaller drive-by nits.