### PR TITLE
chore: added context managers

### DIFF
--- a/playwright/_impl/_browser.py
+++ b/playwright/_impl/_browser.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import base64
 import json
 from pathlib import Path

--- a/playwright/_impl/_browser.py
+++ b/playwright/_impl/_browser.py
@@ -11,12 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import base64
 import json
 from pathlib import Path
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Dict, List, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Type, Union
 
 from playwright._impl._api_structures import (
     Geolocation,
@@ -188,6 +187,17 @@ class Browser(ChannelOwner):
     async def stop_tracing(self) -> bytes:
         encoded_binary = await self._channel.send("stopTracing")
         return base64.b64decode(encoded_binary)
+
+    async def __aenter__(self) -> "Browser":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Type[BaseException],
+        exc_val: BaseException,
+        traceback: Any,
+    ) -> None:
+        await self.close()
 
 
 def normalize_context_params(is_sync: bool, params: Dict) -> None:

--- a/playwright/_impl/_browser_context.py
+++ b/playwright/_impl/_browser_context.py
@@ -15,9 +15,21 @@
 import asyncio
 import inspect
 import json
+import typing
 from pathlib import Path
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Type,
+    Union,
+    cast,
+)
 
 from playwright._impl._api_structures import Cookie, Geolocation, StorageState
 from playwright._impl._api_types import Error
@@ -374,3 +386,14 @@ class BrowserContext(ChannelOwner):
     @property
     def tracing(self) -> Tracing:
         return self._tracing
+
+    async def __aenter__(self) -> "BrowserContext":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Type[BaseException],
+        exc_val: BaseException,
+        traceback: typing.Any,
+    ) -> None:
+        await self.close()

--- a/playwright/_impl/_page.py
+++ b/playwright/_impl/_page.py
@@ -18,7 +18,7 @@ import inspect
 import sys
 from pathlib import Path
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type, Union, cast
 
 from playwright._impl._accessibility import Accessibility
 from playwright._impl._api_structures import (
@@ -868,6 +868,17 @@ class Page(ChannelOwner):
         timeout: float = None,
     ) -> EventContextManagerImpl["Worker"]:
         return self.expect_event("worker", predicate, timeout)
+
+    async def __aenter__(self) -> "Page":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Type[BaseException],
+        exc_val: BaseException,
+        traceback: Any,
+    ) -> None:
+        await self.close()
 
 
 class Worker(ChannelOwner):

--- a/playwright/async_api/_generated.py
+++ b/playwright/async_api/_generated.py
@@ -5029,6 +5029,28 @@ class Page(AsyncBase):
         """
         return mapping.from_impl_nullable(self._impl_obj.video)
 
+    async def __aenter__(self) -> "Page":
+        return mapping.from_impl(
+            await self._async("page.__aenter__", self._impl_obj.__aenter__())
+        )
+
+    async def __aexit__(
+        self,
+        exc_type: typing.Type[BaseException],
+        exc_val: BaseException,
+        traceback: typing.Any,
+    ) -> NoneType:
+        return mapping.from_maybe_impl(
+            await self._async(
+                "page.__aexit__",
+                self._impl_obj.__aexit__(
+                    exc_type=exc_type,
+                    exc_val=exc_val,
+                    traceback=mapping.to_impl(traceback),
+                ),
+            )
+        )
+
     async def opener(self) -> typing.Optional["Page"]:
         """Page.opener
 
@@ -8167,6 +8189,28 @@ class BrowserContext(AsyncBase):
         """
         return mapping.from_impl(self._impl_obj.tracing)
 
+    async def __aenter__(self) -> "BrowserContext":
+        return mapping.from_impl(
+            await self._async("browser_context.__aenter__", self._impl_obj.__aenter__())
+        )
+
+    async def __aexit__(
+        self,
+        exc_type: typing.Type[BaseException],
+        exc_val: BaseException,
+        traceback: typing.Any,
+    ) -> NoneType:
+        return mapping.from_maybe_impl(
+            await self._async(
+                "browser_context.__aexit__",
+                self._impl_obj.__aexit__(
+                    exc_type=exc_type,
+                    exc_val=exc_val,
+                    traceback=mapping.to_impl(traceback),
+                ),
+            )
+        )
+
     def set_default_navigation_timeout(self, timeout: float) -> NoneType:
         """BrowserContext.set_default_navigation_timeout
 
