### PR TITLE
fix: handle cancelled tasks

### DIFF
--- a/playwright/_impl/_connection.py
+++ b/playwright/_impl/_connection.py
@@ -220,6 +220,8 @@ class Connection:
         id = msg.get("id")
         if id:
             callback = self._callbacks.pop(id)
+            if callback.future.cancelled():
+                return
             error = msg.get("error")
             if error:
                 parsed_error = parse_error(error["error"])  # type: ignore


### PR DESCRIPTION
prevents `InvalidStateError` when the task has been cancelled, here:

```python
callback.future.set_exception(parsed_error)
```