### PR TITLE
fix(1.14): do not trigger playwright install message for deps

### DIFF
--- a/playwright/_impl/_browser_type.py
+++ b/playwright/_impl/_browser_type.py
@@ -85,7 +85,7 @@ class BrowserType(ChannelOwner):
         try:
             return from_channel(await self._channel.send("launch", params))
         except Exception as e:
-            if "npx playwright install" in str(e):
+            if "npx playwright install " in str(e):
                 raise not_installed_error(f'"{self.name}" browser was not found.')
             raise e
 
@@ -146,7 +146,7 @@ class BrowserType(ChannelOwner):
             context._options = params
             return context
         except Exception as e:
-            if "npx playwright install" in str(e):
+            if "npx playwright install " in str(e):
                 raise not_installed_error(f'"{self.name}" browser was not found.')
             raise e
 


### PR DESCRIPTION
When the OS dependencies are not satisfied, Playwright throws an exception with `npx playwright install-deps`. This will also trigger this if condition, but it should not. To prevent that for the release we add a space after it.

For 1.15 this logic is not relevant anymore, since we don't wrap it in Python anymore. We throw it from Node.js directly in the correct format.