### PR TITLE
test: fix flaky tests by rerunning

### DIFF
--- a/local-requirements.txt
+++ b/local-requirements.txt
@@ -3,9 +3,9 @@ pytest==6.1.0
 pytest-asyncio==0.14.0
 pytest-cov==2.10.1
 pytest-sugar==0.9.4
+pytest-rerunfailures==9.1.1
 pytest-xdist==2.1.0
 pytest-timeout==1.4.2
-flaky==3.7.0
 pixelmatch==0.2.1
 Pillow==8.0.0
 mypy==0.782

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
 [tool:pytest]
+addopts = --reruns 5 --reruns-delay 1 -n auto
 markers =
     skip_browser
     only_browser

--- a/tests/async/test_defaultbrowsercontext.py
+++ b/tests/async/test_defaultbrowsercontext.py
@@ -16,7 +16,6 @@ import asyncio
 import os
 
 import pytest
-from flaky import flaky
 
 from playwright._impl._api_types import Error
 
@@ -280,7 +279,6 @@ async def test_should_accept_user_data_dir(server, tmpdir, launch_persistent):
     assert len(os.listdir(tmpdir)) > 0
 
 
-@flaky
 async def test_should_restore_state_from_userDataDir(
     browser_type, launch_arguments, server, tmp_path_factory
 ):

--- a/tests/async/test_headful.py
+++ b/tests/async/test_headful.py
@@ -14,7 +14,6 @@
 
 
 import pytest
-from flaky import flaky
 
 
 async def test_should_have_default_url_when_launching_browser(
@@ -177,7 +176,6 @@ async def test_should_not_override_viewport_size_when_passed_null(
     await browser.close()
 
 
-@flaky
 async def test_page_bring_to_front_should_work(browser_type, launch_arguments):
     browser = await browser_type.launch(**{**launch_arguments, "headless": False})
     page1 = await browser.new_page()


### PR DESCRIPTION
Reruns flaky tests five times in total at maximum, speed up tests using `pytest-xdist` , it was already in requirements but was not used.