### PR TITLE
fix: env param in BrowserType.launch doesn't serialize properly to Nodejs

### DIFF
--- a/playwright/_impl/_browser_type.py
+++ b/playwright/_impl/_browser_type.py
@@ -138,7 +138,7 @@ class BrowserType(ChannelOwner):
 
 def normalize_launch_params(params: Dict) -> None:
     if "env" in params:
-        params["env"] = {name: str(value) for [name, value] in params["env"].items()}
+        params["env"] = [{"name": name, "value":str(value)} for [name, value] in params["env"].items()]
     if "ignoreDefaultArgs" in params:
         if params["ignoreDefaultArgs"] is True:
             params["ignoreAllDefaultArgs"] = True

--- a/playwright/_impl/_browser_type.py
+++ b/playwright/_impl/_browser_type.py
@@ -138,7 +138,10 @@ class BrowserType(ChannelOwner):
 
 def normalize_launch_params(params: Dict) -> None:
     if "env" in params:
-        params["env"] = [{"name": name, "value":str(value)} for [name, value] in params["env"].items()]
+        params["env"] = [
+            {"name": name, "value": str(value)}
+            for [name, value] in params["env"].items()
+        ]
     if "ignoreDefaultArgs" in params:
         if params["ignoreDefaultArgs"] is True:
             params["ignoreAllDefaultArgs"] = True


### PR DESCRIPTION
[The Nodejs code expects the env param to be of type EnvArr](https://github.com/microsoft/playwright/blob/da1dafcadb05fd648f13610d8eefc4baa5c2261e/src/server/browserType.ts#L139), which is defined as [EnvArray = { name: string, value: string }[];](https://github.com/microsoft/playwright/blob/da1dafcadb05fd648f13610d8eefc4baa5c2261e/src/server/types.ts#L253)
This updates the playwright-python code to format the env dict to the same format to fix the error:
`playwright._impl._api_types.Error: env: expected array, got object`

Example to reproduce error:
```
from playwright.sync_api import sync_playwright

with sync_playwright() as p:
    env = {"SSLKEYLOGFILE": "~/test"}
    browser = p.chromium.launch(env=env)
    page = browser.new_page()
    page.goto("http://playwright.dev")
    print(page.title())
    browser.close()
```