### PR TITLE
fix: ignore utf-8 decoding errors on APIResponsee

### DIFF
--- a/playwright/_impl/_fetch.py
+++ b/playwright/_impl/_fetch.py
@@ -390,7 +390,7 @@ class APIResponse:
 
     async def text(self) -> str:
         content = await self.body()
-        return content.decode()
+        return content.decode("utf-8", "ignore")
 
     async def json(self) -> Any:
         content = await self.text()


### PR DESCRIPTION
https://github.com/microsoft/playwright-python/issues/1208