### PR TITLE
chore: smart detection for a driver download url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,14 @@ class PlaywrightBDistWheelCommand(BDistWheelCommand):
             for arch in platform:
                 zip_file = f"playwright-{driver_version}-{arch['zip_name']}.zip"
                 if not os.path.exists("driver/" + zip_file):
-                    url = f"https://playwright.azureedge.net/builds/driver/next/{zip_file}"
+                    url = "https://playwright.azureedge.net/builds/driver/"
+                    if (
+                        "-alpha" in driver_version
+                        or "-beta" in driver_version
+                        or "-next" in driver_version
+                    ):
+                        url = url + "next/"
+                    url = url + zip_file
                     print(f"Fetching {url}")
                     # Don't replace this with urllib - Python won't have certificates to do SSL on all platforms.
                     subprocess.check_call(["curl", url, "-o", "driver/" + zip_file])


### PR DESCRIPTION
Since Nov 16, 2021, we have the following conventions:

- Drivers published from tip-of-tree have an `-alpha` version and are
  stored at `/next` subfolder on Azure Storage.
- Drivers auto-published for each commit of the release branch have a `-beta` version and are
  stored at `/next` subfolder on Azure Storage.
- Drivers published due to a release might have `-rc` as part of the
  version, and are stored in root subfolder on Azure Storage.

We no longer have driver versions that include "next" as part of the
version. I kept it for backwards compatibility.