### PR TITLE
devops: try to publish under playwright namespace in MCR

### DIFF
--- a/.github/workflows/publish_canary_docker.yml
+++ b/.github/workflows/publish_canary_docker.yml
@@ -37,6 +37,6 @@ jobs:
     - run: docker build -t playwright-python:localbuild .
     - name: tag & publish
       run: |
-        ./scripts/tag_image_and_push.sh playwright-python:localbuild playwright.azurecr.io/public/playwright-python:next
-        ./scripts/tag_image_and_push.sh playwright-python:localbuild playwright.azurecr.io/public/playwright-python:next-focal
-        ./scripts/tag_image_and_push.sh playwright-python:localbuild playwright.azurecr.io/public/playwright-python:sha-${{ github.sha }}
+        # ./scripts/tag_image_and_push.sh playwright-python:localbuild playwright.azurecr.io/public/playwright/python:next
+        # ./scripts/tag_image_and_push.sh playwright-python:localbuild playwright.azurecr.io/public/playwright/python:next-focal
+        ./scripts/tag_image_and_push.sh playwright-python:localbuild playwright.azurecr.io/public/playwright/python:sha-${{ github.sha }}


### PR DESCRIPTION
This patch attempts to publish playwright under `playwright/python` mcr
namespace, thus re-using the default `playwrigh` namespace that was
already approved.

Just to be on the safe side, this disables all image publishing except
the one marked with a unique SHA.