### PR TITLE
support overloads and add overloads to `wait_for_selector` for when it returns `None`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ _repo_version.py
 coverage.xml
 junit/
 htmldocs/
+.venv

--- a/playwright/_impl/_element_handle.py
+++ b/playwright/_impl/_element_handle.py
@@ -15,7 +15,17 @@
 import base64
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Union,
+    cast,
+    overload,
+)
 
 from playwright._impl._api_structures import FilePayload, FloatRect, Position
 from playwright._impl._connection import ChannelOwner, from_nullable_channel
@@ -308,6 +318,24 @@ class ElementHandle(JSHandle):
         timeout: float = None,
     ) -> None:
         await self._channel.send("waitForElementState", locals_to_params(locals()))
+
+    @overload
+    async def wait_for_selector(
+        self,
+        selector: str,
+        state: Literal["attached", "visible"] = None,
+        timeout: float = None,
+    ) -> "ElementHandle":
+        ...
+
+    @overload
+    async def wait_for_selector(
+        self,
+        selector: str,
+        state: Literal["detached", "hidden"],
+        timeout: float = None,
+    ) -> None:
+        ...
 
     async def wait_for_selector(
         self,

--- a/playwright/_impl/_element_handle.py
+++ b/playwright/_impl/_element_handle.py
@@ -15,17 +15,7 @@
 import base64
 import sys
 from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Union,
-    cast,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, cast
 
 from playwright._impl._api_structures import FilePayload, FloatRect, Position
 from playwright._impl._connection import ChannelOwner, from_nullable_channel
@@ -319,19 +309,19 @@ class ElementHandle(JSHandle):
     ) -> None:
         await self._channel.send("waitForElementState", locals_to_params(locals()))
 
