### PR TITLE
chore: use requests to download drivers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     rev: v0.910-1
     hooks:
       - id: mypy
-        additional_dependencies: [types-pyOpenSSL==20.0.6]
+        additional_dependencies: [types-pyOpenSSL==20.0.6, types-requests==2.25.11]
   - repo: https://github.com/pycqa/flake8
     rev: 4.0.1
     hooks:

--- a/meta.yaml
+++ b/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - python
     - wheel
     - pip
-    - curl
+    - requests
     - setuptools_scm
   run:
     - python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools-scm==6.3.2", "wheel==0.37.0", "auditwheel==5.0.0"]
+requires = ["setuptools-scm==6.3.2", "wheel==0.37.0", "auditwheel==5.0.0", "requests==2.26.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]

--- a/setup.py
+++ b/setup.py
@@ -16,12 +16,12 @@ import glob
 import os
 import platform
 import shutil
-import subprocess
 import sys
 import zipfile
 from pathlib import Path
 from typing import Dict, List
 
+import requests
 from setuptools import find_packages, setup
 
 try:
@@ -55,8 +55,8 @@ def download_driver(zip_name: str) -> None:
         url = url + "next/"
     url = url + zip_file
     print(f"Fetching {url}")
-    # Don't replace this with urllib - Python won't have certificates to do SSL on all platforms.
-    subprocess.check_call(["curl", url, "-o", "driver/" + zip_file])
+    with open(f"driver/{zip_file}", "wb") as f:
+        f.write(requests.get(url).content)
 
 
 class PlaywrightBDistWheelCommand(BDistWheelCommand):


### PR DESCRIPTION
This avoids the use of `curl` which is not available on all platforms by default., on windows cmd.exe it is not available 