### PR TITLE
fix: disposing generated references correctly

### DIFF
--- a/playwright/_impl/_impl_to_api_mapping.py
+++ b/playwright/_impl/_impl_to_api_mapping.py
@@ -14,14 +14,14 @@
 
 import inspect
 from typing import Any, Callable, Dict, List, Optional
-from weakref import WeakKeyDictionary
+from weakref import WeakKeyDictionary, proxy
 
 from playwright._impl._api_types import Error
 
 
 class ImplWrapper:
     def __init__(self, impl_obj: Any) -> None:
-        self._impl_obj = impl_obj
+        self._impl_obj = proxy(impl_obj)
 
 
 class ImplToApiMapping:


### PR DESCRIPTION
Case 1 (fix is the first commit):

Clear regular generated objects and de-reference their wrappers so that the GC collects them.

```py
import asyncio
from playwright.async_api import async_playwright

async def main():
    async with async_playwright() as p:
        browser = await p.chromium._impl_obj.launch()
        page = await browser.new_page()
        page.on("dialog", lambda dialog: dialog.dismiss())
        for i in range(5000):
            await page.evaluate(
                """async () => alert()"""
            )
        await browser.close()
    print_memory_objects()


asyncio.run(main())
```

Case 2 (fix todo):

Route handling.

```py
from playwright.sync_api import sync_playwright

with sync_playwright() as p:
    browser = p.chromium.launch()
    page = browser.new_page()
    page.goto("http://example.com")
    page.route("**/foo", lambda route: route.fulfill(body="OK"))

    for i in range(5000):
        result = page.evaluate("""async () => (await fetch("/foo")).text()""")
        assert result == "OK"
    browser.close()
print_memory_objects()
```

Helper function:

```py
import pandas as pd
from guppy import hpy
from pympler import muppy, summary

def print_memory_objects():
    heap = hpy()
    heap.heap()

    all_objects = muppy.get_objects()
    sum1 = summary.summarize(all_objects)
    # Prints out a summary of the large objects
    summary.print_(sum1)
    # Get references to certain types of objects such as dataframe
    dataframes = [ao for ao in all_objects if isinstance(ao, pd.DataFrame)]
    for d in dataframes:
        print(d.columns.values)
        print(len(d))

    df_dicts = pd.DataFrame()
    df_dicts['dicts'] = objgraph.by_type('dict')
    df_dicts['pw_types'] = df_dicts['dicts'].apply(lambda x: x.get('_type'))
    out = df_dicts['pw_types'].value_counts().head(20)
    print(out)
```