### PR TITLE
chore: remove special handling for `__getitem__`

### DIFF
--- a/playwright/_impl/_playwright.py
+++ b/playwright/_impl/_playwright.py
@@ -40,6 +40,15 @@ class Playwright(ChannelOwner):
             for device in initializer["deviceDescriptors"]
         }
 
+    def __getitem__(self, value: str) -> "BrowserType":
+        if value == "chromium":
+            return self.chromium
+        elif value == "firefox":
+            return self.firefox
+        elif value == "webkit":
+            return self.webkit
+        raise ValueError("Invalid browser " + value)
+
     def stop(self) -> None:
         pass
 

--- a/playwright/async_api/_generated.py
+++ b/playwright/async_api/_generated.py
@@ -76,9 +76,6 @@ NoneType = type(None)
 
 
 class Request(AsyncBase):
-    def __init__(self, obj: RequestImpl):
-        super().__init__(obj)
-
     @property
     def url(self) -> str:
         """Request.url
@@ -341,9 +338,6 @@ mapping.register(RequestImpl, Request)
 
 
 class Response(AsyncBase):
-    def __init__(self, obj: ResponseImpl):
-        super().__init__(obj)
-
     @property
     def url(self) -> str:
         """Response.url
@@ -546,9 +540,6 @@ mapping.register(ResponseImpl, Response)
 
 
 class Route(AsyncBase):
-    def __init__(self, obj: RouteImpl):
-        super().__init__(obj)
-
     @property
     def request(self) -> "Request":
         """Route.request
@@ -702,9 +693,6 @@ mapping.register(RouteImpl, Route)
 
 
 class WebSocket(AsyncBase):
-    def __init__(self, obj: WebSocketImpl):
-        super().__init__(obj)
-
     @property
     def url(self) -> str:
         """WebSocket.url
@@ -800,9 +788,6 @@ mapping.register(WebSocketImpl, WebSocket)
 
 
 class Keyboard(AsyncBase):
-    def __init__(self, obj: KeyboardImpl):
-        super().__init__(obj)
-
     async def down(self, key: str) -> NoneType:
         """Keyboard.down
 
@@ -961,9 +946,6 @@ mapping.register(KeyboardImpl, Keyboard)
 
 
 class Mouse(AsyncBase):
-    def __init__(self, obj: MouseImpl):
-        super().__init__(obj)
-
     async def move(self, x: float, y: float, *, steps: int = None) -> NoneType:
         """Mouse.move
 
@@ -1098,9 +1080,6 @@ mapping.register(MouseImpl, Mouse)
 
 
 class Touchscreen(AsyncBase):
-    def __init__(self, obj: TouchscreenImpl):
-        super().__init__(obj)
-
     async def tap(self, x: float, y: float) -> NoneType:
         """Touchscreen.tap
 
@@ -1121,9 +1100,6 @@ mapping.register(TouchscreenImpl, Touchscreen)
 
 
 class JSHandle(AsyncBase):
-    def __init__(self, obj: JSHandleImpl):
-        super().__init__(obj)
-
     async def evaluate(self, expression: str, arg: typing.Any = None) -> typing.Any:
         """JSHandle.evaluate
 
@@ -1291,9 +1267,6 @@ mapping.register(JSHandleImpl, JSHandle)
 
 
 class ElementHandle(JSHandle):
-    def __init__(self, obj: ElementHandleImpl):
-        super().__init__(obj)
-
     def as_element(self) -> typing.Optional["ElementHandle"]:
         """ElementHandle.as_element
 
@@ -2656,9 +2629,6 @@ mapping.register(ElementHandleImpl, ElementHandle)
 
 
 class Accessibility(AsyncBase):
-    def __init__(self, obj: AccessibilityImpl):
-        super().__init__(obj)
-
     async def snapshot(
         self, *, interesting_only: bool = None, root: "ElementHandle" = None
     ) -> typing.Optional[typing.Dict]:
@@ -2720,9 +2690,6 @@ mapping.register(AccessibilityImpl, Accessibility)
 
 
 class FileChooser(AsyncBase):
-    def __init__(self, obj: FileChooserImpl):
-        super().__init__(obj)
-
     @property
     def page(self) -> "Page":
         """FileChooser.page
