### PR TITLE
chore: test on python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,22 +68,15 @@ jobs:
         - os: ubuntu-latest
           python-version: '3.10-dev'
           browser: chromium
-        # TODO: Enable windows once https://github.com/python-pillow/Pillow/issues/5569 is fixed
-        # - os: windows-latest
-        #   python-version: '3.10-dev'
-        #   browser: chromium
+        - os: windows-latest
+          python-version: '3.10-dev'
+          browser: chromium
         - os: macos-latest
           python-version: '3.10-dev'
           browser: chromium
         - os: macos-11.0
           python-version: '3.10-dev'
           browser: chromium
-        - os: macos-11.0
-          python-version: '3.10-dev'
-          browser: firefox
-        - os: macos-11.0
-          python-version: '3.10-dev'
-          browser: webkit
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,21 +20,20 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
-    - name: Install dependencies
+    - name: Install dependencies & browsers
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip wheel
         pip install -r local-requirements.txt
         pip install -e .
         python setup.py bdist_wheel
-        python -m playwright install-deps
-    - name: Install browsers
-      run: python -m playwright install
+        python -m playwright install --with-deps
     - name: Lint
       uses: pre-commit/action@v2.0.3
     - name: Generate APIs
       run: bash scripts/update_api.sh
     - name: Verify generated API is up to date
       run: git diff --exit-code
+
   build:
     name: Build
     timeout-minutes: 30
@@ -44,28 +43,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.7, 3.8]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-11.0]
+        python-version: [3.7, 3.8, 3.9, '3.10-dev']
         browser: [chromium, firefox, webkit]
-        include:
-        - os: ubuntu-latest
-          python-version: 3.9
-          browser: chromium
-        - os: windows-latest
-          python-version: 3.9
-          browser: chromium
-        - os: macos-latest
-          python-version: 3.9
-          browser: chromium
-        - os: macos-11.0
-          python-version: 3.9
-          browser: chromium
-        - os: macos-11.0
-          python-version: 3.9
-          browser: firefox
-        - os: macos-11.0
-          python-version: 3.9
-          browser: webkit
+
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
@@ -73,15 +54,13 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install dependencies & browsers
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip wheel
         pip install -r local-requirements.txt
         pip install -e .
         python setup.py bdist_wheel
-        python -m playwright install-deps
-    - name: Install browsers
-      run: python -m playwright install
+        python -m playwright install --with-deps
     - name: Common Tests
       run: pytest tests/common --browser=${{ matrix.browser }} --timeout 90
     - name: Test Reference count
@@ -130,16 +109,14 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
-    - name: Install dependencies
+        python-version: 3.9
+    - name: Install dependencies & browsers
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip wheel
         pip install -r local-requirements.txt
         pip install -e .
         python setup.py bdist_wheel
-        python -m playwright install-deps
-    - name: Install browsers
-      run: python -m playwright install ${{ matrix.browser-channel }}
+        python -m playwright install ${{ matrix.browser-channel }} --with-deps
     - name: Common Tests
       run: pytest tests/common --browser=chromium --browser-channel=${{ matrix.browser-channel }} --timeout 90
     - name: Test Sync API
@@ -159,6 +136,7 @@ jobs:
       with:
         name: ${{ matrix.browser-channel }}-${{ matrix.os }}
         path: pw-log.txt
+
   build-conda:
     name: Conda Build
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,47 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-11.0]
-        python-version: [3.7, 3.8, 3.9, '3.10-dev']
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: [3.7, 3.8]
         browser: [chromium, firefox, webkit]
-
+        include:
+        - os: ubuntu-latest
+          python-version: 3.9
+          browser: chromium
+        - os: windows-latest
+          python-version: 3.9
+          browser: chromium
+        - os: macos-latest
+          python-version: 3.9
+          browser: chromium
+        - os: macos-11.0
+          python-version: 3.9
+          browser: chromium
+        - os: macos-11.0
+          python-version: 3.9
+          browser: firefox
+        - os: macos-11.0
+          python-version: 3.9
+          browser: webkit
+        - os: ubuntu-latest
+          python-version: '3.10-dev'
+          browser: chromium
+        # TODO: Enable windows once https://github.com/python-pillow/Pillow/issues/5569 is fixed
+        # - os: windows-latest
+        #   python-version: '3.10-dev'
+        #   browser: chromium
+        - os: macos-latest
+          python-version: '3.10-dev'
+          browser: chromium
+        - os: macos-11.0
+          python-version: '3.10-dev'
+          browser: chromium
+        - os: macos-11.0
+          python-version: '3.10-dev'
+          browser: firefox
+        - os: macos-11.0
+          python-version: '3.10-dev'
+          browser: webkit
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/local-requirements.txt
+++ b/local-requirements.txt
@@ -23,9 +23,3 @@ twine==3.4.2
 twisted==21.7.0
 types-pyOpenSSL==20.0.6
 wheel==0.37.0
-setuptools==57.0.0
-twine==3.4.1
-twisted==21.2.0
-# Python 3.10
-websockets @ https://github.com/aaugustin/websockets/archive/6edb363af07365867b4c372405b6ab3177a57830.tar.gz; python_version >= '3.10'
-wheel==0.36.2

--- a/local-requirements.txt
+++ b/local-requirements.txt
@@ -23,3 +23,9 @@ twine==3.4.2
 twisted==21.7.0
 types-pyOpenSSL==20.0.6
 wheel==0.37.0
+setuptools==57.0.0
+twine==3.4.1
+twisted==21.2.0
+# Python 3.10
+websockets @ https://github.com/aaugustin/websockets/archive/6edb363af07365867b4c372405b6ab3177a57830.tar.gz; python_version >= '3.10'
+wheel==0.36.2

--- a/setup.py
+++ b/setup.py
@@ -153,6 +153,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],


### PR DESCRIPTION
Python 3.10rc is out and hence we should add it to CI to prevent breakage when the final is out.