### PR TITLE
feat: added hooks for pyinstaller

### DIFF
--- a/playwright/_impl/__pyinstaller/__init__.py
+++ b/playwright/_impl/__pyinstaller/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) Microsoft Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from typing import List
+
+
+def get_hook_dirs() -> List[str]:
+    return [os.path.dirname(__file__)]

--- a/playwright/_impl/__pyinstaller/hook-playwright.async_api.py
+++ b/playwright/_impl/__pyinstaller/hook-playwright.async_api.py
@@ -1,0 +1,17 @@
+# Copyright (c) Microsoft Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files("playwright")

--- a/playwright/_impl/__pyinstaller/hook-playwright.sync_api.py
+++ b/playwright/_impl/__pyinstaller/hook-playwright.sync_api.py
@@ -1,0 +1,17 @@
+# Copyright (c) Microsoft Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files("playwright")

--- a/playwright/_impl/_transport.py
+++ b/playwright/_impl/_transport.py
@@ -105,6 +105,10 @@ class PipeTransport(Transport):
             creationflags = subprocess.CREATE_NO_WINDOW
 
         try:
+            env = os.environ.copy()
+            if getattr(sys, "frozen", False):
+                env["PLAYWRIGHT_BROWSERS_PATH"] = "0"
+
             self._proc = proc = await asyncio.create_subprocess_exec(
                 str(self._driver_executable),
                 "run-driver",
@@ -113,6 +117,7 @@ class PipeTransport(Transport):
                 stderr=_get_stderr_fileno(),
                 limit=32768,
                 creationflags=creationflags,
+                env=env,
             )
         except Exception as exc:
             self.on_error_future.set_exception(exc)

--- a/playwright/_impl/_transport.py
+++ b/playwright/_impl/_transport.py
@@ -105,6 +105,7 @@ class PipeTransport(Transport):
             creationflags = subprocess.CREATE_NO_WINDOW
 
         try:
+            # For pyinstaller
             env = os.environ.copy()
             if getattr(sys, "frozen", False):
                 env["PLAYWRIGHT_BROWSERS_PATH"] = "0"

--- a/setup.py
+++ b/setup.py
@@ -168,5 +168,6 @@ setup(
         "console_scripts": [
             "playwright=playwright.__main__:main",
         ],
+        "pyinstaller40": ["hook-dirs=playwright._impl.__pyinstaller:get_hook_dirs"],
     },
 )


### PR DESCRIPTION
For review instructions:

- Create a file `main.py`
- add this to the file 
```python
import os

from playwright.sync_api import sync_playwright

with sync_playwright() as p:
    browser = p.chromium.launch()
    page = browser.new_page()
    page.goto("http://whatsmyuseragent.org/")
    page.screenshot(path="example.png")
    browser.close()

```

- If you want to bundle browsers then set `PLAYWRIGHT_BROWSERS_PATH=0` to include bowser's inside the binary and then download the browsers 
- installer pyinstaller 
```sh
pip install pyinstaller
```

- Run pyinstaller on the file like 
```sh
pyinstaller -F main.py
```

- Binary would be placed in `dist/` relative to current dir and test it 