@@ -2803,9 +2770,6 @@ mapping.register(FileChooserImpl, FileChooser)
 
 
 class Frame(AsyncBase):
-    def __init__(self, obj: FrameImpl):
-        super().__init__(obj)
-
     @property
     def page(self) -> "Page":
         """Frame.page
@@ -5037,9 +5001,6 @@ mapping.register(FrameImpl, Frame)
 
 
 class Worker(AsyncBase):
-    def __init__(self, obj: WorkerImpl):
-        super().__init__(obj)
-
     @property
     def url(self) -> str:
         """Worker.url
@@ -5124,9 +5085,6 @@ mapping.register(WorkerImpl, Worker)
 
 
 class Selectors(AsyncBase):
-    def __init__(self, obj: SelectorsImpl):
-        super().__init__(obj)
-
     async def register(
         self,
         name: str,
@@ -5208,9 +5166,6 @@ mapping.register(SelectorsImpl, Selectors)
 
 
 class ConsoleMessage(AsyncBase):
-    def __init__(self, obj: ConsoleMessageImpl):
-        super().__init__(obj)
-
     @property
     def type(self) -> str:
         """ConsoleMessage.type
@@ -5264,9 +5219,6 @@ mapping.register(ConsoleMessageImpl, ConsoleMessage)
 
 
 class Dialog(AsyncBase):
-    def __init__(self, obj: DialogImpl):
-        super().__init__(obj)
-
     @property
     def type(self) -> str:
         """Dialog.type
@@ -5335,9 +5287,6 @@ mapping.register(DialogImpl, Dialog)
 
 
 class Download(AsyncBase):
-    def __init__(self, obj: DownloadImpl):
-        super().__init__(obj)
-
     @property
     def page(self) -> "Page":
         """Download.page
@@ -5451,9 +5400,6 @@ mapping.register(DownloadImpl, Download)
 
 
 class Video(AsyncBase):
-    def __init__(self, obj: VideoImpl):
-        super().__init__(obj)
-
     async def path(self) -> pathlib.Path:
         """Video.path
 
@@ -5500,9 +5446,6 @@ mapping.register(VideoImpl, Video)
 
 
 class Page(AsyncContextManager):
-    def __init__(self, obj: PageImpl):
-        super().__init__(obj)
-
     @property
     def accessibility(self) -> "Accessibility":
         """Page.accessibility
@@ -9072,9 +9015,6 @@ mapping.register(PageImpl, Page)
 
 
 class BrowserContext(AsyncContextManager):
-    def __init__(self, obj: BrowserContextImpl):
-        super().__init__(obj)
-
     @property
     def pages(self) -> typing.List["Page"]:
         """BrowserContext.pages
@@ -9837,9 +9777,6 @@ mapping.register(BrowserContextImpl, BrowserContext)
 
 
 class CDPSession(AsyncBase):
-    def __init__(self, obj: CDPSessionImpl):
-        super().__init__(obj)
-
     async def send(self, method: str, params: typing.Dict = None) -> typing.Dict:
         """CDPSession.send
 
@@ -9878,9 +9815,6 @@ mapping.register(CDPSessionImpl, CDPSession)
 
 
 class Browser(AsyncContextManager):
-    def __init__(self, obj: BrowserImpl):
-        super().__init__(obj)
-
     @property
     def contexts(self) -> typing.List["BrowserContext"]:
         """Browser.contexts
@@ -10382,9 +10316,6 @@ mapping.register(BrowserImpl, Browser)
 
 
 class BrowserType(AsyncBase):
-    def __init__(self, obj: BrowserTypeImpl):
-        super().__init__(obj)
-
     @property
     def name(self) -> str:
         """BrowserType.name
@@ -10875,9 +10806,6 @@ mapping.register(BrowserTypeImpl, BrowserType)
 
 
 class Playwright(AsyncBase):
-    def __init__(self, obj: PlaywrightImpl):
-        super().__init__(obj)
-
     @property
     def devices(self) -> typing.Dict:
         """Playwright.devices
@@ -10991,9 +10919,6 @@ mapping.register(PlaywrightImpl, Playwright)
 
 
 class Tracing(AsyncBase):
-    def __init__(self, obj: TracingImpl):
-        super().__init__(obj)
-
     async def start(
         self, *, name: str = None, snapshots: bool = None, screenshots: bool = None
     ) -> NoneType:
@@ -11095,9 +11020,6 @@ mapping.register(TracingImpl, Tracing)
 
 
 class Locator(AsyncBase):
-    def __init__(self, obj: LocatorImpl):
-        super().__init__(obj)
-
     @property
     def first(self) -> "Locator":
         """Locator.first

--- a/playwright/async_api/_generated.py
+++ b/playwright/async_api/_generated.py
@@ -10959,6 +10959,10 @@ class Playwright(AsyncBase):
         """
         return mapping.from_impl(self._impl_obj.webkit)
 
+    def __getitem__(self, value: str) -> "BrowserType":
+
+        return mapping.from_impl(self._impl_obj.__getitem__(value=value))
+
     def stop(self) -> NoneType:
         """Playwright.stop
 
@@ -10981,15 +10985,6 @@ class Playwright(AsyncBase):
         """
 
         return mapping.from_maybe_impl(self._impl_obj.stop())
-
-    def __getitem__(self, value: str) -> "BrowserType":
-        if value == "chromium":
-            return self.chromium
-        elif value == "firefox":
-            return self.firefox
-        elif value == "webkit":
-            return self.webkit
-        raise ValueError("Invalid browser " + value)
 
 
 mapping.register(PlaywrightImpl, Playwright)

--- a/playwright/sync_api/_generated.py
+++ b/playwright/sync_api/_generated.py
@@ -10889,6 +10889,10 @@ class Playwright(SyncBase):
         """
         return mapping.from_impl(self._impl_obj.webkit)
 
+    def __getitem__(self, value: str) -> "BrowserType":
+
+        return mapping.from_impl(self._impl_obj.__getitem__(value=value))
+
     def stop(self) -> NoneType:
         """Playwright.stop
 
@@ -10911,15 +10915,6 @@ class Playwright(SyncBase):
         """
 
         return mapping.from_maybe_impl(self._impl_obj.stop())
-
-    def __getitem__(self, value: str) -> "BrowserType":
-        if value == "chromium":
-            return self.chromium
-        elif value == "firefox":
-            return self.firefox
-        elif value == "webkit":
-            return self.webkit
-        raise ValueError("Invalid browser " + value)
 
 
 mapping.register(PlaywrightImpl, Playwright)

--- a/playwright/sync_api/_generated.py
+++ b/playwright/sync_api/_generated.py
@@ -76,9 +76,6 @@ NoneType = type(None)
 
 
 class Request(SyncBase):
-    def __init__(self, obj: RequestImpl):
-        super().__init__(obj)
-
     @property
     def url(self) -> str:
         """Request.url
@@ -339,9 +336,6 @@ mapping.register(RequestImpl, Request)
 
 
 class Response(SyncBase):
-    def __init__(self, obj: ResponseImpl):
-        super().__init__(obj)
-
     @property
     def url(self) -> str:
         """Response.url
@@ -542,9 +536,6 @@ mapping.register(ResponseImpl, Response)
 
 
 class Route(SyncBase):
-    def __init__(self, obj: RouteImpl):
-        super().__init__(obj)
-
     @property
     def request(self) -> "Request":
         """Route.request
@@ -698,9 +689,6 @@ mapping.register(RouteImpl, Route)
 
 
 class WebSocket(SyncBase):
-    def __init__(self, obj: WebSocketImpl):
-        super().__init__(obj)
-
     @property
     def url(self) -> str:
         """WebSocket.url
@@ -796,9 +784,6 @@ mapping.register(WebSocketImpl, WebSocket)
 
 
 class Keyboard(SyncBase):
-    def __init__(self, obj: KeyboardImpl):
-        super().__init__(obj)
-
     def down(self, key: str) -> NoneType:
         """Keyboard.down
 
@@ -951,9 +936,6 @@ mapping.register(KeyboardImpl, Keyboard)
 
 
 class Mouse(SyncBase):
-    def __init__(self, obj: MouseImpl):
-        super().__init__(obj)
-
     def move(self, x: float, y: float, *, steps: int = None) -> NoneType:
         """Mouse.move
 
@@ -1088,9 +1070,6 @@ mapping.register(MouseImpl, Mouse)
 
 
 class Touchscreen(SyncBase):
-    def __init__(self, obj: TouchscreenImpl):
-        super().__init__(obj)
-
     def tap(self, x: float, y: float) -> NoneType:
         """Touchscreen.tap
 
@@ -1111,9 +1090,6 @@ mapping.register(TouchscreenImpl, Touchscreen)
 
 
 class JSHandle(SyncBase):
-    def __init__(self, obj: JSHandleImpl):
-        super().__init__(obj)
-
     def evaluate(self, expression: str, arg: typing.Any = None) -> typing.Any:
         """JSHandle.evaluate
 
@@ -1277,9 +1253,6 @@ mapping.register(JSHandleImpl, JSHandle)
 
 
 class ElementHandle(JSHandle):
-    def __init__(self, obj: ElementHandleImpl):
-        super().__init__(obj)
-
     def as_element(self) -> typing.Optional["ElementHandle"]:
         """ElementHandle.as_element
 
@@ -2637,9 +2610,6 @@ mapping.register(ElementHandleImpl, ElementHandle)
 
 
 class Accessibility(SyncBase):
-    def __init__(self, obj: AccessibilityImpl):
-        super().__init__(obj)
-
     def snapshot(
         self, *, interesting_only: bool = None, root: "ElementHandle" = None
     ) -> typing.Optional[typing.Dict]:
@@ -2701,9 +2671,6 @@ mapping.register(AccessibilityImpl, Accessibility)
 
 
 class FileChooser(SyncBase):
-    def __init__(self, obj: FileChooserImpl):
-        super().__init__(obj)
-
     @property
     def page(self) -> "Page":
         """FileChooser.page
@@ -2784,9 +2751,6 @@ mapping.register(FileChooserImpl, FileChooser)
 
 
 class Frame(SyncBase):
-    def __init__(self, obj: FrameImpl):
-        super().__init__(obj)
-
     @property
     def page(self) -> "Page":
         """Frame.page
@@ -5010,9 +4974,6 @@ mapping.register(FrameImpl, Frame)
 
 
 class Worker(SyncBase):
-    def __init__(self, obj: WorkerImpl):
-        super().__init__(obj)
-
     @property
     def url(self) -> str:
         """Worker.url
@@ -5095,9 +5056,6 @@ mapping.register(WorkerImpl, Worker)
 
 
 class Selectors(SyncBase):
-    def __init__(self, obj: SelectorsImpl):
-        super().__init__(obj)
-
     def register(
         self,
         name: str,
@@ -5175,9 +5133,6 @@ mapping.register(SelectorsImpl, Selectors)
 
 
 class ConsoleMessage(SyncBase):
-    def __init__(self, obj: ConsoleMessageImpl):
-        super().__init__(obj)
-
     @property
     def type(self) -> str:
         """ConsoleMessage.type
@@ -5231,9 +5186,6 @@ mapping.register(ConsoleMessageImpl, ConsoleMessage)
 
 
 class Dialog(SyncBase):
-    def __init__(self, obj: DialogImpl):
-        super().__init__(obj)
-
     @property
     def type(self) -> str:
         """Dialog.type
@@ -5300,9 +5252,6 @@ mapping.register(DialogImpl, Dialog)
 
 
 class Download(SyncBase):
-    def __init__(self, obj: DownloadImpl):
-        super().__init__(obj)
-
     @property
     def page(self) -> "Page":
         """Download.page
@@ -5416,9 +5365,6 @@ mapping.register(DownloadImpl, Download)
 
 
 class Video(SyncBase):
-    def __init__(self, obj: VideoImpl):
-        super().__init__(obj)
-
     def path(self) -> pathlib.Path:
         """Video.path
 
@@ -5463,9 +5409,6 @@ mapping.register(VideoImpl, Video)
 
 
 class Page(SyncContextManager):
-    def __init__(self, obj: PageImpl):
-        super().__init__(obj)
-
     @property
     def accessibility(self) -> "Accessibility":
         """Page.accessibility
@@ -9016,9 +8959,6 @@ mapping.register(PageImpl, Page)
 
 
 class BrowserContext(SyncContextManager):
-    def __init__(self, obj: BrowserContextImpl):
-        super().__init__(obj)
-
     @property
     def pages(self) -> typing.List["Page"]:
         """BrowserContext.pages
@@ -9770,9 +9710,6 @@ mapping.register(BrowserContextImpl, BrowserContext)
 
 
 class CDPSession(SyncBase):
-    def __init__(self, obj: CDPSessionImpl):
-        super().__init__(obj)
-
     def send(self, method: str, params: typing.Dict = None) -> typing.Dict:
         """CDPSession.send
 
@@ -9811,9 +9748,6 @@ mapping.register(CDPSessionImpl, CDPSession)
 
 
 class Browser(SyncContextManager):
-    def __init__(self, obj: BrowserImpl):
-        super().__init__(obj)
-
     @property
     def contexts(self) -> typing.List["BrowserContext"]:
         """Browser.contexts
@@ -10315,9 +10249,6 @@ mapping.register(BrowserImpl, Browser)
 
 
 class BrowserType(SyncBase):
-    def __init__(self, obj: BrowserTypeImpl):
-        super().__init__(obj)
-
     @property
     def name(self) -> str:
         """BrowserType.name
@@ -10808,9 +10739,6 @@ mapping.register(BrowserTypeImpl, BrowserType)
 
 
 class Playwright(SyncBase):
-    def __init__(self, obj: PlaywrightImpl):
-        super().__init__(obj)
-
     @property
     def devices(self) -> typing.Dict:
         """Playwright.devices
@@ -10921,9 +10849,6 @@ mapping.register(PlaywrightImpl, Playwright)
 
 
 class Tracing(SyncBase):
-    def __init__(self, obj: TracingImpl):
-        super().__init__(obj)
-
     def start(
         self, *, name: str = None, snapshots: bool = None, screenshots: bool = None
     ) -> NoneType:
@@ -11021,9 +10946,6 @@ mapping.register(TracingImpl, Tracing)
 
 
 class Locator(SyncBase):
-    def __init__(self, obj: LocatorImpl):
-        super().__init__(obj)
-
     @property
     def first(self) -> "Locator":
         """Locator.first

--- a/scripts/generate_async_api.py
+++ b/scripts/generate_async_api.py
@@ -47,8 +47,6 @@ def generate(t: Any) -> None:
         base_sync_class = base_class
     print(f"class {class_name}({base_sync_class}):")
     print("")
-    print(f"    def __init__(self, obj: {class_name}Impl):")
-    print("        super().__init__(obj)")
     for [name, type] in get_type_hints(t, api_globals).items():
         print("")
         print("    @property")

--- a/scripts/generate_async_api.py
+++ b/scripts/generate_async_api.py
@@ -76,11 +76,13 @@ def generate(t: Any) -> None:
             prefix = "        return " + prefix + f"self._impl_obj.{name}"
             print(f"{prefix}{arguments(value, len(prefix))}{suffix}")
     for [name, value] in t.__dict__.items():
-        if (
-            not name.startswith("_")
-            and isinstance(value, FunctionType)
-            and "remove_listener" != name
-        ):
+        if isinstance(value, FunctionType) and "remove_listener" != name:
+            # List of dunder methods to allow without docs
+            allow_without_docs_methods = [
+                "__getitem__",
+            ]
+            if name.startswith("_") and name not in allow_without_docs_methods:
+                continue
             is_async = inspect.iscoroutinefunction(value)
             return_type_value = return_type(value)
             return_type_value = re.sub(r"\"([^\"]+)Impl\"", r"\1", return_type_value)
@@ -92,9 +94,11 @@ def generate(t: Any) -> None:
             print(
                 f"    {async_prefix}def {name}({signature(value, len(name) + 9)}) -> {return_type_value}:"
             )
-            documentation_provider.print_entry(
-                class_name, name, get_type_hints(value, api_globals)
-            )
+            # Allow dunder methods without docs
+            if name not in allow_without_docs_methods:
+                documentation_provider.print_entry(
+                    class_name, name, get_type_hints(value, api_globals)
+                )
             if "expect_" in name:
                 print("")
                 print(
@@ -115,19 +119,6 @@ def generate(t: Any) -> None:
                     f"""
         return {prefix}{arguments(value, len(prefix))}{suffix}"""
                 )
-    if class_name == "Playwright":
-        print(
-            """
-    def __getitem__(self, value: str) -> "BrowserType":
-        if value == "chromium":
-            return self.chromium
-        elif value == "firefox":
-            return self.firefox
-        elif value == "webkit":
-            return self.webkit
-        raise ValueError("Invalid browser "+value)
-            """
-        )
     print("")
     print(f"mapping.register({class_name}Impl, {class_name})")
 

--- a/scripts/generate_sync_api.py
+++ b/scripts/generate_sync_api.py
@@ -48,8 +48,6 @@ def generate(t: Any) -> None:
         base_sync_class = base_class
     print(f"class {class_name}({base_sync_class}):")
     print("")
-    print(f"    def __init__(self, obj: {class_name}Impl):")
-    print("        super().__init__(obj)")
     for [name, type] in get_type_hints(t, api_globals).items():
         print("")
         print("    @property")

--- a/scripts/generate_sync_api.py
+++ b/scripts/generate_sync_api.py
@@ -77,11 +77,13 @@ def generate(t: Any) -> None:
             prefix = "        return " + prefix + f"self._impl_obj.{name}"
             print(f"{prefix}{arguments(value, len(prefix))}{suffix}")
     for [name, value] in t.__dict__.items():
-        if (
-            not name.startswith("_")
-            and isinstance(value, FunctionType)
-            and "remove_listener" != name
-        ):
+        if isinstance(value, FunctionType) and "remove_listener" != name:
+            # List of dunder methods to allow without docs
+            allow_without_docs_methods = [
+                "__getitem__",
+            ]
+            if name.startswith("_") and name not in allow_without_docs_methods:
+                continue
             is_async = inspect.iscoroutinefunction(value)
             return_type_value = return_type(value)
             return_type_value = re.sub(r"\"([^\"]+)Impl\"", r"\1", return_type_value)
@@ -89,9 +91,11 @@ def generate(t: Any) -> None:
             print(
                 f"    def {name}({signature(value, len(name) + 9)}) -> {return_type_value}:"
             )
-            documentation_provider.print_entry(
-                class_name, name, get_type_hints(value, api_globals)
-            )
+            # Allow dunder methods without docs
+            if name not in allow_without_docs_methods:
+                documentation_provider.print_entry(
+                    class_name, name, get_type_hints(value, api_globals)
+                )
             if "expect_" in name:
                 print(
                     f"        return EventContextManager(self, self._impl_obj.{name}({arguments(value, 12)}).future)"
@@ -114,19 +118,6 @@ def generate(t: Any) -> None:
                     f"""
         return {prefix}{arguments(value, len(prefix))}{suffix}"""
                 )
-    if class_name == "Playwright":
-        print(
-            """
-    def __getitem__(self, value: str) -> "BrowserType":
-        if value == "chromium":
-            return self.chromium
-        elif value == "firefox":
-            return self.firefox
-        elif value == "webkit":
-            return self.webkit
-        raise ValueError("Invalid browser "+value)
-            """
-        )
     print("")
     print(f"mapping.register({class_name}Impl, {class_name})")
 

--- a/tests/common/test_threads.py
+++ b/tests/common/test_threads.py
@@ -24,7 +24,7 @@ def test_running_in_thread(browser_name: str, launch_arguments: Dict) -> None:
     class TestThread(threading.Thread):
         def run(self) -> None:
             with sync_playwright() as playwright:
-                browser = getattr(playwright, browser_name).launch(**launch_arguments)
+                browser = playwright[browser_name].launch(**launch_arguments)
                 # This should not throw ^^.
                 browser.new_page()
                 browser.close()


### PR DESCRIPTION
Cleans up special handling for `__getitem__` as there is now a list of allowed methods without docs and makes it more maintainable as more dunder methods would be added.