### PR TITLE
chore: port record_har_* options (content, mode, url_filter)

### DIFF
--- a/playwright/_impl/_browser.py
+++ b/playwright/_impl/_browser.py
@@ -226,9 +226,6 @@ async def normalize_context_params(is_sync: bool, params: Dict) -> None:
     if "recordHarPath" in params:
         recordHar: Dict[str, Any] = {"path": str(params["recordHarPath"])}
         params["recordHar"] = recordHar
-        if "recordHarOmitContent" in params:
-            params["recordHar"]["omitContent"] = params["recordHarOmitContent"]
-            del params["recordHarOmitContent"]
         if "recordHarUrlFilter" in params:
             opt = params["recordHarUrlFilter"]
             if isinstance(opt, str):
@@ -237,6 +234,22 @@ async def normalize_context_params(is_sync: bool, params: Dict) -> None:
                 params["recordHar"]["urlRegexSource"] = opt.pattern
                 params["recordHar"]["urlRegexFlags"] = escape_regex_flags(opt)
             del params["recordHarUrlFilter"]
+        if "recordHarMode" in params:
+            params["recordHar"]["mode"] = params["recordHarMode"]
+            del params["recordHarMode"]
+
+        new_content_api = None
+        old_content_api = None
+        if "recordHarContent" in params:
+            new_content_api = params["recordHarContent"]
+            del params["recordHarContent"]
+        if "recordHarOmitContent" in params:
+            old_content_api = params["recordHarOmitContent"]
+            del params["recordHarOmitContent"]
+        content = new_content_api or ("omit" if old_content_api else None)
+        if content:
+            params["recordHar"]["content"] = content
+
         del params["recordHarPath"]
     if "recordVideoDir" in params:
         params["recordVideo"] = {"dir": str(params["recordVideoDir"])}

--- a/playwright/_impl/_browser.py
+++ b/playwright/_impl/_browser.py
@@ -31,6 +31,8 @@ from playwright._impl._connection import ChannelOwner, from_channel
 from playwright._impl._helper import (
     ColorScheme,
     ForcedColors,
+    HarContentPolicy,
+    HarMode,
     ReducedMotion,
     ServiceWorkersPolicy,
     async_readfile,
@@ -118,6 +120,8 @@ class Browser(ChannelOwner):
         strictSelectors: bool = None,
         serviceWorkers: ServiceWorkersPolicy = None,
         recordHarUrlFilter: Union[Pattern, str] = None,
+        recordHarMode: HarMode = None,
+        recordHarContent: HarContentPolicy = None,
     ) -> BrowserContext:
         params = locals_to_params(locals())
         await normalize_context_params(self._connection._is_sync, params)
@@ -163,6 +167,8 @@ class Browser(ChannelOwner):
         strictSelectors: bool = None,
         serviceWorkers: ServiceWorkersPolicy = None,
         recordHarUrlFilter: Union[Pattern, str] = None,
+        recordHarMode: HarMode = None,
+        recordHarContent: HarContentPolicy = None,
     ) -> Page:
         params = locals_to_params(locals())
         context = await self.new_context(**params)

--- a/playwright/_impl/_browser_type.py
+++ b/playwright/_impl/_browser_type.py
@@ -15,7 +15,7 @@
 import asyncio
 import pathlib
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Dict, List, Optional, Pattern, Union, cast
 
 from playwright._impl._api_structures import (
     Geolocation,
@@ -139,6 +139,7 @@ class BrowserType(ChannelOwner):
         baseURL: str = None,
         strictSelectors: bool = None,
         serviceWorkers: ServiceWorkersPolicy = None,
+        recordHarUrlFilter: Union[Pattern, str] = None,
     ) -> BrowserContext:
         userDataDir = str(Path(userDataDir))
         params = locals_to_params(locals())

--- a/playwright/_impl/_browser_type.py
+++ b/playwright/_impl/_browser_type.py
@@ -36,6 +36,8 @@ from playwright._impl._helper import (
     ColorScheme,
     Env,
     ForcedColors,
+    HarContentPolicy,
+    HarMode,
     ReducedMotion,
     ServiceWorkersPolicy,
     locals_to_params,
@@ -140,6 +142,8 @@ class BrowserType(ChannelOwner):
         strictSelectors: bool = None,
         serviceWorkers: ServiceWorkersPolicy = None,
         recordHarUrlFilter: Union[Pattern, str] = None,
+        recordHarMode: HarMode = None,
+        recordHarContent: HarContentPolicy = None,
     ) -> BrowserContext:
         userDataDir = str(Path(userDataDir))
         params = locals_to_params(locals())

