### PR TITLE
chore: remove layout locators, roll to 1.22.0

### DIFF
--- a/playwright/_impl/_frame.py
+++ b/playwright/_impl/_frame.py
@@ -499,27 +499,9 @@ class Frame(ChannelOwner):
         await self._channel.send("fill", locals_to_params(locals()))
 
     def locator(
-        self,
-        selector: str,
-        has_text: Union[str, Pattern] = None,
-        has: Locator = None,
-        left_of: "Locator" = None,
-        right_of: "Locator" = None,
-        above: "Locator" = None,
-        below: "Locator" = None,
-        near: "Locator" = None,
+        self, selector: str, has_text: Union[str, Pattern] = None, has: Locator = None
     ) -> Locator:
-        return Locator(
-            self,
-            selector,
-            has_text=has_text,
-            has=has,
-            left_of=left_of,
-            right_of=right_of,
-            above=above,
-            below=below,
-            near=near,
-        )
+        return Locator(self, selector, has_text=has_text, has=has)
 
     def frame_locator(self, selector: str) -> FrameLocator:
         return FrameLocator(self, selector)

--- a/playwright/_impl/_locator.py
+++ b/playwright/_impl/_locator.py
@@ -26,7 +26,6 @@ from typing import (
     Pattern,
     TypeVar,
     Union,
-    cast,
 )
 
 from playwright._impl._api_structures import (
@@ -67,13 +66,7 @@ class Locator:
         selector: str,
         has_text: Union[str, Pattern] = None,
         has: "Locator" = None,
-        left_of: "Locator" = None,
-        right_of: "Locator" = None,
-        above: "Locator" = None,
-        below: "Locator" = None,
-        near: "Locator" = None,
     ) -> None:
-        _params = locals()
         self._frame = frame
         self._selector = selector
         self._loop = frame._loop
@@ -88,18 +81,10 @@ class Locator:
                 escaped = escape_with_quotes(has_text, '"')
                 self._selector += f" >> :scope:has-text({escaped})"
 
-        for inner in ["has", "left_of", "right_of", "above", "below", "near"]:
-            locator: Optional["Locator"] = cast("Locator", _params.get(inner))
-            if not locator:
-                continue
-            if locator._frame != frame:
-                raise Error(f'Inner "{inner}" locator must belong to the same frame.')
-            engine_name = inner
-            if engine_name == "left_of":
-                engine_name = "left-of"
-            elif engine_name == "right_of":
-                engine_name = "right-of"
-            self._selector += f" >> {engine_name}=" + json.dumps(locator._selector)
+        if has:
+            if has._frame != frame:
+                raise Error('Inner "has" locator must belong to the same frame.')
+            self._selector += " >> has=" + json.dumps(has._selector)
 
     def __repr__(self) -> str:
         return f"<Locator frame={self._frame!r} selector={self._selector!r}>"
@@ -215,22 +200,12 @@ class Locator:
         selector: str,
         has_text: Union[str, Pattern] = None,
         has: "Locator" = None,
-        left_of: "Locator" = None,
-        right_of: "Locator" = None,
-        above: "Locator" = None,
-        below: "Locator" = None,
-        near: "Locator" = None,
     ) -> "Locator":
         return Locator(
             self._frame,
             f"{self._selector} >> {selector}",
             has_text=has_text,
             has=has,
-            left_of=left_of,
-            right_of=right_of,
-            above=above,
-            below=below,
-            near=near,
         )
 
     def frame_locator(self, selector: str) -> "FrameLocator":
@@ -265,22 +240,12 @@ class Locator:
         self,
         has_text: Union[str, Pattern] = None,
         has: "Locator" = None,
-        left_of: "Locator" = None,
-        right_of: "Locator" = None,
-        above: "Locator" = None,
-        below: "Locator" = None,
-        near: "Locator" = None,
     ) -> "Locator":
         return Locator(
             self._frame,
             self._selector,
             has_text=has_text,
             has=has,
-            left_of=left_of,
-            right_of=right_of,
-            above=above,
-            below=below,
-            near=near,
         )
 
     async def focus(self, timeout: float = None) -> None:
@@ -612,26 +577,13 @@ class FrameLocator:
         self._frame_selector = frame_selector
 
     def locator(
-        self,
-        selector: str,
-        has_text: Union[str, Pattern] = None,
-        has: "Locator" = None,
-        left_of: "Locator" = None,
-        right_of: "Locator" = None,
-        above: "Locator" = None,
-        below: "Locator" = None,
-        near: "Locator" = None,
+        self, selector: str, has_text: Union[str, Pattern] = None, has: "Locator" = None
     ) -> Locator:
         return Locator(
             self._frame,
             f"{self._frame_selector} >> control=enter-frame >> {selector}",
             has_text=has_text,
             has=has,
-            left_of=left_of,
-            right_of=right_of,
-            above=above,
-            below=below,
-            near=near,
         )
 
     def frame_locator(self, selector: str) -> "FrameLocator":

--- a/playwright/_impl/_page.py
+++ b/playwright/_impl/_page.py
@@ -712,22 +712,8 @@ class Page(ChannelOwner):
         selector: str,
         has_text: Union[str, Pattern] = None,
         has: "Locator" = None,
-        left_of: "Locator" = None,
-        right_of: "Locator" = None,
-        above: "Locator" = None,
-        below: "Locator" = None,
-        near: "Locator" = None,
     ) -> "Locator":
