### PR TITLE
test: fix Docker tests

### DIFF
--- a/.github/workflows/test_docker.yml
+++ b/.github/workflows/test_docker.yml
@@ -36,6 +36,8 @@ jobs:
     - name: Test
       run: |
         CONTAINER_ID="$(docker run --rm -v $(pwd):/root/playwright --name playwright-docker-test --workdir /root/playwright/ -d -t playwright-python:localbuild-focal /bin/bash)"
+        # Fix permissions for Git inside the container
+        docker exec "${CONTAINER_ID}" chown -R root:root /root/playwright
         docker exec "${CONTAINER_ID}" pip install -r local-requirements.txt
         docker exec "${CONTAINER_ID}" pip install -e .
         docker exec "${CONTAINER_ID}" python setup.py bdist_wheel


### PR DESCRIPTION
`/root/playwright` inside the Docker container is owned by `1001:121` (`runner:docker`) which is != `root:root` thats why we get the following error message:

```
root@4d691546890c:~/playwright# git log
fatal: unsafe repository ('/root/playwright' is owned by someone else)
To add an exception for this directory, call:

        git config --global --add safe.directory /root/playwright
```

The folder was created by the checkout action from GitHub Actions, which uses the GitHub Action default user for that.

Relates to https://github.com/git/git/commit/8959555cee7ec045958f9b6dd62e541affb7e7d9

cc/FYI @dscho