--- a/playwright/_impl/_helper.py
+++ b/playwright/_impl/_helper.py
@@ -65,6 +65,8 @@ DocumentLoadState = Literal["commit", "domcontentloaded", "load", "networkidle"]
 KeyboardModifier = Literal["Alt", "Control", "Meta", "Shift"]
 MouseButton = Literal["left", "middle", "right"]
 ServiceWorkersPolicy = Literal["allow", "block"]
+HarMode = Literal["full", "minimal"]
+HarContentPolicy = Literal["attach", "embed", "omit"]
 
 
 class ErrorPayload(TypedDict, total=False):

--- a/playwright/async_api/_generated.py
+++ b/playwright/async_api/_generated.py
@@ -10647,7 +10647,8 @@ class Browser(AsyncContextManager):
         storage_state: typing.Union[StorageState, str, pathlib.Path] = None,
         base_url: str = None,
         strict_selectors: bool = None,
-        service_workers: Literal["allow", "block"] = None
+        service_workers: Literal["allow", "block"] = None,
+        record_har_url_filter: typing.Union[str, typing.Pattern] = None
     ) -> "BrowserContext":
         """Browser.new_context
 
@@ -10756,6 +10757,7 @@ class Browser(AsyncContextManager):
             Whether to allow sites to register Service workers. Defaults to `'allow'`.
             - `'allow'`: [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) can be registered.
             - `'block'`: Playwright will block all registration of Service Workers.
+        record_har_url_filter : Union[Pattern, str, NoneType]
 
         Returns
         -------
@@ -10795,6 +10797,7 @@ class Browser(AsyncContextManager):
                 baseURL=base_url,
                 strictSelectors=strict_selectors,
                 serviceWorkers=service_workers,
+                recordHarUrlFilter=record_har_url_filter,
             )
         )
 
@@ -10831,7 +10834,8 @@ class Browser(AsyncContextManager):
         storage_state: typing.Union[StorageState, str, pathlib.Path] = None,
         base_url: str = None,
         strict_selectors: bool = None,
-        service_workers: Literal["allow", "block"] = None
+        service_workers: Literal["allow", "block"] = None,
+        record_har_url_filter: typing.Union[str, typing.Pattern] = None
     ) -> "Page":
         """Browser.new_page
 
@@ -10935,6 +10939,7 @@ class Browser(AsyncContextManager):
             Whether to allow sites to register Service workers. Defaults to `'allow'`.
             - `'allow'`: [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) can be registered.
             - `'block'`: Playwright will block all registration of Service Workers.
+        record_har_url_filter : Union[Pattern, str, NoneType]
 
         Returns
         -------
@@ -10974,6 +10979,7 @@ class Browser(AsyncContextManager):
                 baseURL=base_url,
                 strictSelectors=strict_selectors,
                 serviceWorkers=service_workers,
+                recordHarUrlFilter=record_har_url_filter,
             )
         )
 
@@ -11269,7 +11275,8 @@ class BrowserType(AsyncBase):
         record_video_size: ViewportSize = None,
         base_url: str = None,
         strict_selectors: bool = None,
-        service_workers: Literal["allow", "block"] = None
+        service_workers: Literal["allow", "block"] = None,
+        record_har_url_filter: typing.Union[str, typing.Pattern] = None
     ) -> "BrowserContext":
         """BrowserType.launch_persistent_context
 
@@ -11413,6 +11420,7 @@ class BrowserType(AsyncBase):
             Whether to allow sites to register Service workers. Defaults to `'allow'`.
             - `'allow'`: [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) can be registered.
             - `'block'`: Playwright will block all registration of Service Workers.
+        record_har_url_filter : Union[Pattern, str, NoneType]
 
         Returns
         -------
@@ -11466,6 +11474,7 @@ class BrowserType(AsyncBase):
                 baseURL=base_url,
                 strictSelectors=strict_selectors,
                 serviceWorkers=service_workers,
+                recordHarUrlFilter=record_har_url_filter,
             )
         )
 

--- a/playwright/async_api/_generated.py
+++ b/playwright/async_api/_generated.py
@@ -10648,7 +10648,9 @@ class Browser(AsyncContextManager):
         base_url: str = None,
         strict_selectors: bool = None,
         service_workers: Literal["allow", "block"] = None,
-        record_har_url_filter: typing.Union[str, typing.Pattern] = None
+        record_har_url_filter: typing.Union[str, typing.Pattern] = None,
+        record_har_mode: Literal["full", "minimal"] = None,
+        record_har_content: Literal["attach", "embed", "omit"] = None
     ) -> "BrowserContext":
         """Browser.new_context
 