@@ -8926,6 +8970,28 @@ class Browser(AsyncBase):
         str
         """
         return mapping.from_maybe_impl(self._impl_obj.version)
+
+    async def __aenter__(self) -> "Browser":
+        return mapping.from_impl(
+            await self._async("browser.__aenter__", self._impl_obj.__aenter__())
+        )
+
+    async def __aexit__(
+        self,
+        exc_type: typing.Type[BaseException],
+        exc_val: BaseException,
+        traceback: typing.Any,
+    ) -> NoneType:
+        return mapping.from_maybe_impl(
+            await self._async(
+                "browser.__aexit__",
+                self._impl_obj.__aexit__(
+                    exc_type=exc_type,
+                    exc_val=exc_val,
+                    traceback=mapping.to_impl(traceback),
+                ),
+            )
+        )
 
     def is_connected(self) -> bool:
         """Browser.is_connected

--- a/playwright/sync_api/_generated.py
+++ b/playwright/sync_api/_generated.py
@@ -5002,6 +5002,28 @@ class Page(SyncBase):
         """
         return mapping.from_impl_nullable(self._impl_obj.video)
 
+    def __enter__(self) -> "Page":
+        return mapping.from_impl(
+            self._sync("page.__enter__", self._impl_obj.__aenter__())
+        )
+
+    def __exit__(
+        self,
+        exc_type: typing.Type[BaseException],
+        exc_val: BaseException,
+        traceback: typing.Any,
+    ) -> NoneType:
+        return mapping.from_maybe_impl(
+            self._sync(
+                "page.__exit__",
+                self._impl_obj.__aexit__(
+                    exc_type=exc_type,
+                    exc_val=exc_val,
+                    traceback=mapping.to_impl(traceback),
+                ),
+            )
+        )
+
     def opener(self) -> typing.Optional["Page"]:
         """Page.opener
 
@@ -8121,6 +8143,28 @@ class BrowserContext(SyncBase):
         """
         return mapping.from_impl(self._impl_obj.tracing)
 
+    def __enter__(self) -> "BrowserContext":
+        return mapping.from_impl(
+            self._sync("browser_context.__enter__", self._impl_obj.__aenter__())
+        )
+
+    def __exit__(
+        self,
+        exc_type: typing.Type[BaseException],
+        exc_val: BaseException,
+        traceback: typing.Any,
+    ) -> NoneType:
+        return mapping.from_maybe_impl(
+            self._sync(
+                "browser_context.__exit__",
+                self._impl_obj.__aexit__(
+                    exc_type=exc_type,
+                    exc_val=exc_val,
+                    traceback=mapping.to_impl(traceback),
+                ),
+            )
+        )
+
     def set_default_navigation_timeout(self, timeout: float) -> NoneType:
         """BrowserContext.set_default_navigation_timeout
 
@@ -8871,6 +8915,28 @@ class Browser(SyncBase):
         str
         """
         return mapping.from_maybe_impl(self._impl_obj.version)
+
+    def __enter__(self) -> "Browser":
+        return mapping.from_impl(
+            self._sync("browser.__enter__", self._impl_obj.__aenter__())
+        )
+
+    def __exit__(
+        self,
+        exc_type: typing.Type[BaseException],
+        exc_val: BaseException,
+        traceback: typing.Any,
+    ) -> NoneType:
+        return mapping.from_maybe_impl(
+            self._sync(
+                "browser.__exit__",
+                self._impl_obj.__aexit__(
+                    exc_type=exc_type,
+                    exc_val=exc_val,
+                    traceback=mapping.to_impl(traceback),
+                ),
+            )
+        )
 
     def is_connected(self) -> bool:
         """Browser.is_connected

--- a/scripts/generate_async_api.py
+++ b/scripts/generate_async_api.py
@@ -58,7 +58,21 @@ def generate(t: Any) -> None:
         print(f"{prefix}{suffix}")
     for [name, value] in t.__dict__.items():
         if name.startswith("_"):
