### PR TITLE
Test Python 3.11 beta5 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,18 @@ jobs:
         - os: macos-11.0
           python-version: '3.10'
           browser: chromium
+        - os: ubuntu-latest
+          python-version: '3.11-dev'
+          browser: chromium
+        - os: windows-latest
+          python-version: '3.11-dev'
+          browser: chromium
+        - os: macos-latest
+          python-version: '3.11-dev'
+          browser: chromium
+        - os: macos-11.0
+          python-version: '3.11-dev'
+          browser: chromium
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Python 3.11 RC1 is now a month away, this PR expands the test suite to include 3.11-dev