@@ -10758,6 +10760,13 @@ class Browser(AsyncContextManager):
             - `'allow'`: [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) can be registered.
             - `'block'`: Playwright will block all registration of Service Workers.
         record_har_url_filter : Union[Pattern, str, NoneType]
+        record_har_mode : Union["full", "minimal", NoneType]
+            When set to `minimal`, only record information necessary for routing from HAR. This omits sizes, timing, page, cookies,
+            security and other types of HAR information that are not used when replaying from HAR. Defaults to `full`.
+        record_har_content : Union["attach", "embed", "omit", NoneType]
+            Optional setting to control resource content management. If `omit` is specified, content is not persisted. If `attach`
+            is specified, resources are persistet as separate files and all of these files are archived along with the HAR file.
+            Defaults to `embed`, which stores content inline the HAR file as per HAR specification.
 
         Returns
         -------
@@ -10798,6 +10807,8 @@ class Browser(AsyncContextManager):
                 strictSelectors=strict_selectors,
                 serviceWorkers=service_workers,
                 recordHarUrlFilter=record_har_url_filter,
+                recordHarMode=record_har_mode,
+                recordHarContent=record_har_content,
             )
         )
 
@@ -10835,7 +10846,9 @@ class Browser(AsyncContextManager):
         base_url: str = None,
         strict_selectors: bool = None,
         service_workers: Literal["allow", "block"] = None,
-        record_har_url_filter: typing.Union[str, typing.Pattern] = None
+        record_har_url_filter: typing.Union[str, typing.Pattern] = None,
+        record_har_mode: Literal["full", "minimal"] = None,
+        record_har_content: Literal["attach", "embed", "omit"] = None
     ) -> "Page":
         """Browser.new_page
 
@@ -10940,6 +10953,13 @@ class Browser(AsyncContextManager):
             - `'allow'`: [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) can be registered.
             - `'block'`: Playwright will block all registration of Service Workers.
         record_har_url_filter : Union[Pattern, str, NoneType]
+        record_har_mode : Union["full", "minimal", NoneType]
+            When set to `minimal`, only record information necessary for routing from HAR. This omits sizes, timing, page, cookies,
+            security and other types of HAR information that are not used when replaying from HAR. Defaults to `full`.
+        record_har_content : Union["attach", "embed", "omit", NoneType]
+            Optional setting to control resource content management. If `omit` is specified, content is not persisted. If `attach`
+            is specified, resources are persistet as separate files and all of these files are archived along with the HAR file.
+            Defaults to `embed`, which stores content inline the HAR file as per HAR specification.
 
         Returns
         -------
@@ -10980,6 +11000,8 @@ class Browser(AsyncContextManager):
                 strictSelectors=strict_selectors,
                 serviceWorkers=service_workers,
                 recordHarUrlFilter=record_har_url_filter,
+                recordHarMode=record_har_mode,
+                recordHarContent=record_har_content,
             )
         )
 
@@ -11276,7 +11298,9 @@ class BrowserType(AsyncBase):
         base_url: str = None,
         strict_selectors: bool = None,
         service_workers: Literal["allow", "block"] = None,
-        record_har_url_filter: typing.Union[str, typing.Pattern] = None
+        record_har_url_filter: typing.Union[str, typing.Pattern] = None,
+        record_har_mode: Literal["full", "minimal"] = None,
+        record_har_content: Literal["attach", "embed", "omit"] = None
     ) -> "BrowserContext":
         """BrowserType.launch_persistent_context
 
@@ -11421,6 +11445,13 @@ class BrowserType(AsyncBase):
             - `'allow'`: [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) can be registered.
             - `'block'`: Playwright will block all registration of Service Workers.
         record_har_url_filter : Union[Pattern, str, NoneType]
+        record_har_mode : Union["full", "minimal", NoneType]
+            When set to `minimal`, only record information necessary for routing from HAR. This omits sizes, timing, page, cookies,
+            security and other types of HAR information that are not used when replaying from HAR. Defaults to `full`.
+        record_har_content : Union["attach", "embed", "omit", NoneType]
+            Optional setting to control resource content management. If `omit` is specified, content is not persisted. If `attach`
+            is specified, resources are persistet as separate files and all of these files are archived along with the HAR file.
+            Defaults to `embed`, which stores content inline the HAR file as per HAR specification.
 
         Returns
         -------
@@ -11475,6 +11506,8 @@ class BrowserType(AsyncBase):
                 strictSelectors=strict_selectors,
                 serviceWorkers=service_workers,
                 recordHarUrlFilter=record_har_url_filter,
+                recordHarMode=record_har_mode,
+                recordHarContent=record_har_content,
             )
         )
 

