### PR TITLE
chore: fix deprecation warning

### DIFF
--- a/playwright/_impl/_network.py
+++ b/playwright/_impl/_network.py
@@ -268,7 +268,7 @@ class Route(ChannelOwner):
             # Note that page could be missing when routing popup's initial request that
             # does not have a Page initialized just yet.
             await asyncio.wait(
-                [future, page._closed_or_crashed_future],
+                [asyncio.create_task(future), page._closed_or_crashed_future],
                 return_when=asyncio.FIRST_COMPLETED,
             )
         else:


### PR DESCRIPTION
Fixes:

```
  /Users/max/development/playwright-python/playwright/_impl/_network.py:270: DeprecationWarning: The explicit passing of coroutine objects to asyncio.wait() is deprecated since Python 3.8, and scheduled for removal in Python 3.11.
    await asyncio.wait(
```