### PR TITLE
chore: Kill windows subprocess using kill

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -238,14 +238,7 @@ class RemoteServer:
         # Send the signal to all the process groups
         if self.process.poll() is not None:
             return
-        if sys.platform == "win32":
-            subprocess.check_call(
-                ["taskkill", "/F", "/PID", str(self.process.pid)],
-                stderr=subprocess.DEVNULL,
-                stdout=subprocess.DEVNULL,
-            )
-        else:
-            self.process.kill()
+        self.process.kill()
         self.process.wait()
 
 


### PR DESCRIPTION
There is no special handling required for windows so the code was redundant and hence removed.