--- a/playwright/sync_api/_generated.py
+++ b/playwright/sync_api/_generated.py
@@ -10670,7 +10670,9 @@ class Browser(SyncContextManager):
         base_url: str = None,
         strict_selectors: bool = None,
         service_workers: Literal["allow", "block"] = None,
-        record_har_url_filter: typing.Union[str, typing.Pattern] = None
+        record_har_url_filter: typing.Union[str, typing.Pattern] = None,
+        record_har_mode: Literal["full", "minimal"] = None,
+        record_har_content: Literal["attach", "embed", "omit"] = None
     ) -> "BrowserContext":
         """Browser.new_context
 
@@ -10780,6 +10782,13 @@ class Browser(SyncContextManager):
             - `'allow'`: [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) can be registered.
             - `'block'`: Playwright will block all registration of Service Workers.
         record_har_url_filter : Union[Pattern, str, NoneType]
+        record_har_mode : Union["full", "minimal", NoneType]
+            When set to `minimal`, only record information necessary for routing from HAR. This omits sizes, timing, page, cookies,
+            security and other types of HAR information that are not used when replaying from HAR. Defaults to `full`.
+        record_har_content : Union["attach", "embed", "omit", NoneType]
+            Optional setting to control resource content management. If `omit` is specified, content is not persisted. If `attach`
+            is specified, resources are persistet as separate files and all of these files are archived along with the HAR file.
+            Defaults to `embed`, which stores content inline the HAR file as per HAR specification.
 
         Returns
         -------
@@ -10821,6 +10830,8 @@ class Browser(SyncContextManager):
                     strictSelectors=strict_selectors,
                     serviceWorkers=service_workers,
                     recordHarUrlFilter=record_har_url_filter,
+                    recordHarMode=record_har_mode,
+                    recordHarContent=record_har_content,
                 )
             )
         )
@@ -10859,7 +10870,9 @@ class Browser(SyncContextManager):
         base_url: str = None,
         strict_selectors: bool = None,
         service_workers: Literal["allow", "block"] = None,
-        record_har_url_filter: typing.Union[str, typing.Pattern] = None
+        record_har_url_filter: typing.Union[str, typing.Pattern] = None,
+        record_har_mode: Literal["full", "minimal"] = None,
+        record_har_content: Literal["attach", "embed", "omit"] = None
     ) -> "Page":
         """Browser.new_page
 
@@ -10964,6 +10977,13 @@ class Browser(SyncContextManager):
             - `'allow'`: [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) can be registered.
             - `'block'`: Playwright will block all registration of Service Workers.
         record_har_url_filter : Union[Pattern, str, NoneType]
+        record_har_mode : Union["full", "minimal", NoneType]
+            When set to `minimal`, only record information necessary for routing from HAR. This omits sizes, timing, page, cookies,
+            security and other types of HAR information that are not used when replaying from HAR. Defaults to `full`.
+        record_har_content : Union["attach", "embed", "omit", NoneType]
+            Optional setting to control resource content management. If `omit` is specified, content is not persisted. If `attach`
+            is specified, resources are persistet as separate files and all of these files are archived along with the HAR file.
+            Defaults to `embed`, which stores content inline the HAR file as per HAR specification.
 
         Returns
         -------
@@ -11005,6 +11025,8 @@ class Browser(SyncContextManager):
                     strictSelectors=strict_selectors,
                     serviceWorkers=service_workers,
                     recordHarUrlFilter=record_har_url_filter,
+                    recordHarMode=record_har_mode,
+                    recordHarContent=record_har_content,
                 )
             )
         )
@@ -11306,7 +11328,9 @@ class BrowserType(SyncBase):
         base_url: str = None,
         strict_selectors: bool = None,
         service_workers: Literal["allow", "block"] = None,