-    @overload
-    async def wait_for_selector(
+    async def _overload1_wait_for_selector(
         self,
         selector: str,
+        *,
         state: Literal["attached", "visible"] = None,
         timeout: float = None,
     ) -> "ElementHandle":
         ...
 
-    @overload
-    async def wait_for_selector(
+    async def _overload2_wait_for_selector(
         self,
         selector: str,
+        *,
         state: Literal["detached", "hidden"],
         timeout: float = None,
     ) -> None:
@@ -340,6 +330,7 @@ class ElementHandle(JSHandle):
     async def wait_for_selector(
         self,
         selector: str,
+        *,
         state: Literal["attached", "detached", "hidden", "visible"] = None,
         timeout: float = None,
     ) -> Optional["ElementHandle"]:

--- a/playwright/_impl/_element_handle.py
+++ b/playwright/_impl/_element_handle.py
@@ -33,6 +33,7 @@ from playwright._impl._js_handle import (
     parse_result,
     serialize_argument,
 )
+from playwright._impl._overload import api_overload
 
 if sys.version_info >= (3, 8):  # pragma: no cover
     from typing import Literal
@@ -309,7 +310,8 @@ class ElementHandle(JSHandle):
     ) -> None:
         await self._channel.send("waitForElementState", locals_to_params(locals()))
 
-    async def _overload1_wait_for_selector(
+    @api_overload
+    async def wait_for_selector(
         self,
         selector: str,
         *,
@@ -318,7 +320,8 @@ class ElementHandle(JSHandle):
     ) -> "ElementHandle":
         ...
 
-    async def _overload2_wait_for_selector(
+    @api_overload  # type: ignore[no-redef]
+    async def wait_for_selector(
         self,
         selector: str,
         *,
@@ -327,7 +330,7 @@ class ElementHandle(JSHandle):
     ) -> None:
         ...
 
-    async def wait_for_selector(
+    async def wait_for_selector(  # type: ignore[no-redef]
         self,
         selector: str,
         *,

--- a/playwright/_impl/_frame.py
+++ b/playwright/_impl/_frame.py
@@ -48,6 +48,7 @@ from playwright._impl._js_handle import (
 )
 from playwright._impl._locator import Locator
 from playwright._impl._network import Response
+from playwright._impl._overload import api_overload
 from playwright._impl._wait_helper import WaitHelper
 
 if sys.version_info >= (3, 8):  # pragma: no cover
@@ -270,7 +271,8 @@ class Frame(ChannelOwner):
             )
         )
 
-    async def _overload1_wait_for_selector(
+    @api_overload
+    async def wait_for_selector(
         self,
         selector: str,
         *,
@@ -280,7 +282,8 @@ class Frame(ChannelOwner):
     ) -> ElementHandle:
         ...
 
-    async def _overload2_wait_for_selector(
+    @api_overload  # type: ignore[no-redef]
+    async def wait_for_selector(
         self,
         selector: str,
         *,
@@ -290,7 +293,7 @@ class Frame(ChannelOwner):
     ) -> None:
         ...
 
-    async def wait_for_selector(
+    async def wait_for_selector(  # type: ignore[no-redef]
         self,
         selector: str,
         *,

--- a/playwright/_impl/_frame.py
+++ b/playwright/_impl/_frame.py
@@ -15,7 +15,7 @@
 import asyncio
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union, cast, overload
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union, cast
 
 from pyee import EventEmitter
 
@@ -270,39 +270,30 @@ class Frame(ChannelOwner):
             )
         )
 
-    @overload
-    async def wait_for_selector(
+    async def _overload1_wait_for_selector(
         self,
         selector: str,
+        *,
         strict: bool = None,
         timeout: float = None,
         state: Literal["attached", "visible"] = None,
     ) -> ElementHandle:
         ...
 
-    @overload
-    async def wait_for_selector(
-            self,
-            selector: str,
-            strict: bool = None,
-            timeout: float = None,
-            *,
-            state: Literal["detached", "hidden"],
-    ) -> None:
-        ...
-    @overload
-    async def wait_for_selector(
-            self,
-            selector: str,
-            strict: Optional[bool],
-            timeout: Optional[float],
-            state: Literal["detached", "hidden"],
+    async def _overload2_wait_for_selector(
+        self,
+        selector: str,
+        *,
+        strict: bool = None,
+        timeout: float = None,
+        state: Literal["detached", "hidden"],
     ) -> None:
         ...
 
     async def wait_for_selector(
         self,
         selector: str,
+        *,
         strict: bool = None,
         timeout: float = None,
         state: Literal["attached", "detached", "hidden", "visible"] = None,

--- a/playwright/_impl/_frame.py
+++ b/playwright/_impl/_frame.py
@@ -15,7 +15,7 @@
 import asyncio
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union, cast, overload
 
 from pyee import EventEmitter
 
@@ -269,6 +269,36 @@ class Frame(ChannelOwner):
                 await self._channel.send("querySelectorAll", dict(selector=selector)),
             )
         )
+
+    @overload
+    async def wait_for_selector(
+        self,
+        selector: str,
+        strict: bool = None,
+        timeout: float = None,
+        state: Literal["attached", "visible"] = None,
+    ) -> ElementHandle:
+        ...
+
+    @overload
+    async def wait_for_selector(
+            self,
+            selector: str,
+            strict: bool = None,
+            timeout: float = None,
+            *,
+            state: Literal["detached", "hidden"],
+    ) -> None:
+        ...
+    @overload
+    async def wait_for_selector(
+            self,
+            selector: str,
+            strict: Optional[bool],
+            timeout: Optional[float],
+            state: Literal["detached", "hidden"],
+    ) -> None:
+        ...
 
     async def wait_for_selector(
         self,

--- a/playwright/_impl/_locator.py
+++ b/playwright/_impl/_locator.py
@@ -173,9 +173,12 @@ class Locator:
         timeout: float = None,
     ) -> ElementHandle:
         params = locals_to_params(locals())
-        return await self._frame.wait_for_selector(
+        return cast(
+            ElementHandle,
+            await self._frame.wait_for_selector(
                 self._selector, strict=True, state="attached", **params
-            )
+            ),
+        )
 
     async def element_handles(self) -> List[ElementHandle]:
         return await self._frame.query_selector_all(self._selector)

--- a/playwright/_impl/_locator.py
+++ b/playwright/_impl/_locator.py
@@ -173,12 +173,9 @@ class Locator:
         timeout: float = None,
     ) -> ElementHandle:
         params = locals_to_params(locals())
-        return cast(
-            ElementHandle,
-            await self._frame.wait_for_selector(
+        return await self._frame.wait_for_selector(
                 self._selector, strict=True, state="attached", **params
-            ),
-        )
+            )
 
     async def element_handles(self) -> List[ElementHandle]:
         return await self._frame.query_selector_all(self._selector)

--- a/playwright/_impl/_overload.py
+++ b/playwright/_impl/_overload.py
@@ -1,0 +1,16 @@
+from collections import defaultdict
+import inspect
+from typing import Callable
+
+
+def api_overload(fn: Callable) -> Callable:
+    """
+    Creates an overload that's visible to the api generate scripts. use this decorator instead of `typing.overload` when exposing overloads from `_impl`.
+    You will need to suppress mypy errors using a `# type: ignore[no-redef]` comment
+    """
+    dictionary = inspect.getmodule(fn).__dict__
+    overloads_key = "__overloads__"
+    if dictionary.get(overloads_key) is None:
+        dictionary[overloads_key] = defaultdict(list)
+    dictionary[overloads_key][fn.__name__].append(fn)
+    return fn

--- a/playwright/_impl/_page.py
+++ b/playwright/_impl/_page.py
@@ -19,17 +19,7 @@ import re
 import sys
 from pathlib import Path
 from types import SimpleNamespace
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Union,
-    cast,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, cast
 
 from playwright._impl._accessibility import Accessibility
 from playwright._impl._api_structures import (
@@ -335,40 +325,30 @@ class Page(ChannelOwner):
     async def query_selector_all(self, selector: str) -> List[ElementHandle]:
         return await self._main_frame.query_selector_all(selector)
 
-    @overload
-    async def wait_for_selector(
+    async def _overload1_wait_for_selector(
         self,
         selector: str,
+        *,
         timeout: float = None,
         state: Literal["attached", "visible"] = None,
         strict: bool = None,
     ) -> ElementHandle:
         ...
 
-    @overload
-    async def wait_for_selector(
-            self,
-            selector: str,
-            timeout: float= None,
-            *,
-            state: Literal["detached", "hidden"],
-            strict: bool = None,
-    ) -> None:
-        ...
-
-    @overload
-    async def wait_for_selector(
-            self,
-            selector: str,
-            timeout: Optional[float],
-            state: Literal["detached", "hidden"],
-            strict: bool = None,
+    async def _overload2_wait_for_selector(
+        self,
+        selector: str,
+        *,
+        timeout: float = None,
+        state: Literal["detached", "hidden"],
+        strict: bool = None,
     ) -> None:
         ...
 
     async def wait_for_selector(
         self,
         selector: str,
+        *,
         timeout: float = None,
         state: Literal["attached", "detached", "hidden", "visible"] = None,
         strict: bool = None,

--- a/playwright/_impl/_page.py
+++ b/playwright/_impl/_page.py
@@ -71,6 +71,7 @@ from playwright._impl._js_handle import (
     serialize_argument,
 )
 from playwright._impl._network import Request, Response, Route, serialize_headers
+from playwright._impl._overload import api_overload
 from playwright._impl._video import Video
 from playwright._impl._wait_helper import WaitHelper
 
@@ -325,7 +326,8 @@ class Page(ChannelOwner):
     async def query_selector_all(self, selector: str) -> List[ElementHandle]:
         return await self._main_frame.query_selector_all(selector)
 
-    async def _overload1_wait_for_selector(
+    @api_overload
+    async def wait_for_selector(
         self,
         selector: str,
         *,
@@ -335,7 +337,8 @@ class Page(ChannelOwner):
     ) -> ElementHandle:
         ...
 
-    async def _overload2_wait_for_selector(
+    @api_overload  # type: ignore[no-redef]
+    async def wait_for_selector(
         self,
         selector: str,
         *,
@@ -345,7 +348,7 @@ class Page(ChannelOwner):
     ) -> None:
         ...
 
-    async def wait_for_selector(
+    async def wait_for_selector(  # type: ignore[no-redef]
         self,
         selector: str,
         *,

--- a/playwright/_impl/_page.py
+++ b/playwright/_impl/_page.py
@@ -19,7 +19,17 @@ import re
 import sys
 from pathlib import Path
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Union,
+    cast,
+    overload,
+)
 
 from playwright._impl._accessibility import Accessibility
 from playwright._impl._api_structures import (
@@ -324,6 +334,37 @@ class Page(ChannelOwner):
 
     async def query_selector_all(self, selector: str) -> List[ElementHandle]:
         return await self._main_frame.query_selector_all(selector)
+
+    @overload
+    async def wait_for_selector(
+        self,
+        selector: str,
+        timeout: float = None,
+        state: Literal["attached", "visible"] = None,
+        strict: bool = None,
+    ) -> ElementHandle:
+        ...
+
+    @overload
+    async def wait_for_selector(
+            self,
+            selector: str,
+            timeout: float= None,
+            *,
+            state: Literal["detached", "hidden"],
+            strict: bool = None,
+    ) -> None:
+        ...
+
+    @overload
+    async def wait_for_selector(
+            self,
+            selector: str,
+            timeout: Optional[float],
+            state: Literal["detached", "hidden"],
+            strict: bool = None,
+    ) -> None:
+        ...
 
     async def wait_for_selector(
         self,

--- a/playwright/async_api/_generated.py
+++ b/playwright/async_api/_generated.py
@@ -2467,8 +2467,8 @@ class ElementHandle(JSHandle):
         self,
         selector: str,
         *,
-        state: typing.Optional[Literal["attached", "visible"]],
-        timeout: typing.Optional[float]
+        state: Literal["attached", "visible"] = None,
+        timeout: float = None
     ) -> "ElementHandle":
         pass
 
@@ -2478,7 +2478,7 @@ class ElementHandle(JSHandle):
         selector: str,
         *,
         state: Literal["detached", "hidden"],
-        timeout: typing.Optional[float]
+        timeout: float = None
     ) -> NoneType:
         pass
 
@@ -3143,9 +3143,9 @@ class Frame(AsyncBase):
         self,
         selector: str,
         *,
-        strict: typing.Optional[bool],
-        timeout: typing.Optional[float],
-        state: typing.Optional[Literal["attached", "visible"]]
+        strict: bool = None,
+        timeout: float = None,
+        state: Literal["attached", "visible"] = None
     ) -> "ElementHandle":
         pass
 
@@ -3154,8 +3154,8 @@ class Frame(AsyncBase):
         self,
         selector: str,
         *,
-        strict: typing.Optional[bool],
-        timeout: typing.Optional[float],
+        strict: bool = None,
+        timeout: float = None,
         state: Literal["detached", "hidden"]
     ) -> NoneType:
         pass
@@ -5583,9 +5583,9 @@ class Page(AsyncContextManager):
         self,
         selector: str,
         *,
-        timeout: typing.Optional[float],
-        state: typing.Optional[Literal["attached", "visible"]],
-        strict: typing.Optional[bool]
+        timeout: float = None,
+        state: Literal["attached", "visible"] = None,
+        strict: bool = None
     ) -> "ElementHandle":
         pass
 
@@ -5594,9 +5594,9 @@ class Page(AsyncContextManager):
         self,
         selector: str,
         *,
-        timeout: typing.Optional[float],
+        timeout: float = None,
         state: Literal["detached", "hidden"],
-        strict: typing.Optional[bool]
+        strict: bool = None
     ) -> NoneType:
         pass
 

--- a/playwright/async_api/_generated.py
+++ b/playwright/async_api/_generated.py
@@ -2462,6 +2462,26 @@ class ElementHandle(JSHandle):
             )
         )
 
+    @typing.overload
+    async def wait_for_selector(
+        self,
+        selector: str,
+        *,
+        state: typing.Optional[Literal["attached", "visible"]],
+        timeout: typing.Optional[float]
+    ) -> "ElementHandle":
+        pass
+
+    @typing.overload
+    async def wait_for_selector(
+        self,
+        selector: str,
+        *,
+        state: Literal["detached", "hidden"],
+        timeout: typing.Optional[float]
+    ) -> NoneType:
+        pass
+
     async def wait_for_selector(
         self,
         selector: str,
@@ -3117,6 +3137,28 @@ class Frame(AsyncBase):
                 self._impl_obj.query_selector_all(selector=selector),
             )
         )
+
+    @typing.overload
+    async def wait_for_selector(
+        self,
+        selector: str,
+        *,
+        strict: typing.Optional[bool],
+        timeout: typing.Optional[float],
+        state: typing.Optional[Literal["attached", "visible"]]
+    ) -> "ElementHandle":
+        pass
+
+    @typing.overload
+    async def wait_for_selector(
+        self,
+        selector: str,
+        *,
+        strict: typing.Optional[bool],
+        timeout: typing.Optional[float],
+        state: Literal["detached", "hidden"]
+    ) -> NoneType:
+        pass
 
     async def wait_for_selector(
         self,
@@ -5535,6 +5577,28 @@ class Page(AsyncContextManager):
                 self._impl_obj.query_selector_all(selector=selector),
             )
         )
+
+    @typing.overload
+    async def wait_for_selector(
+        self,
+        selector: str,
+        *,
+        timeout: typing.Optional[float],
+        state: typing.Optional[Literal["attached", "visible"]],
+        strict: typing.Optional[bool]
+    ) -> "ElementHandle":
+        pass
+
+    @typing.overload
+    async def wait_for_selector(
+        self,
+        selector: str,
+        *,
+        timeout: typing.Optional[float],
+        state: Literal["detached", "hidden"],
+        strict: typing.Optional[bool]
+    ) -> NoneType:
+        pass
 
     async def wait_for_selector(
         self,

--- a/playwright/sync_api/_generated.py
+++ b/playwright/sync_api/_generated.py
@@ -2450,8 +2450,8 @@ class ElementHandle(JSHandle):
         self,
         selector: str,
         *,
-        state: typing.Optional[Literal["attached", "visible"]],
-        timeout: typing.Optional[float]
+        state: Literal["attached", "visible"] = None,
+        timeout: float = None
     ) -> "ElementHandle":
         pass
 
@@ -2461,7 +2461,7 @@ class ElementHandle(JSHandle):
         selector: str,
         *,
         state: Literal["detached", "hidden"],
-        timeout: typing.Optional[float]
+        timeout: float = None
     ) -> NoneType:
         pass
 
@@ -3124,9 +3124,9 @@ class Frame(SyncBase):
         self,
         selector: str,
         *,
-        strict: typing.Optional[bool],
-        timeout: typing.Optional[float],
-        state: typing.Optional[Literal["attached", "visible"]]
+        strict: bool = None,
+        timeout: float = None,
+        state: Literal["attached", "visible"] = None
     ) -> "ElementHandle":
         pass
 
@@ -3135,8 +3135,8 @@ class Frame(SyncBase):
         self,
         selector: str,
         *,
-        strict: typing.Optional[bool],
-        timeout: typing.Optional[float],
+        strict: bool = None,
+        timeout: float = None,
         state: Literal["detached", "hidden"]
     ) -> NoneType:
         pass
@@ -5552,9 +5552,9 @@ class Page(SyncContextManager):
         self,
         selector: str,
         *,
-        timeout: typing.Optional[float],
-        state: typing.Optional[Literal["attached", "visible"]],
-        strict: typing.Optional[bool]
+        timeout: float = None,
+        state: Literal["attached", "visible"] = None,
+        strict: bool = None
     ) -> "ElementHandle":
         pass
 
