### PR TITLE
Import AsyncIOEventEmitter from pyee.asyncio on pyee >= 9

### DIFF
--- a/playwright/_impl/_connection.py
+++ b/playwright/_impl/_connection.py
@@ -19,7 +19,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 from greenlet import greenlet
-from pyee import AsyncIOEventEmitter
+
+try:
+    from pyee.asyncio import AsyncIOEventEmitter
+except ImportError:
+    # pyee < 9.0.0
+    from pyee import AsyncIOEventEmitter
 
 from playwright._impl._helper import ParsedMessagePayload, parse_error
 from playwright._impl._transport import Transport

--- a/playwright/_impl/_transport.py
+++ b/playwright/_impl/_transport.py
@@ -24,7 +24,13 @@ from typing import Callable, Dict, Optional, Union
 
 import websockets
 import websockets.exceptions
-from pyee import AsyncIOEventEmitter
+
+try:
+    from pyee.asyncio import AsyncIOEventEmitter
+except ImportError:
+    # pyee < 9.0.0
+    from pyee import AsyncIOEventEmitter
+
 from websockets.client import connect as websocket_connect
 
 from playwright._impl._api_types import Error


### PR DESCRIPTION
`pyee` 9.0.0 has moved some interfaces into submodules. Importing `AsyncIOEventEmitter` directly from `pyee` results in a DeprecationWarning now.