-        return self._main_frame.locator(
-            selector,
-            has_text=has_text,
-            has=has,
-            left_of=left_of,
-            right_of=right_of,
-            above=above,
-            below=below,
-            near=near,
-        )
+        return self._main_frame.locator(selector, has_text=has_text, has=has)
 
     def frame_locator(self, selector: str) -> "FrameLocator":
         return self.main_frame.frame_locator(selector)

--- a/playwright/async_api/_generated.py
+++ b/playwright/async_api/_generated.py
@@ -4356,12 +4356,7 @@ class Frame(AsyncBase):
         selector: str,
         *,
         has_text: typing.Union[str, typing.Pattern] = None,
-        has: "Locator" = None,
-        left_of: "Locator" = None,
-        right_of: "Locator" = None,
-        above: "Locator" = None,
-        below: "Locator" = None,
-        near: "Locator" = None
+        has: "Locator" = None
     ) -> "Locator":
         """Frame.locator
 
@@ -4384,36 +4379,6 @@ class Frame(AsyncBase):
             For example, `article` that has `text=Playwright` matches `<article><div>Playwright</div></article>`.
 
             Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        left_of : Union[Locator, NoneType]
-            Matches elements that are to the left of any element matching the inner locator, at any vertical position. Inner locator
-            is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        right_of : Union[Locator, NoneType]
-            Matches elements that are to the right of any element matching the inner locator, at any vertical position. Inner
-            locator is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        above : Union[Locator, NoneType]
-            Matches elements that are above any of the elements matching the inner locator, at any horizontal position. Inner
-            locator is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        below : Union[Locator, NoneType]
-            Matches elements that are below any of the elements matching the inner locator, at any horizontal position. Inner
-            locator is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        near : Union[Locator, NoneType]
-            Matches elements that are near (<= 50 css pixels) any of the elements matching the inner locator. Inner locator is
-            queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
 
         Returns
         -------
@@ -4422,14 +4387,7 @@ class Frame(AsyncBase):
 
         return mapping.from_impl(
             self._impl_obj.locator(
-                selector=selector,
-                has_text=has_text,
-                has=has._impl_obj if has else None,
-                left_of=left_of._impl_obj if left_of else None,
-                right_of=right_of._impl_obj if right_of else None,
-                above=above._impl_obj if above else None,
-                below=below._impl_obj if below else None,
-                near=near._impl_obj if near else None,
+                selector=selector, has_text=has_text, has=has._impl_obj if has else None
             )
         )
 
@@ -5384,12 +5342,7 @@ class FrameLocator(AsyncBase):
         selector: str,
         *,
         has_text: typing.Union[str, typing.Pattern] = None,
-        has: "Locator" = None,
-        left_of: "Locator" = None,
-        right_of: "Locator" = None,
-        above: "Locator" = None,
-        below: "Locator" = None,
-        near: "Locator" = None
+        has: "Locator" = None
     ) -> "Locator":
         """FrameLocator.locator
 
@@ -5408,36 +5361,6 @@ class FrameLocator(AsyncBase):
             For example, `article` that has `text=Playwright` matches `<article><div>Playwright</div></article>`.
 
             Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        left_of : Union[Locator, NoneType]
-            Matches elements that are to the left of any element matching the inner locator, at any vertical position. Inner locator
-            is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        right_of : Union[Locator, NoneType]
-            Matches elements that are to the right of any element matching the inner locator, at any vertical position. Inner
-            locator is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        above : Union[Locator, NoneType]
-            Matches elements that are above any of the elements matching the inner locator, at any horizontal position. Inner
-            locator is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        below : Union[Locator, NoneType]
-            Matches elements that are below any of the elements matching the inner locator, at any horizontal position. Inner
-            locator is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        near : Union[Locator, NoneType]
-            Matches elements that are near (<= 50 css pixels) any of the elements matching the inner locator. Inner locator is
-            queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
 
         Returns
         -------
@@ -5446,14 +5369,7 @@ class FrameLocator(AsyncBase):
 
         return mapping.from_impl(
             self._impl_obj.locator(
-                selector=selector,
-                has_text=has_text,
-                has=has._impl_obj if has else None,
-                left_of=left_of._impl_obj if left_of else None,
-                right_of=right_of._impl_obj if right_of else None,
-                above=above._impl_obj if above else None,
-                below=below._impl_obj if below else None,
-                near=near._impl_obj if near else None,
+                selector=selector, has_text=has_text, has=has._impl_obj if has else None
             )
         )
 
@@ -8640,12 +8556,7 @@ class Page(AsyncContextManager):
         selector: str,
         *,
         has_text: typing.Union[str, typing.Pattern] = None,
-        has: "Locator" = None,
-        left_of: "Locator" = None,
-        right_of: "Locator" = None,
-        above: "Locator" = None,
-        below: "Locator" = None,
-        near: "Locator" = None
+        has: "Locator" = None
     ) -> "Locator":
         """Page.locator
 
@@ -8670,36 +8581,6 @@ class Page(AsyncContextManager):
             For example, `article` that has `text=Playwright` matches `<article><div>Playwright</div></article>`.
 
             Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        left_of : Union[Locator, NoneType]
-            Matches elements that are to the left of any element matching the inner locator, at any vertical position. Inner locator
-            is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        right_of : Union[Locator, NoneType]
-            Matches elements that are to the right of any element matching the inner locator, at any vertical position. Inner
-            locator is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        above : Union[Locator, NoneType]
-            Matches elements that are above any of the elements matching the inner locator, at any horizontal position. Inner
-            locator is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        below : Union[Locator, NoneType]
-            Matches elements that are below any of the elements matching the inner locator, at any horizontal position. Inner
-            locator is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        near : Union[Locator, NoneType]
-            Matches elements that are near (<= 50 css pixels) any of the elements matching the inner locator. Inner locator is
-            queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
 
         Returns
         -------
@@ -8708,14 +8589,7 @@ class Page(AsyncContextManager):
 
         return mapping.from_impl(
             self._impl_obj.locator(
-                selector=selector,
-                has_text=has_text,
-                has=has._impl_obj if has else None,
-                left_of=left_of._impl_obj if left_of else None,
-                right_of=right_of._impl_obj if right_of else None,
-                above=above._impl_obj if above else None,
-                below=below._impl_obj if below else None,
-                near=near._impl_obj if near else None,
+                selector=selector, has_text=has_text, has=has._impl_obj if has else None
             )
         )
 
@@ -13029,12 +12903,7 @@ class Locator(AsyncBase):
         selector: str,
         *,
         has_text: typing.Union[str, typing.Pattern] = None,
-        has: "Locator" = None,
-        left_of: "Locator" = None,
-        right_of: "Locator" = None,
-        above: "Locator" = None,
-        below: "Locator" = None,
-        near: "Locator" = None
+        has: "Locator" = None
     ) -> "Locator":
         """Locator.locator
 
