### PR TITLE
chore: simplified transport stopping

### DIFF
--- a/playwright/_impl/_browser_context.py
+++ b/playwright/_impl/_browser_context.py
@@ -128,8 +128,8 @@ class BrowserContext(ChannelOwner):
                 from_nullable_channel(params.get("page")),
             ),
         )
-        self._closed_future: asyncio.Future = asyncio.Future()
-        self.once(self.Events.Close, lambda: self._closed_future.set_result(True))
+        self._closed = asyncio.Event()
+        self.once(self.Events.Close, lambda: self._closed.set())
 
     def __repr__(self) -> str:
         return f"<BrowserContext browser={self.browser}>"
@@ -287,7 +287,7 @@ class BrowserContext(ChannelOwner):
     async def close(self) -> None:
         try:
             await self._channel.send("close")
-            await self._closed_future
+            await self._closed.wait()
         except Exception as e:
             if not is_safe_close_error(e):
                 raise e

--- a/playwright/sync_api/_context_manager.py
+++ b/playwright/sync_api/_context_manager.py
@@ -37,6 +37,7 @@ class PlaywrightContextManager:
             loop = asyncio.get_running_loop()
         except RuntimeError:
             loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
             own_loop = loop
         if loop.is_running():
             raise Error(


### PR DESCRIPTION
Uses [`asyncio.Event`](https://docs.python.org/3/library/asyncio-sync.html#asyncio.Event) synchronization primitive to simplify the code.