@@ -5563,9 +5563,9 @@ class Page(SyncContextManager):
         self,
         selector: str,
         *,
-        timeout: typing.Optional[float],
+        timeout: float = None,
         state: Literal["detached", "hidden"],
-        strict: typing.Optional[bool]
+        strict: bool = None
     ) -> NoneType:
         pass
 

--- a/playwright/sync_api/_generated.py
+++ b/playwright/sync_api/_generated.py
@@ -2445,6 +2445,26 @@ class ElementHandle(JSHandle):
             )
         )
 
+    @typing.overload
+    def wait_for_selector(
+        self,
+        selector: str,
+        *,
+        state: typing.Optional[Literal["attached", "visible"]],
+        timeout: typing.Optional[float]
+    ) -> "ElementHandle":
+        pass
+
+    @typing.overload
+    def wait_for_selector(
+        self,
+        selector: str,
+        *,
+        state: Literal["detached", "hidden"],
+        timeout: typing.Optional[float]
+    ) -> NoneType:
+        pass
+
     def wait_for_selector(
         self,
         selector: str,
@@ -3098,6 +3118,28 @@ class Frame(SyncBase):
                 self._impl_obj.query_selector_all(selector=selector),
             )
         )
+
+    @typing.overload
+    def wait_for_selector(
+        self,
+        selector: str,
+        *,
+        strict: typing.Optional[bool],
+        timeout: typing.Optional[float],
+        state: typing.Optional[Literal["attached", "visible"]]
+    ) -> "ElementHandle":
+        pass
+
+    @typing.overload
+    def wait_for_selector(
+        self,
+        selector: str,
+        *,
+        strict: typing.Optional[bool],
+        timeout: typing.Optional[float],
+        state: Literal["detached", "hidden"]
+    ) -> NoneType:
+        pass
 
     def wait_for_selector(
         self,
@@ -5504,6 +5546,28 @@ class Page(SyncContextManager):
                 self._impl_obj.query_selector_all(selector=selector),
             )
         )