@@ -13054,36 +12923,6 @@ class Locator(AsyncBase):
             For example, `article` that has `text=Playwright` matches `<article><div>Playwright</div></article>`.
 
             Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        left_of : Union[Locator, NoneType]
-            Matches elements that are to the left of any element matching the inner locator, at any vertical position. Inner locator
-            is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        right_of : Union[Locator, NoneType]
-            Matches elements that are to the right of any element matching the inner locator, at any vertical position. Inner
-            locator is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        above : Union[Locator, NoneType]
-            Matches elements that are above any of the elements matching the inner locator, at any horizontal position. Inner
-            locator is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        below : Union[Locator, NoneType]
-            Matches elements that are below any of the elements matching the inner locator, at any horizontal position. Inner
-            locator is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        near : Union[Locator, NoneType]
-            Matches elements that are near (<= 50 css pixels) any of the elements matching the inner locator. Inner locator is
-            queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
 
         Returns
         -------
@@ -13092,14 +12931,7 @@ class Locator(AsyncBase):
 
         return mapping.from_impl(
             self._impl_obj.locator(
-                selector=selector,
-                has_text=has_text,
-                has=has._impl_obj if has else None,
-                left_of=left_of._impl_obj if left_of else None,
-                right_of=right_of._impl_obj if right_of else None,
-                above=above._impl_obj if above else None,
-                below=below._impl_obj if below else None,
-                near=near._impl_obj if near else None,
+                selector=selector, has_text=has_text, has=has._impl_obj if has else None
             )
         )
 
@@ -13185,12 +13017,7 @@ class Locator(AsyncBase):
         self,
         *,
         has_text: typing.Union[str, typing.Pattern] = None,
-        has: "Locator" = None,
-        left_of: "Locator" = None,
-        right_of: "Locator" = None,
-        above: "Locator" = None,
-        below: "Locator" = None,
-        near: "Locator" = None
+        has: "Locator" = None
     ) -> "Locator":
         """Locator.filter
 
@@ -13207,36 +13034,6 @@ class Locator(AsyncBase):
             For example, `article` that has `text=Playwright` matches `<article><div>Playwright</div></article>`.
 
             Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        left_of : Union[Locator, NoneType]
-            Matches elements that are to the left of any element matching the inner locator, at any vertical position. Inner locator
-            is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        right_of : Union[Locator, NoneType]
-            Matches elements that are to the right of any element matching the inner locator, at any vertical position. Inner
-            locator is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        above : Union[Locator, NoneType]
-            Matches elements that are above any of the elements matching the inner locator, at any horizontal position. Inner
-            locator is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        below : Union[Locator, NoneType]
-            Matches elements that are below any of the elements matching the inner locator, at any horizontal position. Inner
-            locator is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        near : Union[Locator, NoneType]
-            Matches elements that are near (<= 50 css pixels) any of the elements matching the inner locator. Inner locator is
-            queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
 
         Returns
         -------
@@ -13244,15 +13041,7 @@ class Locator(AsyncBase):
         """
 
         return mapping.from_impl(
-            self._impl_obj.filter(
-                has_text=has_text,
-                has=has._impl_obj if has else None,
-                left_of=left_of._impl_obj if left_of else None,
-                right_of=right_of._impl_obj if right_of else None,
-                above=above._impl_obj if above else None,
-                below=below._impl_obj if below else None,
-                near=near._impl_obj if near else None,
-            )
+            self._impl_obj.filter(has_text=has_text, has=has._impl_obj if has else None)
         )
 
     async def focus(self, *, timeout: float = None) -> NoneType:

--- a/playwright/sync_api/_generated.py
+++ b/playwright/sync_api/_generated.py
@@ -4300,12 +4300,7 @@ class Frame(SyncBase):
         selector: str,
         *,
         has_text: typing.Union[str, typing.Pattern] = None,
