### PR TITLE
devops: only install required OS dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
         pip install -r local-requirements.txt
         pip install -e .
         python setup.py bdist_wheel
-        python -m playwright install --with-deps
+        python -m playwright install --with-deps ${{ matrix.browser }}
     - name: Common Tests
       run: pytest tests/common --browser=${{ matrix.browser }} --timeout 90
     - name: Test Reference count

--- a/tests/test_reference_count_async.py
+++ b/tests/test_reference_count_async.py
@@ -23,9 +23,9 @@ from tests.server import Server
 
 
 @pytest.mark.asyncio
-async def test_memory_objects(server: Server) -> None:
+async def test_memory_objects(server: Server, browser_name: str) -> None:
     async with async_playwright() as p:
-        browser = await p.chromium.launch()
+        browser = await p[browser_name].launch()
         page = await browser.new_page()
         await page.goto(server.EMPTY_PAGE)
 


### PR DESCRIPTION
lets see if bots are passing.