### PR TITLE
fix(cli): forward CLI exit code over to the parent

### DIFF
--- a/playwright/__main__.py
+++ b/playwright/__main__.py
@@ -23,7 +23,8 @@ def main() -> None:
     driver_executable = compute_driver_executable()
     env = os.environ.copy()
     env["PW_CLI_TARGET_LANG"] = "python"
-    subprocess.run([str(driver_executable), *sys.argv[1:]], env=env)
+    completed_process = subprocess.run([str(driver_executable), *sys.argv[1:]], env=env)
+    sys.exit(completed_process.returncode)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Bug: When the installation was failing due e.g. a TCP timeout it still reported exit code 0. With this change it now forwards all CLI exit codes to the parent.