-        has: "Locator" = None,
-        left_of: "Locator" = None,
-        right_of: "Locator" = None,
-        above: "Locator" = None,
-        below: "Locator" = None,
-        near: "Locator" = None
+        has: "Locator" = None
     ) -> "Locator":
         """Frame.locator
 
@@ -4328,36 +4323,6 @@ class Frame(SyncBase):
             For example, `article` that has `text=Playwright` matches `<article><div>Playwright</div></article>`.
 
             Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        left_of : Union[Locator, NoneType]
-            Matches elements that are to the left of any element matching the inner locator, at any vertical position. Inner locator
-            is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        right_of : Union[Locator, NoneType]
-            Matches elements that are to the right of any element matching the inner locator, at any vertical position. Inner
-            locator is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        above : Union[Locator, NoneType]
-            Matches elements that are above any of the elements matching the inner locator, at any horizontal position. Inner
-            locator is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        below : Union[Locator, NoneType]
-            Matches elements that are below any of the elements matching the inner locator, at any horizontal position. Inner
-            locator is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        near : Union[Locator, NoneType]
-            Matches elements that are near (<= 50 css pixels) any of the elements matching the inner locator. Inner locator is
-            queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
 
         Returns
         -------
@@ -4366,14 +4331,7 @@ class Frame(SyncBase):
 
         return mapping.from_impl(
             self._impl_obj.locator(
-                selector=selector,
-                has_text=has_text,
-                has=has._impl_obj if has else None,
-                left_of=left_of._impl_obj if left_of else None,
-                right_of=right_of._impl_obj if right_of else None,
-                above=above._impl_obj if above else None,
-                below=below._impl_obj if below else None,
-                near=near._impl_obj if near else None,
+                selector=selector, has_text=has_text, has=has._impl_obj if has else None
             )
         )
 
@@ -5325,12 +5283,7 @@ class FrameLocator(SyncBase):
         selector: str,
         *,
         has_text: typing.Union[str, typing.Pattern] = None,
-        has: "Locator" = None,
-        left_of: "Locator" = None,
-        right_of: "Locator" = None,
-        above: "Locator" = None,
-        below: "Locator" = None,
-        near: "Locator" = None
+        has: "Locator" = None
     ) -> "Locator":
         """FrameLocator.locator
 
@@ -5349,36 +5302,6 @@ class FrameLocator(SyncBase):
             For example, `article` that has `text=Playwright` matches `<article><div>Playwright</div></article>`.
 
             Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        left_of : Union[Locator, NoneType]
-            Matches elements that are to the left of any element matching the inner locator, at any vertical position. Inner locator
-            is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        right_of : Union[Locator, NoneType]
-            Matches elements that are to the right of any element matching the inner locator, at any vertical position. Inner
-            locator is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        above : Union[Locator, NoneType]
-            Matches elements that are above any of the elements matching the inner locator, at any horizontal position. Inner
-            locator is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        below : Union[Locator, NoneType]
-            Matches elements that are below any of the elements matching the inner locator, at any horizontal position. Inner
-            locator is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        near : Union[Locator, NoneType]
-            Matches elements that are near (<= 50 css pixels) any of the elements matching the inner locator. Inner locator is
-            queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
 
         Returns
         -------
@@ -5387,14 +5310,7 @@ class FrameLocator(SyncBase):
 
         return mapping.from_impl(
             self._impl_obj.locator(
-                selector=selector,
-                has_text=has_text,
-                has=has._impl_obj if has else None,
-                left_of=left_of._impl_obj if left_of else None,
-                right_of=right_of._impl_obj if right_of else None,
-                above=above._impl_obj if above else None,
-                below=below._impl_obj if below else None,
-                near=near._impl_obj if near else None,
+                selector=selector, has_text=has_text, has=has._impl_obj if has else None
             )
         )
 
@@ -8449,12 +8365,7 @@ class Page(SyncContextManager):
         selector: str,
         *,
         has_text: typing.Union[str, typing.Pattern] = None,
-        has: "Locator" = None,
-        left_of: "Locator" = None,
-        right_of: "Locator" = None,
-        above: "Locator" = None,
-        below: "Locator" = None,
-        near: "Locator" = None
+        has: "Locator" = None
     ) -> "Locator":
         """Page.locator
 
@@ -8479,36 +8390,6 @@ class Page(SyncContextManager):
             For example, `article` that has `text=Playwright` matches `<article><div>Playwright</div></article>`.
 
             Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        left_of : Union[Locator, NoneType]
-            Matches elements that are to the left of any element matching the inner locator, at any vertical position. Inner locator
-            is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        right_of : Union[Locator, NoneType]
-            Matches elements that are to the right of any element matching the inner locator, at any vertical position. Inner
-            locator is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        above : Union[Locator, NoneType]
-            Matches elements that are above any of the elements matching the inner locator, at any horizontal position. Inner
-            locator is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        below : Union[Locator, NoneType]
-            Matches elements that are below any of the elements matching the inner locator, at any horizontal position. Inner
-            locator is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        near : Union[Locator, NoneType]
-            Matches elements that are near (<= 50 css pixels) any of the elements matching the inner locator. Inner locator is
-            queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
 
         Returns
         -------
@@ -8517,14 +8398,7 @@ class Page(SyncContextManager):
 
         return mapping.from_impl(
             self._impl_obj.locator(
-                selector=selector,
-                has_text=has_text,
-                has=has._impl_obj if has else None,
-                left_of=left_of._impl_obj if left_of else None,
-                right_of=right_of._impl_obj if right_of else None,
-                above=above._impl_obj if above else None,
-                below=below._impl_obj if below else None,
-                near=near._impl_obj if near else None,
+                selector=selector, has_text=has_text, has=has._impl_obj if has else None
             )
         )
 
@@ -12763,12 +12637,7 @@ class Locator(SyncBase):
         selector: str,
         *,
         has_text: typing.Union[str, typing.Pattern] = None,
-        has: "Locator" = None,
-        left_of: "Locator" = None,
-        right_of: "Locator" = None,
-        above: "Locator" = None,
-        below: "Locator" = None,
-        near: "Locator" = None
+        has: "Locator" = None
     ) -> "Locator":
         """Locator.locator
 
