### PR TITLE
test: re-renable CORS tests

### DIFF
--- a/playwright/_impl/_page.py
+++ b/playwright/_impl/_page.py
@@ -779,8 +779,6 @@ class Page(ChannelOwner):
     def video(
         self,
     ) -> Optional[Video]:
-        if "recordVideo" not in self._browser_context._options:
-            return None
         if not self._video:
             self._video = Video(self)
         return self._video

--- a/tests/async/test_interception.py
+++ b/tests/async/test_interception.py
@@ -580,8 +580,6 @@ async def test_page_route_should_support_cors_with_GET(page, server):
     assert "failed" in exc.value.message
 
 
-# RELEASE BLOCKER: Temporary upstream issue https://github.com/microsoft/playwright-python/issues/608
-@pytest.mark.skip_browser("chromium")
 async def test_page_route_should_support_cors_with_POST(page, server):
     await page.goto(server.EMPTY_PAGE)
     await page.route(
@@ -609,8 +607,6 @@ async def test_page_route_should_support_cors_with_POST(page, server):
     assert resp == ["electric", "gas"]
 
 
-# RELEASE BLOCKER: Temporary upstream issue https://github.com/microsoft/playwright-python/issues/608
-@pytest.mark.skip_browser("chromium")
 async def test_page_route_should_support_cors_for_different_methods(page, server):
     await page.goto(server.EMPTY_PAGE)
     await page.route(

--- a/tests/async/test_video.py
+++ b/tests/async/test_video.py
@@ -36,8 +36,6 @@ async def test_short_video_should_throw(browser, tmpdir, server):
     assert os.path.exists(path)
 
 
-# RELEASE BLOCKER: Temporary upstream issue https://github.com/microsoft/playwright-python/issues/608
-@pytest.mark.skip()
 async def test_short_video_should_throw_persistent_context(
     browser_type, tmpdir, launch_arguments
 ):

--- a/tests/async/test_video.py
+++ b/tests/async/test_video.py
@@ -14,10 +14,6 @@
 
 import os
 
-import pytest
-
-from playwright.async_api import Error
-
 
 async def test_should_expose_video_path(browser, tmpdir, server):
     page = await browser.new_page(record_video_dir=tmpdir)
@@ -37,7 +33,7 @@ async def test_short_video_should_throw(browser, tmpdir, server):
 
 
 async def test_short_video_should_throw_persistent_context(
-    browser_type, tmpdir, launch_arguments
+    browser_type, tmpdir, launch_arguments, server
 ):
     context = await browser_type.launch_persistent_context(
         str(tmpdir),
@@ -46,7 +42,8 @@ async def test_short_video_should_throw_persistent_context(
         record_video_dir=str(tmpdir) + "1",
     )
     page = context.pages[0]
+    await page.goto(server.PREFIX + "/grid.html")
     await context.close()
-    with pytest.raises(Error) as exc_info:
-        await page.video.path()
-    assert "Page closed" in exc_info.value.message
+
+    path = await page.video.path()
+    assert str(tmpdir) in str(path)

--- a/tests/sync/test_video.py
+++ b/tests/sync/test_video.py
@@ -14,8 +14,6 @@
 
 import os
 
-import pytest
-
 
 def test_should_expose_video_path(browser, tmpdir, server):
     page = browser.new_page(
@@ -46,8 +44,6 @@ def test_record_video_to_path(browser, tmpdir, server):
     assert os.path.exists(path)
 
 
-# RELEASE BLOCKER: Temporary upstream issue https://github.com/microsoft/playwright-python/issues/608
-@pytest.mark.skip()
 def test_record_video_to_path_persistent(
     browser_type, tmpdir, server, launch_arguments
 ):

--- a/tests/sync/test_video.py
+++ b/tests/sync/test_video.py
@@ -56,3 +56,16 @@ def test_record_video_to_path_persistent(
     assert str(tmpdir) in str(path)
     context.close()
     assert os.path.exists(path)
+
+
+def test_record_video_can_get_video_path_immediately(
+    browser_type, tmpdir, launch_arguments
+):
+    context = browser_type.launch_persistent_context(
+        tmpdir, **launch_arguments, record_video_dir=tmpdir
+    )
+    page = context.pages[0]
+    path = page.video.path()
+    assert str(tmpdir) in str(path)
+    context.close()
+    assert os.path.exists(path)


### PR DESCRIPTION
After enabling the video test again WK+FF failed. The reason for that was a race between `context.on("page")` which comes after `page.on("video")` in WK and FF. This resulted in that the options were not yet there since the `page`->`browserContext` association was not yet there.

Seems like the condition which was removed was a leftover from the old video channels. In upstream PW we don't have such a logic, so lets keep it in sync.

Fixes #608