### PR TITLE
Fixing a pyee DeprecationWarning

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -24,7 +24,7 @@ requirements:
   run:
     - python
     - greenlet >=0.4
-    - pyee >=8.0.1
+    - pyee >=9.0.0
     - websockets >=8.1
     - typing_extensions # [py<39]
 test:

--- a/playwright/_impl/_connection.py
+++ b/playwright/_impl/_connection.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 from greenlet import greenlet
-from pyee import AsyncIOEventEmitter
+from pyee.asyncio import AsyncIOEventEmitter
 
 from playwright._impl._helper import ParsedMessagePayload, parse_error
 from playwright._impl._transport import Transport

--- a/playwright/_impl/_transport.py
+++ b/playwright/_impl/_transport.py
@@ -24,7 +24,7 @@ from typing import Callable, Dict, Optional, Union
 
 import websockets
 import websockets.exceptions
-from pyee import AsyncIOEventEmitter
+from pyee.asyncio import AsyncIOEventEmitter
 from websockets.client import connect as websocket_connect
 
 from playwright._impl._api_types import Error

--- a/setup.py
+++ b/setup.py
@@ -210,7 +210,7 @@ setup(
     install_requires=[
         "websockets>=8.1",
         "greenlet>=1.0.0",
-        "pyee>=8.0.1",
+        "pyee>=9.0.0",
         "typing-extensions;python_version<='3.8'",
     ],
     classifiers=[


### PR DESCRIPTION
pyee.AsyncIOEventEmitter was moved to pyee.asyncio.AsyncIOEventEmitter, so this PR just fixes two imports