@@ -12788,36 +12657,6 @@ class Locator(SyncBase):
             For example, `article` that has `text=Playwright` matches `<article><div>Playwright</div></article>`.
 
             Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        left_of : Union[Locator, NoneType]
-            Matches elements that are to the left of any element matching the inner locator, at any vertical position. Inner locator
-            is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        right_of : Union[Locator, NoneType]
-            Matches elements that are to the right of any element matching the inner locator, at any vertical position. Inner
-            locator is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        above : Union[Locator, NoneType]
-            Matches elements that are above any of the elements matching the inner locator, at any horizontal position. Inner
-            locator is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        below : Union[Locator, NoneType]
-            Matches elements that are below any of the elements matching the inner locator, at any horizontal position. Inner
-            locator is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        near : Union[Locator, NoneType]
-            Matches elements that are near (<= 50 css pixels) any of the elements matching the inner locator. Inner locator is
-            queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
 
         Returns
         -------
@@ -12826,14 +12665,7 @@ class Locator(SyncBase):
 
         return mapping.from_impl(
             self._impl_obj.locator(
-                selector=selector,
-                has_text=has_text,
-                has=has._impl_obj if has else None,
-                left_of=left_of._impl_obj if left_of else None,
-                right_of=right_of._impl_obj if right_of else None,
-                above=above._impl_obj if above else None,
-                below=below._impl_obj if below else None,
-                near=near._impl_obj if near else None,
+                selector=selector, has_text=has_text, has=has._impl_obj if has else None
             )
         )
 
@@ -12917,12 +12749,7 @@ class Locator(SyncBase):
         self,
         *,
         has_text: typing.Union[str, typing.Pattern] = None,
-        has: "Locator" = None,
-        left_of: "Locator" = None,
-        right_of: "Locator" = None,
-        above: "Locator" = None,
-        below: "Locator" = None,
-        near: "Locator" = None
+        has: "Locator" = None
     ) -> "Locator":
         """Locator.filter
 
@@ -12939,36 +12766,6 @@ class Locator(SyncBase):
             For example, `article` that has `text=Playwright` matches `<article><div>Playwright</div></article>`.
 
             Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        left_of : Union[Locator, NoneType]
-            Matches elements that are to the left of any element matching the inner locator, at any vertical position. Inner locator
-            is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        right_of : Union[Locator, NoneType]
-            Matches elements that are to the right of any element matching the inner locator, at any vertical position. Inner
-            locator is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        above : Union[Locator, NoneType]
-            Matches elements that are above any of the elements matching the inner locator, at any horizontal position. Inner
-            locator is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        below : Union[Locator, NoneType]
-            Matches elements that are below any of the elements matching the inner locator, at any horizontal position. Inner
-            locator is queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
-        near : Union[Locator, NoneType]
-            Matches elements that are near (<= 50 css pixels) any of the elements matching the inner locator. Inner locator is
-            queried against the same root as the outer one. More details in
-            [layout selectors](../selectors.md#selecting-elements-based-on-layout) guide.
-
-            Note that outer and inner locators must belong to the same frame. Inner locator must not contain `FrameLocator`s.
 
         Returns
         -------
@@ -12976,15 +12773,7 @@ class Locator(SyncBase):
         """
 
         return mapping.from_impl(
-            self._impl_obj.filter(
-                has_text=has_text,
-                has=has._impl_obj if has else None,
-                left_of=left_of._impl_obj if left_of else None,
-                right_of=right_of._impl_obj if right_of else None,
-                above=above._impl_obj if above else None,
-                below=below._impl_obj if below else None,
-                near=near._impl_obj if near else None,
-            )
+            self._impl_obj.filter(has_text=has_text, has=has._impl_obj if has else None)
         )
 
     def focus(self, *, timeout: float = None) -> NoneType:

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ except ImportError:
     InWheel = None
 from wheel.bdist_wheel import bdist_wheel as BDistWheelCommand
 
-driver_version = "1.22.0-alpha-may-11-2022"
+driver_version = "1.22.0-beta-1652379237000"
 
 
 def extractall(zip: zipfile.ZipFile, path: str) -> None:

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ except ImportError:
     InWheel = None
 from wheel.bdist_wheel import bdist_wheel as BDistWheelCommand
 
-driver_version = "1.22.0-beta-1652379237000"
+driver_version = "1.22.0"
 
 
 def extractall(zip: zipfile.ZipFile, path: str) -> None:

--- a/tests/async/test_locators.py
+++ b/tests/async/test_locators.py
@@ -738,18 +738,16 @@ async def test_locator_should_support_has_locator(page: Page, server: Server) ->
     ).to_have_count(1)
 
 
-async def test_locator_should_enforce_same_frame_for_has_and_layout_locators(
+async def test_locator_should_enforce_same_frame_for_has_locator(
     page: Page, server: Server
 ) -> None:
     await page.goto(server.PREFIX + "/frames/two-frames.html")
     child = page.frames[1]
-    for option in ["has", "left_of", "right_of", "above", "below", "near"]:
-        with pytest.raises(Error) as exc_info:
-            page.locator("div", **{option: child.locator("span")})
-        assert (
-            f'Inner "{option}" locator must belong to the same frame.'
-            in exc_info.value.message
-        )
+    with pytest.raises(Error) as exc_info:
+        page.locator("div", has=child.locator("span"))
+    assert (
+        'Inner "has" locator must belong to the same frame.' in exc_info.value.message
+    )
 
 
 async def test_locator_highlight_should_work(page: Page, server: Server) -> None:

--- a/tests/async/test_queryselector.py
+++ b/tests/async/test_queryselector.py
@@ -243,12 +243,6 @@ async def test_should_work_with_layout_selectors(page: Page) -> None:
 
     assert await page.eval_on_selector("div:right-of(#id6)", "e => e.id") == "id7"
     assert await page.eval_on_selector('div >> right-of="#id6"', "e => e.id") == "id7"
-    assert (
-        await page.locator("div", right_of=page.locator("#id6")).first.evaluate(
-            "e => e.id"
-        )
-        == "id7"
-    )
     assert await page.eval_on_selector("div:right-of(#id1)", "e => e.id") == "id2"
     assert await page.eval_on_selector('div >> right-of="#id1"', "e => e.id") == "id2"
     assert await page.eval_on_selector("div:right-of(#id3)", "e => e.id") == "id4"
@@ -270,12 +264,6 @@ async def test_should_work_with_layout_selectors(page: Page) -> None:
             'div >> right-of="#id3"', "els => els.map(e => e.id).join(',')"
         )
         == "id4,id2,id5,id7,id8,id9"
