### PR TITLE
make TimeoutError Inherit from builtin timeout error

### DIFF
--- a/playwright/_impl/_api_types.py
+++ b/playwright/_impl/_api_types.py
@@ -27,5 +27,5 @@ class Error(Exception):
         super().__init__(message)
 
 
-class TimeoutError(Error):
+class TimeoutError(Error, TimeoutError):
     pass


### PR DESCRIPTION
Making _api_types TimeoutError Inherit from builtin timeout error for better readability in exception handling