### PR TITLE
fix: handle pyinstaller app with no stderr (#1148)

### DIFF
--- a/playwright/_impl/_transport.py
+++ b/playwright/_impl/_transport.py
@@ -37,7 +37,7 @@ def _get_stderr_fileno() -> Optional[int]:
     try:
         # when using pythonw, sys.stderr is None.
         # when Pyinstaller is used, there is no closed attribute because Pyinstaller monkey-patches it with a NullWriter class
-        if sys.stderr is None or not hasattr(sys.stderr, 'closed'):
+        if sys.stderr is None or not hasattr(sys.stderr, "closed"):
             return None
         if sys.stderr.closed:
             return None

--- a/playwright/_impl/_transport.py
+++ b/playwright/_impl/_transport.py
@@ -35,7 +35,8 @@ from playwright._impl._helper import ParsedMessagePayload
 # Sourced from: https://github.com/pytest-dev/pytest/blob/da01ee0a4bb0af780167ecd228ab3ad249511302/src/_pytest/faulthandler.py#L69-L77
 def _get_stderr_fileno() -> Optional[int]:
     try:
-        # handle pythonw, pyinstaller: no stderr
+        # when using pythonw, sys.stderr is None.
+        # when Pyinstaller is used, there is no closed attribute because Pyinstaller monkey-patches it with a NullWriter class
         if sys.stderr is None or not hasattr(sys.stderr, 'closed'):
             return None
         if sys.stderr.closed:

--- a/playwright/_impl/_transport.py
+++ b/playwright/_impl/_transport.py
@@ -34,12 +34,15 @@ from playwright._impl._helper import ParsedMessagePayload
 
 # Sourced from: https://github.com/pytest-dev/pytest/blob/da01ee0a4bb0af780167ecd228ab3ad249511302/src/_pytest/faulthandler.py#L69-L77
 def _get_stderr_fileno() -> Optional[int]:
-    if sys.stderr.closed:
-        return None
-
     try:
+        if sys.stderr.closed:
+            return None
+
         return sys.stderr.fileno()
     except (AttributeError, io.UnsupportedOperation):
+        # pyinstaller apps may not have stderr
+        if not hasattr(sys.stderr, 'closed'):
+            return None
         # pytest-xdist monkeypatches sys.stderr with an object that is not an actual file.
         # https://docs.python.org/3/library/faulthandler.html#issue-with-file-descriptors
         # This is potentially dangerous, but the best we can do.

--- a/playwright/_impl/_transport.py
+++ b/playwright/_impl/_transport.py
@@ -35,14 +35,14 @@ from playwright._impl._helper import ParsedMessagePayload
 # Sourced from: https://github.com/pytest-dev/pytest/blob/da01ee0a4bb0af780167ecd228ab3ad249511302/src/_pytest/faulthandler.py#L69-L77
 def _get_stderr_fileno() -> Optional[int]:
     try:
+        # handle pythonw, pyinstaller: no stderr
+        if sys.stderr is None or not hasattr(sys.stderr, 'closed'):
+            return None
         if sys.stderr.closed:
             return None
 
         return sys.stderr.fileno()
     except (AttributeError, io.UnsupportedOperation):
-        # pyinstaller apps may not have stderr
-        if not hasattr(sys.stderr, 'closed'):
-            return None
         # pytest-xdist monkeypatches sys.stderr with an object that is not an actual file.
         # https://docs.python.org/3/library/faulthandler.html#issue-with-file-descriptors
         # This is potentially dangerous, but the best we can do.


### PR DESCRIPTION
Proposed fix for issue #1148.

When playwright is running in an application which was packaged by pyinstaller, `stderr` can be of type `NullWriter` which has no attribute `closed`.  Moved access to the attribute `closed` inside the following `try` clause to handle the `AttributeError`.
Re-run unit tests after the change an no additional failures seen.