### PR TITLE
Fix unwanted console window with pythonw on windows platform

### DIFF
--- a/playwright/_impl/_transport.py
+++ b/playwright/_impl/_transport.py
@@ -16,6 +16,7 @@ import asyncio
 import io
 import json
 import os
+import subprocess
 import sys
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -97,6 +98,11 @@ class PipeTransport(Transport):
 
     async def run(self) -> None:
         self._stopped_future: asyncio.Future = asyncio.Future()
+        platform = sys.platform
+        if platform == "win32" and sys.stdout is None:
+            creationflags = subprocess.CREATE_NO_WINDOW
+        else:
+            creationflags = 0
 
         try:
             self._proc = proc = await asyncio.create_subprocess_exec(
@@ -106,6 +112,7 @@ class PipeTransport(Transport):
                 stdout=asyncio.subprocess.PIPE,
                 stderr=_get_stderr_fileno(),
                 limit=32768,
+                creationflags=creationflags,
             )
         except Exception as exc:
             self.on_error_future.set_exception(exc)

--- a/playwright/_impl/_transport.py
+++ b/playwright/_impl/_transport.py
@@ -98,6 +98,7 @@ class PipeTransport(Transport):
 
     async def run(self) -> None:
         self._stopped_future: asyncio.Future = asyncio.Future()
+        # Hide the command-line popup on Windows when using Pythonw.exe
         creationflags = 0
         if sys.platform == "win32" and sys.stdout is None:
             creationflags = subprocess.CREATE_NO_WINDOW

--- a/playwright/_impl/_transport.py
+++ b/playwright/_impl/_transport.py
@@ -98,7 +98,7 @@ class PipeTransport(Transport):
 
     async def run(self) -> None:
         self._stopped_future: asyncio.Future = asyncio.Future()
-        # Hide the command-line popup on Windows when using Pythonw.exe
+        # Hide the command-line window on Windows when using Pythonw.exe
         creationflags = 0
         if sys.platform == "win32" and sys.stdout is None:
             creationflags = subprocess.CREATE_NO_WINDOW

--- a/playwright/_impl/_transport.py
+++ b/playwright/_impl/_transport.py
@@ -98,11 +98,9 @@ class PipeTransport(Transport):
 
     async def run(self) -> None:
         self._stopped_future: asyncio.Future = asyncio.Future()
-        platform = sys.platform
-        if platform == "win32" and sys.stdout is None:
+        creationflags = 0
+        if sys.platform == "win32" and sys.stdout is None:
             creationflags = subprocess.CREATE_NO_WINDOW
-        else:
-            creationflags = 0
 
         try:
             self._proc = proc = await asyncio.create_subprocess_exec(


### PR DESCRIPTION
I use playwright python in silent mode, my app runs in a background with no windows.
The Windows platform has a special way to run such applications - pythonw.exe
When I start the browser from my code, an unwanted black console window appears on the screen.
How to reproduce the problem:
Let's take simple script like this:
```python
from playwright.sync_api import sync_playwright
with sync_playwright() as p:
    browser = p.chromium.launch()
    page = browser.new_page()
    page.goto("http://playwright.dev")
    page.screenshot(path="example.png")
    print(page.title())
    browser.close()
```
If we run this script like this:
`python.exe sample.py`
Everything will work fine and no windows will appear
If we run it like this
`pythonw.exe sample.py`
We will see a black console window associated with the call to playwright.cmd in the playwright-python library code.
At start pythonw.exe the console is not created, and sys.stdout is set to None.
Therefore, the playwright.cmd subprocess cannot join to the current sys.stdout (because it is None) and creates a new one