+
+    @typing.overload
+    def wait_for_selector(
+        self,
+        selector: str,
+        *,
+        timeout: typing.Optional[float],
+        state: typing.Optional[Literal["attached", "visible"]],
+        strict: typing.Optional[bool]
+    ) -> "ElementHandle":
+        pass
+
+    @typing.overload
+    def wait_for_selector(
+        self,
+        selector: str,
+        *,
+        timeout: typing.Optional[float],
+        state: Literal["detached", "hidden"],
+        strict: typing.Optional[bool]
+    ) -> NoneType:
+        pass
 
     def wait_for_selector(
         self,

--- a/scripts/generate_api.py
+++ b/scripts/generate_api.py
@@ -150,8 +150,6 @@ def signature(func: FunctionType, indent: int, overload: bool = False) -> str:
                 # This condition should be only triggered once, so
                 # reset the flag
                 render_kw_only_separator = False
-
-            processed = process_type(value, False)
         else:
             if (
                 not positional_exception
@@ -163,7 +161,7 @@ def signature(func: FunctionType, indent: int, overload: bool = False) -> str:
             ):
                 saw_optional = True
                 tokens.append("*")
-            processed = process_type(value, True)
+        processed = process_type(value, True)
         tokens.append(f"{to_snake_case(name)}: {processed}")
     if overload and render_pos_only_separator:
         # There were only positional-only parameters, hence the

--- a/scripts/generate_sync_api.py
+++ b/scripts/generate_sync_api.py
@@ -17,15 +17,17 @@ import inspect
 import re
 import sys
 from types import FunctionType
-from typing import Any, get_type_hints
+from typing import Any, Optional, get_type_hints
 
 from playwright._impl._helper import to_snake_case
 from scripts.documentation_provider import DocumentationProvider
 from scripts.generate_api import (
+    Overload,
     all_types,
     api_globals,
     arguments,
     header,
+    is_overload,
     process_type,
     return_type,
     return_value,
@@ -77,6 +79,11 @@ def generate(t: Any) -> None:
             prefix = "        return " + prefix + f"self._impl_obj.{name}"
             print(f"{prefix}{arguments(value, len(prefix))}{suffix}")
     for [name, value] in t.__dict__.items():
+        overload: Optional[Overload] = None
+        if is_overload(name):
+            overload = Overload(t, name)
+            overload.assert_has_implementation()
+            name = overload.name
         if (
             not name.startswith("_")
             and isinstance(value, FunctionType)
@@ -86,34 +93,39 @@ def generate(t: Any) -> None:
             return_type_value = return_type(value)
             return_type_value = re.sub(r"\"([^\"]+)Impl\"", r"\1", return_type_value)
             print("")
+            if overload is not None:
+                print("    @typing.overload")
             print(
-                f"    def {name}({signature(value, len(name) + 9)}) -> {return_type_value}:"
+                f"    def {name}({signature(value, len(name) + 9, overload is not None)}) -> {return_type_value}:"
             )
-            documentation_provider.print_entry(
-                class_name, name, get_type_hints(value, api_globals)
-            )
-            if "expect_" in name:
-                print(
-                    f"        return EventContextManager(self, self._impl_obj.{name}({arguments(value, 12)}).future)"
+            if overload is None:
+                documentation_provider.print_entry(
+                    class_name, name, get_type_hints(value, api_globals)
                 )
-            else:
-                [prefix, suffix] = return_value(
-                    get_type_hints(value, api_globals)["return"]
-                )
-                if is_async:
-                    prefix = (
-                        prefix
-                        + f'self._sync("{to_snake_case(class_name)}.{name}", self._impl_obj.{name}('
+                if "expect_" in name:
+                    print(
+                        f"        return EventContextManager(self, self._impl_obj.{name}({arguments(value, 12)}).future)"
                     )
-                    suffix = "))" + suffix
                 else:
-                    prefix = prefix + f"self._impl_obj.{name}("
-                    suffix = ")" + suffix
+                    [prefix, suffix] = return_value(
+                        get_type_hints(value, api_globals)["return"]
+                    )
+                    if is_async:
+                        prefix = (
+                            prefix
+                            + f'self._sync("{to_snake_case(class_name)}.{name}", self._impl_obj.{name}('
+                        )
+                        suffix = "))" + suffix
+                    else:
+                        prefix = prefix + f"self._impl_obj.{name}("
+                        suffix = ")" + suffix
 
-                print(
-                    f"""
+                    print(
+                        f"""
         return {prefix}{arguments(value, len(prefix))}{suffix}"""
-                )
+                    )
+            else:
+                print("        pass")
     if class_name == "Playwright":
         print(
             """

--- a/scripts/generate_sync_api.py
+++ b/scripts/generate_sync_api.py
@@ -14,22 +14,20 @@
 # limitations under the License.
 
 import inspect
-import re
 import sys
 from types import FunctionType
-from typing import Any, Optional, get_type_hints
+from typing import Any, Callable, Dict, List, get_type_hints
 
 from playwright._impl._helper import to_snake_case
 from scripts.documentation_provider import DocumentationProvider
 from scripts.generate_api import (
-    Overload,
     all_types,
     api_globals,
     arguments,
     header,
-    is_overload,
     process_type,
     return_type,
+    return_type_value,
     return_value,
     short_name,
     signature,
@@ -60,6 +58,10 @@ def generate(t: Any) -> None:
         [prefix, suffix] = return_value(type)
         prefix = "        return " + prefix + f"self._impl_obj.{name}"
         print(f"{prefix}{suffix}")
+    all_overloads: Dict[str, List[Callable]] = (
+        inspect.getmodule(t).__dict__.get("__overloads__") or {}
+    )
+
     for [name, value] in t.__dict__.items():
         if name.startswith("_"):
             continue
@@ -79,53 +81,49 @@ def generate(t: Any) -> None:
             prefix = "        return " + prefix + f"self._impl_obj.{name}"
             print(f"{prefix}{arguments(value, len(prefix))}{suffix}")
     for [name, value] in t.__dict__.items():
-        overload: Optional[Overload] = None
-        if is_overload(name):
-            overload = Overload(t, name)
-            overload.assert_has_implementation()
-            name = overload.name
+        overloads = all_overloads.get(name) or []
         if (
             not name.startswith("_")
             and isinstance(value, FunctionType)
             and "remove_listener" != name
         ):
             is_async = inspect.iscoroutinefunction(value)
-            return_type_value = return_type(value)
-            return_type_value = re.sub(r"\"([^\"]+)Impl\"", r"\1", return_type_value)
-            print("")
-            if overload is not None:
+            indent = len(name) + 9
+            for overload in overloads:
                 print("    @typing.overload")
-            print(
-                f"    def {name}({signature(value, len(name) + 9, overload is not None)}) -> {return_type_value}:"
-            )
-            if overload is None:
-                documentation_provider.print_entry(
-                    class_name, name, get_type_hints(value, api_globals)
+                print(
+                    f"    def {name}({signature(overload, indent, True)}) -> {return_type_value(overload)}:"
                 )
-                if "expect_" in name:
-                    print(
-                        f"        return EventContextManager(self, self._impl_obj.{name}({arguments(value, 12)}).future)"
-                    )
-                else:
-                    [prefix, suffix] = return_value(
-                        get_type_hints(value, api_globals)["return"]
-                    )
-                    if is_async:
-                        prefix = (
-                            prefix
-                            + f'self._sync("{to_snake_case(class_name)}.{name}", self._impl_obj.{name}('
-                        )
-                        suffix = "))" + suffix
-                    else:
-                        prefix = prefix + f"self._impl_obj.{name}("
-                        suffix = ")" + suffix
-
-                    print(
-                        f"""
-        return {prefix}{arguments(value, len(prefix))}{suffix}"""
-                    )
-            else:
                 print("        pass")
+            print("")
+            print(
+                f"    def {name}({signature(value, indent)}) -> {return_type_value(value)}:"
+            )
+            documentation_provider.print_entry(
+                class_name, name, get_type_hints(value, api_globals)
+            )
+            if "expect_" in name:
+                print(
+                    f"        return EventContextManager(self, self._impl_obj.{name}({arguments(value, 12)}).future)"
+                )
+            else:
+                [prefix, suffix] = return_value(
+                    get_type_hints(value, api_globals)["return"]
+                )
+                if is_async:
+                    prefix = (
+                        prefix
+                        + f'self._sync("{to_snake_case(class_name)}.{name}", self._impl_obj.{name}('
+                    )
+                    suffix = "))" + suffix
+                else:
+                    prefix = prefix + f"self._impl_obj.{name}("
+                    suffix = ")" + suffix
+
+                print(
+                    f"""
+        return {prefix}{arguments(value, len(prefix))}{suffix}"""
+                )
     if class_name == "Playwright":
         print(
             """

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,5 +22,6 @@ ignore =
     E501
     W503
     E302
+    F811 #see CONTRIBUTING.md overloads section
 [isort]
 profile = black

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ warn_redundant_casts = True
 warn_unused_configs = True
 check_untyped_defs = True
 disallow_untyped_defs = True
+show_error_codes = True
 [mypy-tests.*]
 ignore_errors = True
 [flake8]


### PR DESCRIPTION
- optional arguments are now only automatically converted to keyword arguments if the method has no overloads, because otherwise it can invalidate overloads. it's expected that you explicitly specify what arguments should be keywords, like in the example below

- overloads must be defined using `@api_overload` in order for the generate scripts to be able to see them at runtime.
  ```py
  from playwright._impl._overload import api_overload
  
  @api_overload
  async def wait_for_selector(
      self,
      selector: str,
      *,
      timeout: float = None,
      state: Literal["attached", "visible"] = None,
      strict: bool = None,
  ) -> ElementHandle:
      pass

  @api_overload  # type: ignore[no-redef]
  async def wait_for_selector(
      self,
      selector: str,
      *,
      timeout: float = None,
      state: Literal["detached", "hidden"],
      strict: bool = None,
  ) -> None:
      pass

  async def wait_for_selector(  # type: ignore[no-redef]
      self,
      selector: str,
      *,
      timeout: float = None,
      state: Literal["attached", "detached", "hidden", "visible"] = None,
      strict: bool = None,
  ) -> Optional[ElementHandle]:
      ...
  ```