### PR TITLE
test: unflake test_should_upload_large_file

### DIFF
--- a/tests/async/test_browsertype_connect.py
+++ b/tests/async/test_browsertype_connect.py
@@ -282,7 +282,7 @@ async def test_should_upload_large_file(
 
     [request, _] = await asyncio.gather(
         server.wait_for_request("/upload"),
-        page.click("input[type=submit]"),
+        page.click("input[type=submit]", timeout=60_000),
     )
 
     contents = request.args[b"file1"][0]


### PR DESCRIPTION
The guess is that the webserver takes longer to process and then the click times out.