### PR TITLE
fix: compatibility with pyinstaller

### DIFF
--- a/playwright/_impl/_driver.py
+++ b/playwright/_impl/_driver.py
@@ -22,9 +22,13 @@ from playwright._impl._logger import init_logger
 
 
 def compute_driver_executable() -> Path:
-    package_path = Path(inspect.getfile(playwright)).parent
-    platform = sys.platform
-    if platform == "win32":
+    if getattr(sys, "frozen", False):
+        # pyinstaller
+        package_path = Path(sys._MEIPASS)  # type: ignore
+    else:
+        # normal Python environment
+        package_path = Path(inspect.getfile(playwright)).parent
+    if sys.platform == "win32":
         return package_path / "driver" / "playwright.cmd"
     return package_path / "driver" / "playwright.sh"
 


### PR DESCRIPTION
Fixes #407

See here for reference: https://pyinstaller.readthedocs.io/en/v3.3.1/runtime-information.html

Example with pyinstaller:

```bash
#!/bin/bash

pip install playwright pyinstaller

playwright_driver_dir=$(python -c "import importlib;print(importlib.machinery.PathFinder().find_spec('playwright').submodule_search_locations[0]+'/driver')")
pyinstaller --add-data "$playwright_driver_dir:driver" test.py

# start the bundled output
./dist/test/test

# example screenshot files should be generated.
```

Used file (test.py):

```py
import asyncio
from playwright import async_playwright

async def main():
    async with async_playwright() as p:
        for browser_type in [p.chromium, p.firefox, p.webkit]:
            browser = await browser_type.launch()
            page = await browser.newPage()
            await page.goto('http://whatsmyuseragent.org/')
            await page.screenshot(path=f'example-{browser_type.name}.png')
            await browser.close()

asyncio.get_event_loop().run_until_complete(main())
```
