### PR TITLE
fix: exception when page got closed via browser in persistent context

### DIFF
--- a/playwright/_impl/_browser_context.py
+++ b/playwright/_impl/_browser_context.py
@@ -94,7 +94,6 @@ class BrowserContext(ChannelOwner):
         return f"<BrowserContext browser={self.browser}>"
 
     def _on_page(self, page: Page) -> None:
-        page._set_browser_context(self)
         self._pages.append(page)
         self.emit(BrowserContext.Events.Page, page)
         if page._opener and not page._opener.is_closed():


### PR DESCRIPTION
Fixes #681

not sure about a test for it.

A Set in JavaScript simply does not throw when there is no element which gets removed.

it throws here: https://github.com/microsoft/playwright-python/blob/9d796623a104e082f57878d29d9aea20009b88c1/playwright/_impl/_page.py#L274