### PR TITLE
fix: restrict installation to Ubuntu 18.04

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ class PlaywrightBDistWheelCommand(BDistWheelCommand):
             if platform == "mac":
                 wheel = "macosx_10_13_x86_64.whl"
             if platform == "linux":
-                wheel = "manylinux1_x86_64.whl"
+                wheel = "manylinux_2_27_x86_64.whl"
             if platform == "win32":
                 wheel = "win32.whl"
             if platform == "win32_x64":

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -28,9 +28,10 @@ def test_install(tmp_path: Path):
     if sys.platform == "win32":
         wheelpath = list((root / "dist").glob("playwright*win_amd64*.whl"))[0]
     elif sys.platform == "linux":
-        wheelpath = list((root / "dist").glob("playwright*manylinux1*.whl"))[0]
+        wheelpath = list((root / "dist").glob("playwright*manylinux_2_27_*.whl"))[0]
     elif sys.platform == "darwin":
         wheelpath = list((root / "dist").glob("playwright*macosx_10_*.whl"))[0]
+    subprocess.check_output([context.env_exe, "-m", "pip", "install", "pip", "-U"])
     subprocess.check_output(
         [
             context.env_exe,


### PR DESCRIPTION
With [PEP 600](https://github.com/mayeut/pep600_compliance/blob/master/DETAILS.rst) this PR restricts installation to Ubuntu 18.04 or higher. 