### PR TITLE
cherry-pick(#1400): fix: emit Page on load/DOMContentLoaded

### DIFF
--- a/playwright/_impl/_frame.py
+++ b/playwright/_impl/_frame.py
@@ -100,14 +100,14 @@ class Frame(ChannelOwner):
             and hasattr(self, "_page")
             and self._page
         ):
-            self._page.emit("load", self)
+            self._page.emit("load", self._page)
         if (
             not self._parent_frame
             and add == "domcontentloaded"
             and hasattr(self, "_page")
             and self._page
         ):
-            self._page.emit("domcontentloaded", self)
+            self._page.emit("domcontentloaded", self._page)
 
     def _on_frame_navigated(self, event: FrameNavigatedEvent) -> None:
         self._url = event["url"]

--- a/tests/sync/test_page.py
+++ b/tests/sync/test_page.py
@@ -76,3 +76,11 @@ def test_sync_stacks_should_work(page: Page, server: Server) -> None:
         page.goto(server.EMPTY_PAGE)
     assert exc_info.value.stack
     assert __file__ in exc_info.value.stack
+
+
+def test_emitted_for_domcontentloaded_and_load(page: Page, server: Server) -> None:
+    with page.expect_event("domcontentloaded") as dom_info:
+        with page.expect_event("load") as load_info:
+            page.goto(server.EMPTY_PAGE)
+    assert isinstance(dom_info.value, Page)
+    assert isinstance(load_info.value, Page)


### PR DESCRIPTION
Fixes #1399.

Ports in #1374 of https://github.com/microsoft/playwright/commit/cdb862767f408fa6d364179d449f562565b4a793
was incorrect.