-            continue
+            if name in ["__aenter__", "__aexit__"]:
+                print(
+                    f"    async def {name}({signature(value, len(name) + 9)}) -> {return_type(value)}:"
+                )
+                [prefix, suffix] = return_value(
+                    get_type_hints(value, api_globals)["return"]
+                )
+                prefix = (
+                    "        return "
+                    + prefix
+                    + f"await self._async('{to_snake_case(class_name)}.{name}', self._impl_obj.{name}"
+                )
+                print(f"{prefix}({arguments(value, len(prefix))}{suffix}))")
+            else:
+                continue
         if not name.startswith("_") and str(value).startswith("<property"):
             value = value.fget
             print("")

--- a/scripts/generate_sync_api.py
+++ b/scripts/generate_sync_api.py
@@ -59,7 +59,22 @@ def generate(t: Any) -> None:
         print(f"{prefix}{suffix}")
     for [name, value] in t.__dict__.items():
         if name.startswith("_"):
-            continue
+            if name in ["__aenter__", "__aexit__"]:
+                sync_name = name.replace("a", "")
+                print(
+                    f"    def {sync_name}({signature(value, len(name) + 9)}) -> {return_type(value)}:"
+                )
+                [prefix, suffix] = return_value(
+                    get_type_hints(value, api_globals)["return"]
+                )
+                prefix = (
+                    "        return "
+                    + prefix
+                    + f'self._sync("{to_snake_case(class_name)}.{sync_name}", self._impl_obj.{name}'
+                )
+                print(f"{prefix}({arguments(value, len(prefix))}{suffix}))")
+            else:
+                continue
         if not name.startswith("_") and str(value).startswith("<property"):
             value = value.fget
             print("")

--- a/tests/async/test_context_manager.py
+++ b/tests/async/test_context_manager.py
@@ -1,0 +1,29 @@
+# Copyright (c) Microsoft Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from playwright.async_api import BrowserType
+
+
+async def test_context_managers(browser_type: BrowserType, launch_arguments):
+    browser = await browser_type.launch(**launch_arguments)
+    async with browser:
+        context = await browser.new_context()
+        async with context:
+            page = await context.new_page()
+            async with page:
+                assert len(context.pages) == 1
+            assert len(context.pages) == 0
+            assert len(browser.contexts) == 1
+        assert len(browser.contexts) == 0
+    assert not browser.is_connected()

--- a/tests/sync/test_context_manager.py
+++ b/tests/sync/test_context_manager.py
@@ -1,0 +1,26 @@
+# Copyright (c) Microsoft Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from playwright.sync_api import BrowserType
+
+
+def test_context_managers(browser_type: BrowserType, launch_arguments):
+    with browser_type.launch(**launch_arguments) as browser:
+        with browser.new_context() as context:
+            with context.new_page():
+                assert len(context.pages) == 1
+            assert len(context.pages) == 0
+            assert len(browser.contexts) == 1
+        assert len(browser.contexts) == 0
+    assert not browser.is_connected()


### PR DESCRIPTION
Fixes #730
Added context manager for the following:
- Browser
- BrowserContext
- Page


Test the sync code with 
```python
from playwright.sync_api import sync_playwright

with sync_playwright() as p:
    for browser_type in [p.chromium, p.firefox, p.webkit]:
        with browser_type.launch() as browser:
            with browser.new_context() as context:
                with context.new_page() as page:
                    page.goto("http://whatsmyuseragent.org/")
                    page.screenshot(path=f"example-{browser_type.name}.png")
```

Test Async code with 

```python
import asyncio

from playwright.async_api import async_playwright


async def main():
    async with async_playwright() as p:
        for browser_type in [p.chromium, p.firefox, p.webkit]:
            browser = await browser_type.launch()
            async with browser:
                context = await browser.new_context()
                async with context:
                    page = await context.new_page()
                    async with page:
                        await page.goto("http://whatsmyuseragent.org/")
                        await page.screenshot(path=f"example-{browser_type.name}.png")


asyncio.run(main())

```

