### PR TITLE
wait for the process

### DIFF
--- a/playwright/_impl/_transport.py
+++ b/playwright/_impl/_transport.py
@@ -48,12 +48,13 @@ class Transport:
 
     async def wait_until_stopped(self) -> None:
         await self._stopped_future
+        await self._proc.wait()
 
     async def run(self) -> None:
         self._loop = asyncio.get_running_loop()
         self._stopped_future: asyncio.Future = asyncio.Future()
 
-        proc = await asyncio.create_subprocess_exec(
+        self._proc = proc = await asyncio.create_subprocess_exec(
             str(self._driver_executable),
             "run-driver",
             stdin=asyncio.subprocess.PIPE,


### PR DESCRIPTION
fixes #571

when using the `async_playwright()` context manager early in an `asyncio.run` program, the `proc` can be garbage collected after the loop is closed. When `proc` is garbage collected the underlying transport is then garbage collected, which tries to kill the running process but cannot without a running loop