-        record_har_url_filter: typing.Union[str, typing.Pattern] = None
+        record_har_url_filter: typing.Union[str, typing.Pattern] = None,
+        record_har_mode: Literal["full", "minimal"] = None,
+        record_har_content: Literal["attach", "embed", "omit"] = None
     ) -> "BrowserContext":
         """BrowserType.launch_persistent_context
 
@@ -11451,6 +11475,13 @@ class BrowserType(SyncBase):
             - `'allow'`: [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) can be registered.
             - `'block'`: Playwright will block all registration of Service Workers.
         record_har_url_filter : Union[Pattern, str, NoneType]
+        record_har_mode : Union["full", "minimal", NoneType]
+            When set to `minimal`, only record information necessary for routing from HAR. This omits sizes, timing, page, cookies,
+            security and other types of HAR information that are not used when replaying from HAR. Defaults to `full`.
+        record_har_content : Union["attach", "embed", "omit", NoneType]
+            Optional setting to control resource content management. If `omit` is specified, content is not persisted. If `attach`
+            is specified, resources are persistet as separate files and all of these files are archived along with the HAR file.
+            Defaults to `embed`, which stores content inline the HAR file as per HAR specification.
 
         Returns
         -------
@@ -11506,6 +11537,8 @@ class BrowserType(SyncBase):
                     strictSelectors=strict_selectors,
                     serviceWorkers=service_workers,
                     recordHarUrlFilter=record_har_url_filter,
+                    recordHarMode=record_har_mode,
+                    recordHarContent=record_har_content,
                 )
             )
         )

--- a/playwright/sync_api/_generated.py
+++ b/playwright/sync_api/_generated.py
@@ -10669,7 +10669,8 @@ class Browser(SyncContextManager):
         storage_state: typing.Union[StorageState, str, pathlib.Path] = None,
         base_url: str = None,
         strict_selectors: bool = None,
-        service_workers: Literal["allow", "block"] = None
+        service_workers: Literal["allow", "block"] = None,
+        record_har_url_filter: typing.Union[str, typing.Pattern] = None
     ) -> "BrowserContext":
         """Browser.new_context
 
@@ -10778,6 +10779,7 @@ class Browser(SyncContextManager):
             Whether to allow sites to register Service workers. Defaults to `'allow'`.
             - `'allow'`: [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) can be registered.
             - `'block'`: Playwright will block all registration of Service Workers.
+        record_har_url_filter : Union[Pattern, str, NoneType]
 
         Returns
         -------
@@ -10818,6 +10820,7 @@ class Browser(SyncContextManager):
                     baseURL=base_url,
                     strictSelectors=strict_selectors,
                     serviceWorkers=service_workers,
+                    recordHarUrlFilter=record_har_url_filter,
                 )
             )
         )
@@ -10855,7 +10858,8 @@ class Browser(SyncContextManager):
         storage_state: typing.Union[StorageState, str, pathlib.Path] = None,
         base_url: str = None,
         strict_selectors: bool = None,
-        service_workers: Literal["allow", "block"] = None
+        service_workers: Literal["allow", "block"] = None,
+        record_har_url_filter: typing.Union[str, typing.Pattern] = None
     ) -> "Page":
         """Browser.new_page
 
@@ -10959,6 +10963,7 @@ class Browser(SyncContextManager):
             Whether to allow sites to register Service workers. Defaults to `'allow'`.
             - `'allow'`: [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) can be registered.
             - `'block'`: Playwright will block all registration of Service Workers.
+        record_har_url_filter : Union[Pattern, str, NoneType]
 
         Returns
         -------
@@ -10999,6 +11004,7 @@ class Browser(SyncContextManager):
                     baseURL=base_url,
                     strictSelectors=strict_selectors,
                     serviceWorkers=service_workers,
+                    recordHarUrlFilter=record_har_url_filter,
                 )
             )
         )
@@ -11299,7 +11305,8 @@ class BrowserType(SyncBase):
         record_video_size: ViewportSize = None,
         base_url: str = None,
         strict_selectors: bool = None,
-        service_workers: Literal["allow", "block"] = None
+        service_workers: Literal["allow", "block"] = None,
+        record_har_url_filter: typing.Union[str, typing.Pattern] = None
     ) -> "BrowserContext":
         """BrowserType.launch_persistent_context
 
@@ -11443,6 +11450,7 @@ class BrowserType(SyncBase):
             Whether to allow sites to register Service workers. Defaults to `'allow'`.
             - `'allow'`: [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) can be registered.
             - `'block'`: Playwright will block all registration of Service Workers.
+        record_har_url_filter : Union[Pattern, str, NoneType]
 
         Returns
         -------
@@ -11497,6 +11505,7 @@ class BrowserType(SyncBase):
                     baseURL=base_url,
                     strictSelectors=strict_selectors,
                     serviceWorkers=service_workers,
+                    recordHarUrlFilter=record_har_url_filter,
                 )
             )
         )

--- a/scripts/expected_api_mismatch.txt
+++ b/scripts/expected_api_mismatch.txt
@@ -20,9 +20,6 @@ Method not implemented: Error.message
 Method not implemented: PlaywrightAssertions.expect
 
 # Pending 1.23 ports
-Parameter not implemented: BrowserType.launch_persistent_context(record_har_url_filter=)
 Method not implemented: BrowserContext.route_from_har
 Method not implemented: Route.fallback
