### PR TITLE
fix: Installation from source using GitHub

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r local-requirements.txt
         pip install -e .
-        python setup.py bdist_wheel
+        python setup.py bdist_wheel --all
         python -m playwright install-deps
     - name: Publish package
       env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
       - id: end-of-file-fixer
         exclude: ^playwright/drivers/browsers.json$
       - id: check-yaml
+      - id: check-toml
       - id: requirements-txt-fixer
   - repo: https://github.com/psf/black
     rev: 20.8b1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,8 @@ Build and install drivers:
 ```sh
 pip install -e.
 python setup.py bdist_wheel
+# For all platforms
+python setup.py bdist_wheel --all
 ```
 
 Run tests:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools-scm", "wheel", "auditwheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Before when building from source using Github ex: 
```console
pip install git+https://github.com/microsoft/playwright-python
```
It failed because multiple wheels were created, hence it failed.

## Fix

Now there is a special `--all`  flag without which only the wheel for that specific platform would be created hence pip would now work just fine.
Now for uploading to PyPI, `--all` flag would be used to create all the wheels and hence pip install works as expected by the end user. The necessary GitHub actions files are updated for the same for releasing and uploading to PyPI. When user install from GitHub only the driver for that platform is downloaded and hence saves network bandwidth.
Maintainers can try out the new build process with:

```console
pip install git+https://github.com/kumaraditya303/playwright-python@patch-6
```
Output:
```console
Defaulting to user installation because normal site-packages is not writeable
Collecting git+https://github.com/kumaraditya303/playwright-python@patch-6
  Cloning https://github.com/kumaraditya303/playwright-python (to revision patch-6) to /tmp/pip-req-build-eabcvu4_
Requirement already satisfied: greenlet==1.0.0 in /home/codespace/.local/lib/python3.8/site-packages/greenlet-1.0.0-py3.8-linux-x86_64.egg (from playwright==0.152.0.post93+g375ab94) (1.0.0)
Requirement already satisfied: pyee>=8.0.1 in /home/codespace/.local/lib/python3.8/site-packages/pyee-8.1.0-py3.8.egg (from playwright==0.152.0.post93+g375ab94) (8.1.0)
Requirement already satisfied: typing-extensions in /home/codespace/.local/lib/python3.8/site-packages/typing_extensions-3.7.4.3-py3.8.egg (from playwright==0.152.0.post93+g375ab94) (3.7.4.3)
Building wheels for collected packages: playwright
  Building wheel for playwright (setup.py): started
  Building wheel for playwright (setup.py): finished with status 'done'
  Created wheel for playwright: filename=playwright-0.152.0.post93+g375ab94-py3-none-manylinux1_x86_64.whl size=58565510 sha256=173a6fa5afe4a185c8a4ba12dc5cee628f6b7d18ade08535a7124c9f3da9c3df
  Stored in directory: /tmp/pip-ephem-wheel-cache-edhss70u/wheels/12/10/0c/0184077f598942b32369ac04ca050099b4aa871070692a7773
Successfully built playwright
Installing collected packages: playwright
  Attempting uninstall: playwright
    Found existing installation: playwright 0.152.0.post93+g375ab94
    Uninstalling playwright-0.152.0.post93+g375ab94:
      Successfully uninstalled playwright-0.152.0.post93+g375ab94
Successfully installed playwright-0.152.0.post93+g375ab94

```