-    )
-    assert (
-        await page.locator("div", right_of=page.locator("#id3"))
-        .locator("span")
-        .evaluate_all("els => els.map(e => e.textContent).join(',')")
-        == "4,2,5,7,8,9"
     )
     assert (
         await page.eval_on_selector_all(
@@ -318,12 +306,6 @@ async def test_should_work_with_layout_selectors(page: Page) -> None:
 
     assert await page.eval_on_selector("div:left-of(#id2)", "e => e.id") == "id1"
     assert await page.eval_on_selector('div >> left-of="#id2"', "e => e.id") == "id1"
-    assert (
-        await page.locator("div", left_of=page.locator("#id2")).first.evaluate(
-            "e => e.id"
-        )
-        == "id1"
-    )
     assert await page.query_selector("div:left-of(#id0)") is None
     assert await page.query_selector('div >> left-of="#id0"') is None
     assert await page.eval_on_selector("div:left-of(#id5)", "e => e.id") == "id0"
@@ -366,12 +348,6 @@ async def test_should_work_with_layout_selectors(page: Page) -> None:
 
     assert await page.eval_on_selector("div:above(#id0)", "e => e.id") == "id3"
     assert await page.eval_on_selector('div >> above="#id0"', "e => e.id") == "id3"
-    assert (
-        await page.locator("div", above=page.locator("#id0")).first.evaluate(
-            "e => e.id"
-        )
-        == "id3"
-    )
     assert await page.eval_on_selector("div:above(#id5)", "e => e.id") == "id4"
     assert await page.eval_on_selector('div >> above="#id5"', "e => e.id") == "id4"
     assert await page.eval_on_selector("div:above(#id7)", "e => e.id") == "id5"
@@ -409,12 +385,6 @@ async def test_should_work_with_layout_selectors(page: Page) -> None:
 
     assert await page.eval_on_selector("div:below(#id4)", "e => e.id") == "id5"
     assert await page.eval_on_selector('div >> below="#id4"', "e => e.id") == "id5"
-    assert (
-        await page.locator("div", below=page.locator("#id4")).first.evaluate(
-            "e => e.id"
-        )
-        == "id5"
-    )
     assert await page.eval_on_selector("div:below(#id3)", "e => e.id") == "id0"
     assert await page.eval_on_selector('div >> below="#id3"', "e => e.id") == "id0"
     assert await page.eval_on_selector("div:below(#id2)", "e => e.id") == "id4"
@@ -454,10 +424,6 @@ async def test_should_work_with_layout_selectors(page: Page) -> None:
 
     assert await page.eval_on_selector("div:near(#id0)", "e => e.id") == "id3"
     assert await page.eval_on_selector('div >> near="#id0"', "e => e.id") == "id3"
-    assert (
-        await page.locator("div", near=page.locator("#id0")).first.evaluate("e => e.id")
-        == "id3"
-    )
     assert (
         await page.eval_on_selector_all(
             "div:near(#id7)", "els => els.map(e => e.id).join(',')"
@@ -536,12 +502,6 @@ async def test_should_work_with_layout_selectors(page: Page) -> None:
     )
     assert (
         await page.eval_on_selector('div >> below="#id5" >> above="#id8"', "e => e.id")
-        == "id7"
-    )
-    assert (
-        await page.locator(
-            "div", below=page.locator("#id5"), above=page.locator("#id8")
-        ).first.evaluate("e => e.id")
         == "id7"
     )
 

--- a/tests/async/test_queryselector.py
+++ b/tests/async/test_queryselector.py
@@ -242,26 +242,14 @@ async def test_should_work_with_layout_selectors(page: Page) -> None:
     )
 
     assert await page.eval_on_selector("div:right-of(#id6)", "e => e.id") == "id7"
-    assert await page.eval_on_selector('div >> right-of="#id6"', "e => e.id") == "id7"
     assert await page.eval_on_selector("div:right-of(#id1)", "e => e.id") == "id2"
-    assert await page.eval_on_selector('div >> right-of="#id1"', "e => e.id") == "id2"
     assert await page.eval_on_selector("div:right-of(#id3)", "e => e.id") == "id4"
-    assert await page.eval_on_selector('div >> right-of="#id3"', "e => e.id") == "id4"
     assert await page.query_selector("div:right-of(#id4)") is None
-    assert await page.query_selector('div >> right-of="#id4"') is None
     assert await page.eval_on_selector("div:right-of(#id0)", "e => e.id") == "id7"
-    assert await page.eval_on_selector('div >> right-of="#id0"', "e => e.id") == "id7"
     assert await page.eval_on_selector("div:right-of(#id8)", "e => e.id") == "id9"
-    assert await page.eval_on_selector('div >> right-of="#id8"', "e => e.id") == "id9"
     assert (
         await page.eval_on_selector_all(
             "div:right-of(#id3)", "els => els.map(e => e.id).join(',')"
-        )
-        == "id4,id2,id5,id7,id8,id9"
-    )
-    assert (
-        await page.eval_on_selector_all(
-            'div >> right-of="#id3"', "els => els.map(e => e.id).join(',')"
         )
         == "id4,id2,id5,id7,id8,id9"
     )
@@ -273,56 +261,19 @@ async def test_should_work_with_layout_selectors(page: Page) -> None:
     )
     assert (
         await page.eval_on_selector_all(
-            'div >> right-of="#id3",50', "els => els.map(e => e.id).join(',')"
-        )
-        == "id2,id5,id7,id8"
-    )
-    assert (
-        await page.eval_on_selector_all(
-            'div >> right-of="#id3",50 >> span',
-            "els => els.map(e => e.textContent).join(',')",
-        )
-        == "2,5,7,8"
-    )
-    assert (
-        await page.eval_on_selector_all(
             "div:right-of(#id3, 49)", "els => els.map(e => e.id).join(',')"
         )
         == "id7,id8"
     )
-    assert (
-        await page.eval_on_selector_all(
-            'div >> right-of="#id3",49', "els => els.map(e => e.id).join(',')"
-        )
-        == "id7,id8"
-    )
-    assert (
-        await page.eval_on_selector_all(
-            'div >> right-of="#id3",49 >> span',
-            "els => els.map(e => e.textContent).join(',')",
-        )
-        == "7,8"
-    )
 
     assert await page.eval_on_selector("div:left-of(#id2)", "e => e.id") == "id1"
-    assert await page.eval_on_selector('div >> left-of="#id2"', "e => e.id") == "id1"
     assert await page.query_selector("div:left-of(#id0)") is None
-    assert await page.query_selector('div >> left-of="#id0"') is None
     assert await page.eval_on_selector("div:left-of(#id5)", "e => e.id") == "id0"
-    assert await page.eval_on_selector('div >> left-of="#id5"', "e => e.id") == "id0"
     assert await page.eval_on_selector("div:left-of(#id9)", "e => e.id") == "id8"
-    assert await page.eval_on_selector('div >> left-of="#id9"', "e => e.id") == "id8"
     assert await page.eval_on_selector("div:left-of(#id4)", "e => e.id") == "id3"
-    assert await page.eval_on_selector('div >> left-of="#id4"', "e => e.id") == "id3"
     assert (
         await page.eval_on_selector_all(
             "div:left-of(#id5)", "els => els.map(e => e.id).join(',')"
-        )
-        == "id0,id7,id3,id1,id6,id8"
-    )
-    assert (
-        await page.eval_on_selector_all(
-            'div >> left-of="#id5"', "els => els.map(e => e.id).join(',')"
         )
         == "id0,id7,id3,id1,id6,id8"
     )
@@ -332,41 +283,16 @@ async def test_should_work_with_layout_selectors(page: Page) -> None:
         )
         == "id7,id8"
     )