-Parameter not implemented: Browser.new_page(record_har_url_filter=)
 Method not implemented: Page.route_from_har
-Parameter not implemented: Browser.new_context(record_har_url_filter=)

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ except ImportError:
     InWheel = None
 from wheel.bdist_wheel import bdist_wheel as BDistWheelCommand
 
-driver_version = "1.23.0-beta-1656026605000"
+driver_version = "1.23.0-beta-1656093125000"
 
 
 def extractall(zip: zipfile.ZipFile, path: str) -> None:

--- a/tests/async/test_har.py
+++ b/tests/async/test_har.py
@@ -14,6 +14,10 @@
 
 import json
 import os
+import re
+
+from playwright.async_api import Browser
+from tests.server import Server
 
 
 async def test_should_work(browser, server, tmpdir):
@@ -72,3 +76,45 @@ async def test_should_include_content(browser, server, tmpdir):
         content1 = log["entries"][0]["response"]["content"]
         assert content1["mimeType"] == "text/html"
         assert "HAR Page" in content1["text"]
+
+
+async def test_should_filter_by_glob(
+    browser: Browser, server: Server, tmpdir: str
+) -> None:
+    path = os.path.join(tmpdir, "log.har")
+    context = await browser.new_context(
+        base_url=server.PREFIX,
+        record_har_path=path,
+        record_har_url_filter="/*.css",
+        ignore_https_errors=True,
+    )
+    page = await context.new_page()
+    await page.goto(server.PREFIX + "/har.html")
+    await context.close()
+    with open(path) as f:
+        data = json.load(f)
+        assert "log" in data
+        log = data["log"]
+        assert len(log["entries"]) == 1
+        assert log["entries"][0]["request"]["url"].endswith("one-style.css")
+
+
+async def test_should_filter_by_regexp(
+    browser: Browser, server: Server, tmpdir: str
+) -> None:
+    path = os.path.join(tmpdir, "log.har")
+    context = await browser.new_context(
+        base_url=server.PREFIX,
+        record_har_path=path,
+        record_har_url_filter=re.compile("HAR.X?HTML", re.I),
+        ignore_https_errors=True,
+    )
+    page = await context.new_page()
+    await page.goto(server.PREFIX + "/har.html")
+    await context.close()
+    with open(path) as f:
+        data = json.load(f)
+        assert "log" in data
+        log = data["log"]
+        assert len(log["entries"]) == 1
+        assert log["entries"][0]["request"]["url"].endswith("har.html")

--- a/tests/async/test_har.py
+++ b/tests/async/test_har.py
@@ -74,7 +74,7 @@ async def test_should_include_content(browser, server, tmpdir):
         log = data["log"]
 
         content1 = log["entries"][0]["response"]["content"]
-        assert content1["mimeType"] == "text/html"
+        assert content1["mimeType"] == "text/html; charset=utf-8"
         assert "HAR Page" in content1["text"]
 
 

--- a/tests/async/test_request_intercept.py
+++ b/tests/async/test_request_intercept.py
@@ -43,7 +43,9 @@ async def test_should_fulfill_intercepted_response(page: Page, server: Server):
 async def test_should_fulfill_response_with_empty_body(page: Page, server: Server):
     async def handle(route: Route):
         response = await page.request.fetch(route.request)
-        await route.fulfill(response=response, status=201, body="")
+        await route.fulfill(
+            response=response, status=201, body="", headers={"content-length": "0"}
+        )
 
     await page.route("**/*", handle)
     response = await page.goto(server.PREFIX + "/title.html")

