### PR TITLE
Revert "devops: try to publish under playwright namespace in MCR (#445)"

### DIFF
--- a/.github/workflows/publish_canary_docker.yml
+++ b/.github/workflows/publish_canary_docker.yml
@@ -37,6 +37,6 @@ jobs:
     - run: docker build -t playwright-python:localbuild .
     - name: tag & publish
       run: |
-        # ./scripts/tag_image_and_push.sh playwright-python:localbuild playwright.azurecr.io/public/playwright/python:next
-        # ./scripts/tag_image_and_push.sh playwright-python:localbuild playwright.azurecr.io/public/playwright/python:next-focal
-        ./scripts/tag_image_and_push.sh playwright-python:localbuild playwright.azurecr.io/public/playwright/python:sha-${{ github.sha }}
+        ./scripts/tag_image_and_push.sh playwright-python:localbuild playwright.azurecr.io/public/playwright-python:next
+        ./scripts/tag_image_and_push.sh playwright-python:localbuild playwright.azurecr.io/public/playwright-python:next-focal
+        ./scripts/tag_image_and_push.sh playwright-python:localbuild playwright.azurecr.io/public/playwright-python:sha-${{ github.sha }}


### PR DESCRIPTION
This reverts commit 1f2fcd9353a4f0db0f27b4499d764c932e3ddf49. The old
approach was actually correct.