-    assert (
-        await page.eval_on_selector_all(
-            'div >> left-of="#id5",3', "els => els.map(e => e.id).join(',')"
-        )
-        == "id7,id8"
-    )
-    assert (
-        await page.eval_on_selector_all(
-            'div >> left-of="#id5",3 >> span',
-            "els => els.map(e => e.textContent).join(',')",
-        )
-        == "7,8"
-    )
 
     assert await page.eval_on_selector("div:above(#id0)", "e => e.id") == "id3"
-    assert await page.eval_on_selector('div >> above="#id0"', "e => e.id") == "id3"
     assert await page.eval_on_selector("div:above(#id5)", "e => e.id") == "id4"
-    assert await page.eval_on_selector('div >> above="#id5"', "e => e.id") == "id4"
     assert await page.eval_on_selector("div:above(#id7)", "e => e.id") == "id5"
-    assert await page.eval_on_selector('div >> above="#id7"', "e => e.id") == "id5"
     assert await page.eval_on_selector("div:above(#id8)", "e => e.id") == "id0"
-    assert await page.eval_on_selector('div >> above="#id8"', "e => e.id") == "id0"
     assert await page.eval_on_selector("div:above(#id9)", "e => e.id") == "id8"
-    assert await page.eval_on_selector('div >> above="#id9"', "e => e.id") == "id8"
     assert await page.query_selector("div:above(#id2)") is None
-    assert await page.query_selector('div >> above="#id2"') is None
     assert (
         await page.eval_on_selector_all(
             "div:above(#id5)", "els => els.map(e => e.id).join(',')"
-        )
-        == "id4,id2,id3,id1"
-    )
-    assert (
-        await page.eval_on_selector_all(
-            'div >> above="#id5"', "els => els.map(e => e.id).join(',')"
         )
         == "id4,id2,id3,id1"
     )
@@ -376,36 +302,17 @@ async def test_should_work_with_layout_selectors(page: Page) -> None:
         )
         == "id4,id3"
     )
-    assert (
-        await page.eval_on_selector_all(
-            'div >> above="#id5",20', "els => els.map(e => e.id).join(',')"
-        )
-        == "id4,id3"
-    )
 
     assert await page.eval_on_selector("div:below(#id4)", "e => e.id") == "id5"
-    assert await page.eval_on_selector('div >> below="#id4"', "e => e.id") == "id5"
     assert await page.eval_on_selector("div:below(#id3)", "e => e.id") == "id0"
-    assert await page.eval_on_selector('div >> below="#id3"', "e => e.id") == "id0"
     assert await page.eval_on_selector("div:below(#id2)", "e => e.id") == "id4"
