### PR TITLE
docs: add the -U flag for pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Headless execution is supported for all browsers on all platforms.
 ## Usage
 
 ```sh
-pip install playwright
+pip install -U playwright
 playwright install
 ```
 


### PR DESCRIPTION
PIP by default does not download the latest version when there is already a version present on the system. If you want to have "a correct" behaviour, then you need to add the `-U` flag (U means update). Other big Python projects like Celery do that too.

ref: https://playwright.slack.com/archives/C0182HLNSJV/p1617547493062200?thread_ts=1617545917.060000&cid=C0182HLNSJV