### PR TITLE
fix: forward cancelled tasks to the inner task

### DIFF
--- a/tests/async/test_asyncio.py
+++ b/tests/async/test_asyncio.py
@@ -12,33 +12,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
-import contextlib
+import gc
+from typing import Dict
+
+import pytest
 
 from playwright.async_api import async_playwright
 
 
-def test_should_cancel_underlying_calls(browser_name: str):
+async def test_should_cancel_underlying_protocol_calls(
+    browser_name: str, launch_arguments: Dict
+):
     handler_exception = None
 
-    async def main():
-        loop = asyncio.get_running_loop()
+    def exception_handlerdler(loop, context) -> None:
+        nonlocal handler_exception
+        handler_exception = context["exception"]
 
-        def handler(loop, context):
-            nonlocal handler_exception
-            handler_exception = context["exception"]
+    asyncio.get_running_loop().set_exception_handler(exception_handlerdler)
 
-        async with async_playwright() as p:
-            loop.set_exception_handler(handler)
-            browser = await p[browser_name].launch()
-            page = await browser.new_page()
-            task = asyncio.create_task(page.wait_for_selector("will-never-find"))
-            # make sure that the wait_for_selector message was sent to the server (driver)
-            await asyncio.sleep(1)
-            task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await task
-            await browser.close()
+    async with async_playwright() as p:
+        browser = await p[browser_name].launch(**launch_arguments)
+        page = await browser.new_page()
+        task = asyncio.create_task(page.wait_for_selector("will-never-find"))
+        # make sure that the wait_for_selector message was sent to the server (driver)
+        await asyncio.sleep(0.1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        await browser.close()
 
-    asyncio.run(main())
+    # The actual 'Future exception was never retrieved' is logged inside the Future destructor (__del__).
+    gc.collect()
 
     assert handler_exception is None
+
+    asyncio.get_running_loop().set_exception_handler(None)

--- a/tests/async/test_asyncio.py
+++ b/tests/async/test_asyncio.py
@@ -1,0 +1,44 @@
+# Copyright (c) Microsoft Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import asyncio
+import contextlib
+
+from playwright.async_api import async_playwright
+
+
+def test_should_cancel_underlying_calls(browser_name: str):
+    handler_exception = None
+
+    async def main():
+        loop = asyncio.get_running_loop()
+
+        def handler(loop, context):
+            nonlocal handler_exception
+            handler_exception = context["exception"]
+
+        async with async_playwright() as p:
+            loop.set_exception_handler(handler)
+            browser = await p[browser_name].launch()
+            page = await browser.new_page()
+            task = asyncio.create_task(page.wait_for_selector("will-never-find"))
+            # make sure that the wait_for_selector message was sent to the server (driver)
+            await asyncio.sleep(1)
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            await browser.close()
+
+    asyncio.run(main())
+
+    assert handler_exception is None


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-python/issues/1210

Imagine Page.waitForSelector, if a user cancels one of these api calls, the internal protocol calls are still pending and don't get canceled. When one of these errors out it setts the exception and it ends up in `'Future exception was never retrieved'` (asyncio warning). I thought about two ways so far of fixing it:

a) if the outer task gets canceled "propagate" the canceled signal down to the protocol api call, see here for an impl: https://github.com/microsoft/playwright-python/pull/1236/commits/2f8041c0754c96bbff4a23cc10ae2cc4c22ab572
b) store the "outer task" inside the ProtocolCallback class and check when receiving the error if it was canceled: https://github.com/microsoft/playwright-python/pull/1236/files

Not sure whats better! b) is definitely less code.
 
The failing lint is unrelated, it gets fixed in https://github.com/microsoft/playwright-python/pull/1237.