### PR TITLE
chore: updated requirements

### DIFF
--- a/local-requirements.txt
+++ b/local-requirements.txt
@@ -3,6 +3,7 @@ autobahn==22.3.2
 black==22.3.0
 flake8==4.0.1
 flaky==3.7.0
+greenlet==1.1.2
 mypy==0.942
 objgraph==3.5.0
 Pillow==9.1.1
@@ -21,4 +22,5 @@ setuptools==60.9.3
 twine==3.8.0
 twisted==22.4.0
 types-pyOpenSSL==22.0.1
+websockets==10.3.0
 wheel==0.37.1


### PR DESCRIPTION
Recently I've re-installed Python from a clean slate, and when I was setting up playwright-python for contributing, I've noticed that two packages weren't on the local-requirements.txt

So I've updated the requirements file to include those two packages. 