--- a/tests/async/test_request_intercept.py
+++ b/tests/async/test_request_intercept.py
@@ -131,13 +131,13 @@ async def test_should_give_access_to_the_intercepted_response(
     assert response.status_text == "OK"
     assert response.ok is True
     assert response.url.endswith("/title.html") is True
-    assert response.headers["content-type"] == "text/html"
+    assert response.headers["content-type"] == "text/html; charset=utf-8"
     assert list(
         filter(
             lambda header: header["name"].lower() == "content-type",
             response.headers_array,
         )
-    ) == [{"name": "Content-Type", "value": "text/html"}]
+    ) == [{"name": "Content-Type", "value": "text/html; charset=utf-8"}]
 
     await asyncio.gather(
         route.fulfill(response=response),

--- a/tests/server.py
+++ b/tests/server.py
@@ -134,7 +134,10 @@ class Server:
                 file_content = None
                 try:
                     file_content = (static_path / path[1:]).read_bytes()
-                    request.setHeader(b"Content-Type", mimetypes.guess_type(path)[0])
+                    content_type = mimetypes.guess_type(path)[0]
+                    if content_type and content_type.startswith("text/"):
+                        content_type += "; charset=utf-8"
+                    request.setHeader(b"Content-Type", content_type)
                     request.setHeader(b"Cache-Control", "no-cache, no-store")
                     if path in gzip_routes:
                         request.setHeader("Content-Encoding", "gzip")

--- a/tests/server.py
+++ b/tests/server.py
@@ -139,6 +139,7 @@ class Server:
                         content_type += "; charset=utf-8"
                     request.setHeader(b"Content-Type", content_type)
                     request.setHeader(b"Cache-Control", "no-cache, no-store")
+                    request.setHeader(b"Content-Length", str(len(file_content)))
                     if path in gzip_routes:
                         request.setHeader("Content-Encoding", "gzip")
                         request.write(gzip.compress(file_content))

--- a/tests/server.py
+++ b/tests/server.py
@@ -139,11 +139,11 @@ class Server:
                         content_type += "; charset=utf-8"
                     request.setHeader(b"Content-Type", content_type)
                     request.setHeader(b"Cache-Control", "no-cache, no-store")
-                    request.setHeader(b"Content-Length", str(len(file_content)))
                     if path in gzip_routes:
                         request.setHeader("Content-Encoding", "gzip")
                         request.write(gzip.compress(file_content))
                     else:
+                        request.setHeader(b"Content-Length", str(len(file_content)))
                         request.write(file_content)
                     self.setResponseCode(HTTPStatus.OK)
                 except (FileNotFoundError, IsADirectoryError, PermissionError):

--- a/tests/sync/test_har.py
+++ b/tests/sync/test_har.py
@@ -60,7 +60,7 @@ def test_should_include_content(browser: Browser, server: Server, tmpdir: Path) 
         log = data["log"]
 
         content1 = log["entries"][0]["response"]["content"]
-        assert content1["mimeType"] == "text/html"
+        assert content1["mimeType"] == "text/html; charset=utf-8"
         assert "HAR Page" in content1["text"]
 
 

--- a/tests/sync/test_har.py
+++ b/tests/sync/test_har.py
@@ -15,6 +15,7 @@
 import json
 import os
 import re
+import zipfile
 from pathlib import Path
 
 from playwright.sync_api import Browser
@@ -34,6 +35,24 @@ def test_should_work(browser: Browser, server: Server, tmpdir: Path) -> None:
 
 def test_should_omit_content(browser: Browser, server: Server, tmpdir: Path) -> None:
     path = os.path.join(tmpdir, "log.har")
+    context = browser.new_context(record_har_path=path, record_har_content="omit")
+    page = context.new_page()
+    page.goto(server.PREFIX + "/har.html")
+    context.close()
+    with open(path) as f:
+        data = json.load(f)
+        assert "log" in data
+        log = data["log"]
+
+        content1 = log["entries"][0]["response"]["content"]
+        assert "text" not in content1
+        assert "encoding" not in content1
+
+
+def test_should_omit_content_legacy(
+    browser: Browser, server: Server, tmpdir: Path
+) -> None:
+    path = os.path.join(tmpdir, "log.har")
     context = browser.new_context(record_har_path=path, record_har_omit_content=True)
     page = context.new_page()
     page.goto(server.PREFIX + "/har.html")
@@ -44,8 +63,65 @@ def test_should_omit_content(browser: Browser, server: Server, tmpdir: Path) -> 
         log = data["log"]
 
         content1 = log["entries"][0]["response"]["content"]
-        assert "text" in content1
+        assert "text" not in content1
         assert "encoding" not in content1
+
+
+def test_should_attach_content(browser: Browser, server: Server, tmpdir: Path) -> None:
+    path = os.path.join(tmpdir, "log.har.zip")
+    context = browser.new_context(
+        record_har_path=path,
+        record_har_content="attach",
+    )
+    page = context.new_page()
+    page.goto(server.PREFIX + "/har.html")
+    page.evaluate("() => fetch('/pptr.png').then(r => r.arrayBuffer())")
+    context.close()
+    with zipfile.ZipFile(path) as z:
+        with z.open("har.har") as har:
+            entries = json.load(har)["log"]["entries"]
+
+            assert "encoding" not in entries[0]["response"]["content"]
+            assert (
+                entries[0]["response"]["content"]["mimeType"]
+                == "text/html; charset=utf-8"
+            )
+            assert (
+                "75841480e2606c03389077304342fac2c58ccb1b"
+                in entries[0]["response"]["content"]["_file"]
+            )
+            assert entries[0]["response"]["content"]["size"] >= 96
+            assert entries[0]["response"]["content"]["compression"] == 0
+
+            assert "encoding" not in entries[1]["response"]["content"]
+            assert (
+                entries[1]["response"]["content"]["mimeType"]
+                == "text/css; charset=utf-8"
+            )
+            assert (
+                "79f739d7bc88e80f55b9891a22bf13a2b4e18adb"
+                in entries[1]["response"]["content"]["_file"]
+            )
+            assert entries[1]["response"]["content"]["size"] >= 37
+            assert entries[1]["response"]["content"]["compression"] == 0
+
+            assert "encoding" not in entries[2]["response"]["content"]
+            assert entries[2]["response"]["content"]["mimeType"] == "image/png"
+            assert (
+                "a4c3a18f0bb83f5d9fe7ce561e065c36205762fa"
+                in entries[2]["response"]["content"]["_file"]
+            )
+            assert entries[2]["response"]["content"]["size"] >= 6000
+            assert entries[2]["response"]["content"]["compression"] == 0
+
+            with z.open("75841480e2606c03389077304342fac2c58ccb1b.html") as f:
+                assert b"HAR Page" in f.read()
+
+            with z.open("79f739d7bc88e80f55b9891a22bf13a2b4e18adb.css") as f:
+                assert b"pink" in f.read()
+
+            with z.open("a4c3a18f0bb83f5d9fe7ce561e065c36205762fa.png") as f:
+                assert len(f.read()) == entries[2]["response"]["content"]["size"]
 
 
 def test_should_include_content(browser: Browser, server: Server, tmpdir: Path) -> None:
@@ -62,6 +138,41 @@ def test_should_include_content(browser: Browser, server: Server, tmpdir: Path) 
         content1 = log["entries"][0]["response"]["content"]
         assert content1["mimeType"] == "text/html; charset=utf-8"
         assert "HAR Page" in content1["text"]
+
+
+def test_should_default_to_full_mode(
+    browser: Browser, server: Server, tmpdir: Path
+) -> None:
+    path = os.path.join(tmpdir, "log.har")
+    context = browser.new_context(
+        record_har_path=path,
+    )
+    page = context.new_page()
+    page.goto(server.PREFIX + "/har.html")
+    context.close()
+    with open(path) as f:
+        data = json.load(f)
+        assert "log" in data
+        log = data["log"]
+        assert log["entries"][0]["request"]["bodySize"] >= 0
+
+
+def test_should_support_minimal_mode(
+    browser: Browser, server: Server, tmpdir: Path
+) -> None:
+    path = os.path.join(tmpdir, "log.har")
+    context = browser.new_context(
+        record_har_path=path,
+        record_har_mode="minimal",
+    )
+    page = context.new_page()
+    page.goto(server.PREFIX + "/har.html")
+    context.close()
+    with open(path) as f:
+        data = json.load(f)
+        assert "log" in data
+        log = data["log"]
+        assert log["entries"][0]["request"]["bodySize"] == -1
 
 
 def test_should_filter_by_glob(browser: Browser, server: Server, tmpdir: str) -> None:

--- a/tests/sync/test_request_intercept.py
+++ b/tests/sync/test_request_intercept.py
@@ -43,7 +43,9 @@ def test_should_fulfill_intercepted_response(page: Page, server: Server) -> None
 def test_should_fulfill_response_with_empty_body(page: Page, server: Server) -> None:
     def handle(route: Route) -> None:
         response = page.request.fetch(route.request)
-        route.fulfill(response=response, status=201, body="")
+        route.fulfill(
+            response=response, status=201, body="", headers={"content-length": "0"}
+        )
 
     page.route("**/*", handle)
     response = page.goto(server.PREFIX + "/title.html")


### PR DESCRIPTION
This is part 3/n of the 1.23 port.

Relates #1308, #1374, #1376.

Ports:

- [x] https://github.com/microsoft/playwright/commit/fdcdd58d7fb128de2a26828eca4afa78c70047a8 (feat(har): introduce urlFilter (#14693))
- [x] https://github.com/microsoft/playwright/commit/c349c1d57f6a60813aa433fcfc39e0bce4c164c5 (feat: newContext.har (#14892))
- [x] https://github.com/microsoft/playwright/commit/245c33a5d44e6acd93b532e1166587fa716c560d (feat(har): allow storing content as separate files (#14934))
- [x] https://github.com/microsoft/playwright/commit/be64e9ce66bdd1e5b40c79b85a77b61a0c93b00a (chore(har): attach resources for .zip hars (#14938))
- [x] https://github.com/microsoft/playwright/commit/7bd72716f960ed11b48447c22f49a3b4ee453eb5 (feat(har): introduce the slim mode (#15053))