-    assert await page.eval_on_selector('div >> below="#id2"', "e => e.id") == "id4"
     assert await page.eval_on_selector("div:below(#id6)", "e => e.id") == "id8"
-    assert await page.eval_on_selector('div >> below="#id6"', "e => e.id") == "id8"
     assert await page.eval_on_selector("div:below(#id7)", "e => e.id") == "id8"
-    assert await page.eval_on_selector('div >> below="#id7"', "e => e.id") == "id8"
     assert await page.eval_on_selector("div:below(#id8)", "e => e.id") == "id9"
-    assert await page.eval_on_selector('div >> below="#id8"', "e => e.id") == "id9"
     assert await page.query_selector("div:below(#id9)") is None
-    assert await page.query_selector('div >> below="#id9"') is None
     assert (
         await page.eval_on_selector_all(
             "div:below(#id3)", "els => els.map(e => e.id).join(',')"
-        )
-        == "id0,id5,id6,id7,id8,id9"
-    )
-    assert (
-        await page.eval_on_selector_all(
-            'div >> below="#id3"', "els => els.map(e => e.id).join(',')"
         )
         == "id0,id5,id6,id7,id8,id9"
     )
@@ -415,24 +322,11 @@ async def test_should_work_with_layout_selectors(page: Page) -> None:
         )
         == "id0,id5,id6,id7"
     )
-    assert (
-        await page.eval_on_selector_all(
-            'div >> below="#id3" , 105', "els => els.map(e => e.id).join(',')"
-        )
-        == "id0,id5,id6,id7"
-    )
 
     assert await page.eval_on_selector("div:near(#id0)", "e => e.id") == "id3"
-    assert await page.eval_on_selector('div >> near="#id0"', "e => e.id") == "id3"
     assert (
         await page.eval_on_selector_all(
             "div:near(#id7)", "els => els.map(e => e.id).join(',')"
-        )
-        == "id0,id5,id3,id6"
-    )
-    assert (
-        await page.eval_on_selector_all(
-            'div >> near="#id7"', "els => els.map(e => e.id).join(',')"
         )
         == "id0,id5,id3,id6"
     )
@@ -444,19 +338,7 @@ async def test_should_work_with_layout_selectors(page: Page) -> None:
     )
     assert (
         await page.eval_on_selector_all(
-            'div >> near="#id0"', "els => els.map(e => e.id).join(',')"
-        )
-        == "id3,id6,id7,id8,id1,id5"
-    )
-    assert (
-        await page.eval_on_selector_all(
             "div:near(#id6)", "els => els.map(e => e.id).join(',')"
-        )
-        == "id0,id3,id7"
-    )
-    assert (
-        await page.eval_on_selector_all(
-            'div >> near="#id6"', "els => els.map(e => e.id).join(',')"
         )
         == "id0,id3,id7"
     )
@@ -468,19 +350,7 @@ async def test_should_work_with_layout_selectors(page: Page) -> None:
     )
     assert (
         await page.eval_on_selector_all(
-            'div >> near="#id6",10', "els => els.map(e => e.id).join(',')"
-        )
-        == "id0"
-    )
-    assert (
-        await page.eval_on_selector_all(
             "div:near(#id0, 100)", "els => els.map(e => e.id).join(',')"
-        )
-        == "id3,id6,id7,id8,id1,id5,id4,id2"
-    )
-    assert (
-        await page.eval_on_selector_all(
-            'div >> near="#id0",100', "els => els.map(e => e.id).join(',')"
         )
         == "id3,id6,id7,id8,id1,id5,id4,id2"
     )
@@ -492,17 +362,7 @@ async def test_should_work_with_layout_selectors(page: Page) -> None:
         == "id7,id6"
     )
     assert (
-        await page.eval_on_selector_all(
-            'div >> below="#id5" >> above="#id8"', "els => els.map(e => e.id).join(',')"
-        )
-        == "id7,id6"
-    )
-    assert (
         await page.eval_on_selector("div:below(#id5):above(#id8)", "e => e.id") == "id7"
-    )
-    assert (
-        await page.eval_on_selector('div >> below="#id5" >> above="#id8"', "e => e.id")
-        == "id7"
     )
 
     assert (
@@ -520,17 +380,5 @@ async def test_should_work_with_layout_selectors(page: Page) -> None:
         in exc_info.value.message
     )
     with pytest.raises(Error) as exc_info:
-        await page.query_selector("div >> left-of=abc")
-    assert "Malformed selector: left-of=abc" in exc_info.value.message
-    with pytest.raises(Error) as exc_info:
         await page.query_selector('left-of="div"')
     assert '"left-of" selector cannot be first' in exc_info.value.message
-    with pytest.raises(Error) as exc_info:
-        await page.query_selector("div >> left-of=33")
-    assert "Malformed selector: left-of=33" in exc_info.value.message
-    with pytest.raises(Error) as exc_info:
-        await page.query_selector('div >> left-of="span","foo"')
-    assert 'Malformed selector: left-of="span","foo"' in exc_info.value.message
-    with pytest.raises(Error) as exc_info:
-        await page.query_selector('div >> left-of="span",3,4')
-    assert 'Malformed selector: left-of="span",3,4' in exc_info.value.message


### PR DESCRIPTION
Partial revert of ed13a53281bc213e1a4341c50d47fbc65670288f

Ports the following changes:
- [x] https://github.com/microsoft/playwright/commit/0e2855348cba314de3484364eb926626ca97fbd2 (feat(locators): remove layout locators (#14129))

Resolves #1299