### PR TITLE
chore: fix proxy types and don't allow None

### DIFF
--- a/playwright/_impl/_api_structures.py
+++ b/playwright/_impl/_api_structures.py
@@ -93,9 +93,9 @@ class Position(TypedDict):
 
 class ProxySettings(TypedDict, total=False):
     server: str
-    bypass: Optional[str]
-    username: Optional[str]
-    password: Optional[str]
+    bypass: str
+    username: str
+    password: str
 
 
 class StorageState(TypedDict, total=False):


### PR DESCRIPTION
`total=False` implies that a property is either allowed to be defined or not. Having additionally `Optional[...]` on some was not correct documentation wise since we don't filter nested dict `None` values out.

Fixes https://github.com/microsoft/playwright-python/issues/1269