### PR TITLE
chore: constrain Pattern type

### DIFF
--- a/playwright/_impl/_assertions.py
+++ b/playwright/_impl/_assertions.py
@@ -67,7 +67,7 @@ class PageAssertions(AssertionsBase):
         return PageAssertions(self._actual_page, not self._is_not)
 
     async def to_have_title(
-        self, title_or_reg_exp: Union[Pattern, str], timeout: float = None
+        self, title_or_reg_exp: Union[Pattern[str], str], timeout: float = None
     ) -> None:
         expected_values = to_expected_text_values(
             [title_or_reg_exp], normalize_white_space=True
@@ -81,13 +81,13 @@ class PageAssertions(AssertionsBase):
         )
 
     async def not_to_have_title(
-        self, title_or_reg_exp: Union[Pattern, str], timeout: float = None
+        self, title_or_reg_exp: Union[Pattern[str], str], timeout: float = None
     ) -> None:
         __tracebackhide__ = True
         await self._not.to_have_title(title_or_reg_exp, timeout)
 
     async def to_have_url(
-        self, url_or_reg_exp: Union[str, Pattern], timeout: float = None
+        self, url_or_reg_exp: Union[str, Pattern[str]], timeout: float = None
     ) -> None:
         __tracebackhide__ = True
         base_url = self._actual_page.context._options.get("baseURL")
@@ -102,7 +102,7 @@ class PageAssertions(AssertionsBase):
         )
 
     async def not_to_have_url(
-        self, url_or_reg_exp: Union[Pattern, str], timeout: float = None
+        self, url_or_reg_exp: Union[Pattern[str], str], timeout: float = None
     ) -> None:
         __tracebackhide__ = True
         await self._not.to_have_url(url_or_reg_exp, timeout)
@@ -119,7 +119,7 @@ class LocatorAssertions(AssertionsBase):
 
     async def to_contain_text(
         self,
-        expected: Union[List[Union[Pattern, str]], Pattern, str],
+        expected: Union[List[Union[Pattern[str], str]], Pattern[str], str],
         use_inner_text: bool = None,
         timeout: float = None,
         ignore_case: bool = None,
@@ -162,7 +162,7 @@ class LocatorAssertions(AssertionsBase):
 
     async def not_to_contain_text(
         self,
-        expected: Union[List[Union[Pattern, str]], Pattern, str],
+        expected: Union[List[Union[Pattern[str], str]], Pattern[str], str],
         use_inner_text: bool = None,
         timeout: float = None,
         ignore_case: bool = None,
@@ -173,7 +173,7 @@ class LocatorAssertions(AssertionsBase):
     async def to_have_attribute(
         self,
         name: str,
-        value: Union[str, Pattern],
+        value: Union[str, Pattern[str]],
         timeout: float = None,
     ) -> None:
         __tracebackhide__ = True
@@ -190,7 +190,7 @@ class LocatorAssertions(AssertionsBase):
     async def not_to_have_attribute(
         self,
         name: str,
-        value: Union[str, Pattern],
+        value: Union[str, Pattern[str]],
         timeout: float = None,
     ) -> None:
         __tracebackhide__ = True
@@ -198,7 +198,7 @@ class LocatorAssertions(AssertionsBase):
 
     async def to_have_class(
         self,
-        expected: Union[List[Union[Pattern, str]], Pattern, str],
+        expected: Union[List[Union[Pattern[str], str]], Pattern[str], str],
         timeout: float = None,
     ) -> None:
         __tracebackhide__ = True
@@ -221,7 +221,7 @@ class LocatorAssertions(AssertionsBase):
 
     async def not_to_have_class(
         self,
-        expected: Union[List[Union[Pattern, str]], Pattern, str],
+        expected: Union[List[Union[Pattern[str], str]], Pattern[str], str],
         timeout: float = None,
     ) -> None:
         __tracebackhide__ = True
@@ -251,7 +251,7 @@ class LocatorAssertions(AssertionsBase):
     async def to_have_css(
         self,
         name: str,
-        value: Union[str, Pattern],
+        value: Union[str, Pattern[str]],
         timeout: float = None,
     ) -> None:
         __tracebackhide__ = True
@@ -268,7 +268,7 @@ class LocatorAssertions(AssertionsBase):
     async def not_to_have_css(
         self,
         name: str,
-        value: Union[str, Pattern],
+        value: Union[str, Pattern[str]],
         timeout: float = None,
     ) -> None:
         __tracebackhide__ = True
@@ -276,7 +276,7 @@ class LocatorAssertions(AssertionsBase):
 
     async def to_have_id(
         self,
-        id: Union[str, Pattern],
+        id: Union[str, Pattern[str]],
         timeout: float = None,
     ) -> None:
         __tracebackhide__ = True
@@ -290,7 +290,7 @@ class LocatorAssertions(AssertionsBase):
 
     async def not_to_have_id(
         self,
-        id: Union[str, Pattern],
+        id: Union[str, Pattern[str]],
         timeout: float = None,
     ) -> None:
         __tracebackhide__ = True
@@ -323,7 +323,7 @@ class LocatorAssertions(AssertionsBase):
 
     async def to_have_value(
         self,
-        value: Union[str, Pattern],
+        value: Union[str, Pattern[str]],
         timeout: float = None,
     ) -> None:
         __tracebackhide__ = True
@@ -337,7 +337,7 @@ class LocatorAssertions(AssertionsBase):
 
     async def not_to_have_value(
         self,
-        value: Union[str, Pattern],
+        value: Union[str, Pattern[str]],
         timeout: float = None,
     ) -> None:
         __tracebackhide__ = True
@@ -345,7 +345,7 @@ class LocatorAssertions(AssertionsBase):
 
     async def to_have_values(
         self,
-        values: List[Union[Pattern, str]],
+        values: List[Union[Pattern[str], str]],
         timeout: float = None,
     ) -> None:
         __tracebackhide__ = True
@@ -359,7 +359,7 @@ class LocatorAssertions(AssertionsBase):
 
     async def not_to_have_values(
         self,
-        values: List[Union[Pattern, str]],
+        values: List[Union[Pattern[str], str]],
         timeout: float = None,
     ) -> None:
         __tracebackhide__ = True
@@ -367,7 +367,7 @@ class LocatorAssertions(AssertionsBase):
 
     async def to_have_text(
         self,
-        expected: Union[List[Union[Pattern, str]], Pattern, str],
+        expected: Union[List[Union[Pattern[str], str]], Pattern[str], str],
         use_inner_text: bool = None,
         timeout: float = None,
         ignore_case: bool = None,
@@ -406,7 +406,7 @@ class LocatorAssertions(AssertionsBase):
 
     async def not_to_have_text(
         self,
-        expected: Union[List[Union[Pattern, str]], Pattern, str],
+        expected: Union[List[Union[Pattern[str], str]], Pattern[str], str],
         use_inner_text: bool = None,
         timeout: float = None,
         ignore_case: bool = None,
@@ -602,7 +602,7 @@ class APIResponseAssertions:
 
 
 def expected_regex(
-    pattern: Pattern,
+    pattern: Pattern[str],
     match_substring: bool,
     normalize_white_space: bool,
     ignore_case: Optional[bool] = None,
@@ -620,7 +620,7 @@ def expected_regex(
 
 
 def to_expected_text_values(
-    items: Union[List[Pattern], List[str], List[Union[str, Pattern]]],
+    items: Union[List[Pattern[str]], List[str], List[Union[str, Pattern[str]]]],
     match_substring: bool = False,
     normalize_white_space: bool = False,
     ignore_case: Optional[bool] = None,

--- a/playwright/_impl/_browser.py
+++ b/playwright/_impl/_browser.py
@@ -117,7 +117,7 @@ class Browser(ChannelOwner):
         baseURL: str = None,
         strictSelectors: bool = None,
         serviceWorkers: ServiceWorkersPolicy = None,
-        recordHarUrlFilter: Union[Pattern, str] = None,
+        recordHarUrlFilter: Union[Pattern[str], str] = None,
         recordHarMode: HarMode = None,
         recordHarContent: HarContentPolicy = None,
     ) -> BrowserContext:
@@ -165,7 +165,7 @@ class Browser(ChannelOwner):
         baseURL: str = None,
         strictSelectors: bool = None,
         serviceWorkers: ServiceWorkersPolicy = None,
-        recordHarUrlFilter: Union[Pattern, str] = None,
+        recordHarUrlFilter: Union[Pattern[str], str] = None,
         recordHarMode: HarMode = None,
         recordHarContent: HarContentPolicy = None,
     ) -> Page:

--- a/playwright/_impl/_browser_context.py
+++ b/playwright/_impl/_browser_context.py
@@ -321,7 +321,7 @@ class BrowserContext(ChannelOwner):
         self,
         har: Union[Path, str],
         page: Optional[Page] = None,
-        url: Union[Pattern, str] = None,
+        url: Union[Pattern[str], str] = None,
     ) -> None:
         params = {
             "options": prepare_record_har_options(
@@ -341,7 +341,7 @@ class BrowserContext(ChannelOwner):
     async def route_from_har(
         self,
         har: Union[Path, str],
-        url: Union[Pattern, str] = None,
+        url: Union[Pattern[str], str] = None,
         not_found: RouteFromHarNotFoundPolicy = None,
         update: bool = None,
     ) -> None:

--- a/playwright/_impl/_browser_type.py
+++ b/playwright/_impl/_browser_type.py
@@ -142,7 +142,7 @@ class BrowserType(ChannelOwner):
         baseURL: str = None,
         strictSelectors: bool = None,
         serviceWorkers: ServiceWorkersPolicy = None,
-        recordHarUrlFilter: Union[Pattern, str] = None,
+        recordHarUrlFilter: Union[Pattern[str], str] = None,
         recordHarMode: HarMode = None,
         recordHarContent: HarContentPolicy = None,
     ) -> BrowserContext:

--- a/playwright/_impl/_frame.py
+++ b/playwright/_impl/_frame.py
@@ -513,7 +513,10 @@ class Frame(ChannelOwner):
         await self._channel.send("fill", locals_to_params(locals()))
 
     def locator(
-        self, selector: str, has_text: Union[str, Pattern] = None, has: Locator = None
+        self,
+        selector: str,
+        has_text: Union[str, Pattern[str]] = None,
+        has: Locator = None,
     ) -> Locator:
         return Locator(self, selector, has_text=has_text, has=has)
 

--- a/playwright/_impl/_helper.py
+++ b/playwright/_impl/_helper.py
@@ -53,9 +53,9 @@ if TYPE_CHECKING:  # pragma: no cover
     from playwright._impl._api_structures import HeadersArray
     from playwright._impl._network import Request, Response, Route
 
-URLMatch = Union[str, Pattern, Callable[[str], bool]]
-URLMatchRequest = Union[str, Pattern, Callable[["Request"], bool]]
-URLMatchResponse = Union[str, Pattern, Callable[["Response"], bool]]
+URLMatch = Union[str, Pattern[str], Callable[[str], bool]]
+URLMatchRequest = Union[str, Pattern[str], Callable[["Request"], bool]]
+URLMatchResponse = Union[str, Pattern[str], Callable[["Response"], bool]]
 RouteHandlerCallback = Union[
     Callable[["Route"], Any], Callable[["Route", "Request"], Any]
 ]
@@ -152,7 +152,7 @@ Env = Dict[str, Union[str, float, bool]]
 class URLMatcher:
     def __init__(self, base_url: Union[str, None], match: URLMatch) -> None:
         self._callback: Optional[Callable[[str], bool]] = None
-        self._regex_obj: Optional[Pattern] = None
+        self._regex_obj: Optional[Pattern[str]] = None
         if isinstance(match, str):
             if base_url and not match.startswith("*"):
                 match = urljoin(base_url, match)

--- a/playwright/_impl/_locator.py
+++ b/playwright/_impl/_locator.py
@@ -64,7 +64,7 @@ class Locator:
         self,
         frame: "Frame",
         selector: str,
-        has_text: Union[str, Pattern] = None,
+        has_text: Union[str, Pattern[str]] = None,
         has: "Locator" = None,
     ) -> None:
         self._frame = frame
@@ -197,7 +197,7 @@ class Locator:
     def locator(
         self,
         selector: str,
-        has_text: Union[str, Pattern] = None,
+        has_text: Union[str, Pattern[str]] = None,
         has: "Locator" = None,
     ) -> "Locator":
         return Locator(
@@ -237,7 +237,7 @@ class Locator:
 
     def filter(
         self,
-        has_text: Union[str, Pattern] = None,
+        has_text: Union[str, Pattern[str]] = None,
         has: "Locator" = None,
     ) -> "Locator":
         return Locator(
@@ -576,7 +576,10 @@ class FrameLocator:
         self._frame_selector = frame_selector
 
     def locator(
-        self, selector: str, has_text: Union[str, Pattern] = None, has: "Locator" = None
+        self,
+        selector: str,
+        has_text: Union[str, Pattern[str]] = None,
+        has: "Locator" = None,
     ) -> Locator:
         return Locator(
             self._frame,

--- a/playwright/_impl/_page.py
+++ b/playwright/_impl/_page.py
@@ -605,7 +605,7 @@ class Page(ChannelOwner):
     async def route_from_har(
         self,
         har: Union[Path, str],
-        url: Union[Pattern, str] = None,
+        url: Union[Pattern[str], str] = None,
         not_found: RouteFromHarNotFoundPolicy = None,
         update: bool = None,
     ) -> None:
@@ -732,7 +732,7 @@ class Page(ChannelOwner):
     def locator(
         self,
         selector: str,
-        has_text: Union[str, Pattern] = None,
+        has_text: Union[str, Pattern[str]] = None,
         has: "Locator" = None,
     ) -> "Locator":
         return self._main_frame.locator(selector, has_text=has_text, has=has)

--- a/playwright/async_api/_generated.py
+++ b/playwright/async_api/_generated.py
@@ -3018,7 +3018,9 @@ class Frame(AsyncBase):
     def expect_navigation(
         self,
         *,
-        url: typing.Union[str, typing.Pattern, typing.Callable[[str], bool]] = None,
+        url: typing.Union[
+            str, typing.Pattern[str], typing.Callable[[str], bool]
+        ] = None,
         wait_until: Literal["commit", "domcontentloaded", "load", "networkidle"] = None,
         timeout: float = None
     ) -> AsyncEventContextManager["Response"]:
@@ -3042,7 +3044,7 @@ class Frame(AsyncBase):
 
         Parameters
         ----------
-        url : Union[Callable[[str], bool], Pattern, str, NoneType]
+        url : Union[Callable[[str], bool], Pattern[str], str, NoneType]
             A glob pattern, regex pattern or predicate receiving [URL] to match while waiting for the navigation. Note that if the
             parameter is a string without wildcard characters, the method will wait for navigation to URL that is exactly equal to
             the string.
@@ -3071,7 +3073,7 @@ class Frame(AsyncBase):
 
     async def wait_for_url(
         self,
-        url: typing.Union[str, typing.Pattern, typing.Callable[[str], bool]],
+        url: typing.Union[str, typing.Pattern[str], typing.Callable[[str], bool]],
         *,
         wait_until: Literal["commit", "domcontentloaded", "load", "networkidle"] = None,
         timeout: float = None
@@ -3087,7 +3089,7 @@ class Frame(AsyncBase):
 
         Parameters
         ----------
-        url : Union[Callable[[str], bool], Pattern, str]
+        url : Union[Callable[[str], bool], Pattern[str], str]
             A glob pattern, regex pattern or predicate receiving [URL] to match while waiting for the navigation. Note that if the
             parameter is a string without wildcard characters, the method will wait for navigation to URL that is exactly equal to
             the string.
@@ -4162,7 +4164,7 @@ class Frame(AsyncBase):
         self,
         selector: str,
         *,
-        has_text: typing.Union[str, typing.Pattern] = None,
+        has_text: typing.Union[str, typing.Pattern[str]] = None,
         has: "Locator" = None
     ) -> "Locator":
         """Frame.locator
@@ -4177,7 +4179,7 @@ class Frame(AsyncBase):
         ----------
         selector : str
             A selector to use when resolving DOM element. See [working with selectors](../selectors.md) for more details.
-        has_text : Union[Pattern, str, NoneType]
+        has_text : Union[Pattern[str], str, NoneType]
             Matches elements containing specified text somewhere inside, possibly in a child or a descendant element. When passed a
             [string], matching is case-insensitive and searches for a substring. For example, `"Playwright"` matches
             `<article><div>Playwright</div></article>`.
@@ -5101,7 +5103,7 @@ class FrameLocator(AsyncBase):
         self,
         selector: str,
         *,
-        has_text: typing.Union[str, typing.Pattern] = None,
+        has_text: typing.Union[str, typing.Pattern[str]] = None,
         has: "Locator" = None
     ) -> "Locator":
         """FrameLocator.locator
@@ -5112,7 +5114,7 @@ class FrameLocator(AsyncBase):
         ----------
         selector : str
             A selector to use when resolving DOM element. See [working with selectors](../selectors.md) for more details.
-        has_text : Union[Pattern, str, NoneType]
+        has_text : Union[Pattern[str], str, NoneType]
             Matches elements containing specified text somewhere inside, possibly in a child or a descendant element. When passed a
             [string], matching is case-insensitive and searches for a substring. For example, `"Playwright"` matches
             `<article><div>Playwright</div></article>`.
@@ -6286,7 +6288,7 @@ class Page(AsyncContextManager):
         self,
         name: str = None,
         *,
-        url: typing.Union[str, typing.Pattern, typing.Callable[[str], bool]] = None
+        url: typing.Union[str, typing.Pattern[str], typing.Callable[[str], bool]] = None
     ) -> typing.Optional["Frame"]:
         """Page.frame
 
@@ -6304,7 +6306,7 @@ class Page(AsyncContextManager):
         ----------
         name : Union[str, NoneType]
             Frame name specified in the `iframe`'s `name` attribute. Optional.
-        url : Union[Callable[[str], bool], Pattern, str, NoneType]
+        url : Union[Callable[[str], bool], Pattern[str], str, NoneType]
             A glob pattern, regex pattern or predicate receiving frame's `url` as a [URL] object. Optional.
 
         Returns
@@ -7356,7 +7358,7 @@ class Page(AsyncContextManager):
 
     async def wait_for_url(
         self,
-        url: typing.Union[str, typing.Pattern, typing.Callable[[str], bool]],
+        url: typing.Union[str, typing.Pattern[str], typing.Callable[[str], bool]],
         *,
         wait_until: Literal["commit", "domcontentloaded", "load", "networkidle"] = None,
         timeout: float = None
@@ -7374,7 +7376,7 @@ class Page(AsyncContextManager):
 
         Parameters
         ----------
-        url : Union[Callable[[str], bool], Pattern, str]
+        url : Union[Callable[[str], bool], Pattern[str], str]
             A glob pattern, regex pattern or predicate receiving [URL] to match while waiting for the navigation. Note that if the
             parameter is a string without wildcard characters, the method will wait for navigation to URL that is exactly equal to
             the string.
@@ -7642,7 +7644,7 @@ class Page(AsyncContextManager):
 
     async def route(
         self,
-        url: typing.Union[str, typing.Pattern, typing.Callable[[str], bool]],
+        url: typing.Union[str, typing.Pattern[str], typing.Callable[[str], bool]],
         handler: typing.Union[
             typing.Callable[["Route"], typing.Any],
             typing.Callable[["Route", "Request"], typing.Any],
@@ -7700,7 +7702,7 @@ class Page(AsyncContextManager):
 
         Parameters
         ----------
-        url : Union[Callable[[str], bool], Pattern, str]
+        url : Union[Callable[[str], bool], Pattern[str], str]
             A glob pattern, regex pattern or predicate receiving [URL] to match while routing. When a `baseURL` via the context
             options was provided and the passed URL is a path, it gets merged via the
             [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor.
@@ -7720,7 +7722,7 @@ class Page(AsyncContextManager):
 
     async def unroute(
         self,
-        url: typing.Union[str, typing.Pattern, typing.Callable[[str], bool]],
+        url: typing.Union[str, typing.Pattern[str], typing.Callable[[str], bool]],
         handler: typing.Union[
             typing.Callable[["Route"], typing.Any],
             typing.Callable[["Route", "Request"], typing.Any],
@@ -7732,7 +7734,7 @@ class Page(AsyncContextManager):
 
         Parameters
         ----------
-        url : Union[Callable[[str], bool], Pattern, str]
+        url : Union[Callable[[str], bool], Pattern[str], str]
             A glob pattern, regex pattern or predicate receiving [URL] to match while routing.
         handler : Union[Callable[[Route, Request], Any], Callable[[Route], Any], NoneType]
             Optional handler function to route the request.
@@ -7748,7 +7750,7 @@ class Page(AsyncContextManager):
         self,
         har: typing.Union[pathlib.Path, str],
         *,
-        url: typing.Union[str, typing.Pattern] = None,
+        url: typing.Union[str, typing.Pattern[str]] = None,
         not_found: Literal["abort", "fallback"] = None,
         update: bool = None
     ) -> NoneType:
@@ -7766,7 +7768,7 @@ class Page(AsyncContextManager):
         har : Union[pathlib.Path, str]
             Path to a [HAR](http://www.softwareishard.com/blog/har-12-spec) file with prerecorded network data. If `path` is a
             relative path, then it is resolved relative to the current working directory.
-        url : Union[Pattern, str, NoneType]
+        url : Union[Pattern[str], str, NoneType]
             A glob pattern, regular expression or predicate to match the request URL. Only requests with URL matching the pattern
             will be served from the HAR file. If not specified, all requests are served from the HAR file.
         not_found : Union["abort", "fallback", NoneType]
@@ -8207,7 +8209,7 @@ class Page(AsyncContextManager):
         self,
         selector: str,
         *,
-        has_text: typing.Union[str, typing.Pattern] = None,
+        has_text: typing.Union[str, typing.Pattern[str]] = None,
         has: "Locator" = None
     ) -> "Locator":
         """Page.locator
@@ -8224,7 +8226,7 @@ class Page(AsyncContextManager):
         ----------
         selector : str
             A selector to use when resolving DOM element. See [working with selectors](../selectors.md) for more details.
-        has_text : Union[Pattern, str, NoneType]
+        has_text : Union[Pattern[str], str, NoneType]
             Matches elements containing specified text somewhere inside, possibly in a child or a descendant element. When passed a
             [string], matching is case-insensitive and searches for a substring. For example, `"Playwright"` matches
             `<article><div>Playwright</div></article>`.
@@ -9342,7 +9344,9 @@ class Page(AsyncContextManager):
     def expect_navigation(
         self,
         *,
-        url: typing.Union[str, typing.Pattern, typing.Callable[[str], bool]] = None,
+        url: typing.Union[
+            str, typing.Pattern[str], typing.Callable[[str], bool]
+        ] = None,
         wait_until: Literal["commit", "domcontentloaded", "load", "networkidle"] = None,
         timeout: float = None
     ) -> AsyncEventContextManager["Response"]:
@@ -9369,7 +9373,7 @@ class Page(AsyncContextManager):
 
         Parameters
         ----------
-        url : Union[Callable[[str], bool], Pattern, str, NoneType]
+        url : Union[Callable[[str], bool], Pattern[str], str, NoneType]
             A glob pattern, regex pattern or predicate receiving [URL] to match while waiting for the navigation. Note that if the
             parameter is a string without wildcard characters, the method will wait for navigation to URL that is exactly equal to
             the string.
@@ -9430,7 +9434,7 @@ class Page(AsyncContextManager):
     def expect_request(
         self,
         url_or_predicate: typing.Union[
-            str, typing.Pattern, typing.Callable[["Request"], bool]
+            str, typing.Pattern[str], typing.Callable[["Request"], bool]
         ],
         *,
         timeout: float = None
@@ -9453,7 +9457,7 @@ class Page(AsyncContextManager):
 
         Parameters
         ----------
-        url_or_predicate : Union[Callable[[Request], bool], Pattern, str]
+        url_or_predicate : Union[Callable[[Request], bool], Pattern[str], str]
             Request URL string, regex or predicate receiving `Request` object. When a `baseURL` via the context options was provided
             and the passed URL is a path, it gets merged via the
             [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor.
@@ -9506,7 +9510,7 @@ class Page(AsyncContextManager):
     def expect_response(
         self,
         url_or_predicate: typing.Union[
-            str, typing.Pattern, typing.Callable[["Response"], bool]
+            str, typing.Pattern[str], typing.Callable[["Response"], bool]
         ],
         *,
         timeout: float = None
@@ -9530,7 +9534,7 @@ class Page(AsyncContextManager):
 
         Parameters
         ----------
-        url_or_predicate : Union[Callable[[Response], bool], Pattern, str]
+        url_or_predicate : Union[Callable[[Response], bool], Pattern[str], str]
             Request URL string, regex or predicate receiving `Response` object. When a `baseURL` via the context options was
             provided and the passed URL is a path, it gets merged via the
             [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor.
@@ -10379,7 +10383,7 @@ class BrowserContext(AsyncContextManager):
 
     async def route(
         self,
-        url: typing.Union[str, typing.Pattern, typing.Callable[[str], bool]],
+        url: typing.Union[str, typing.Pattern[str], typing.Callable[[str], bool]],
         handler: typing.Union[
             typing.Callable[["Route"], typing.Any],
             typing.Callable[["Route", "Request"], typing.Any],
@@ -10438,7 +10442,7 @@ class BrowserContext(AsyncContextManager):
 
         Parameters
         ----------
-        url : Union[Callable[[str], bool], Pattern, str]
+        url : Union[Callable[[str], bool], Pattern[str], str]
             A glob pattern, regex pattern or predicate receiving [URL] to match while routing. When a `baseURL` via the context
             options was provided and the passed URL is a path, it gets merged via the
             [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor.
@@ -10458,7 +10462,7 @@ class BrowserContext(AsyncContextManager):
 
     async def unroute(
         self,
-        url: typing.Union[str, typing.Pattern, typing.Callable[[str], bool]],
+        url: typing.Union[str, typing.Pattern[str], typing.Callable[[str], bool]],
         handler: typing.Union[
             typing.Callable[["Route"], typing.Any],
             typing.Callable[["Route", "Request"], typing.Any],
@@ -10471,7 +10475,7 @@ class BrowserContext(AsyncContextManager):
 
         Parameters
         ----------
-        url : Union[Callable[[str], bool], Pattern, str]
+        url : Union[Callable[[str], bool], Pattern[str], str]
             A glob pattern, regex pattern or predicate receiving [URL] used to register a routing with
             `browser_context.route()`.
         handler : Union[Callable[[Route, Request], Any], Callable[[Route], Any], NoneType]
@@ -10488,7 +10492,7 @@ class BrowserContext(AsyncContextManager):
         self,
         har: typing.Union[pathlib.Path, str],
         *,
-        url: typing.Union[str, typing.Pattern] = None,
+        url: typing.Union[str, typing.Pattern[str]] = None,
         not_found: Literal["abort", "fallback"] = None,
         update: bool = None
     ) -> NoneType:
@@ -10506,7 +10510,7 @@ class BrowserContext(AsyncContextManager):
         har : Union[pathlib.Path, str]
             Path to a [HAR](http://www.softwareishard.com/blog/har-12-spec) file with prerecorded network data. If `path` is a
             relative path, then it is resolved relative to the current working directory.
-        url : Union[Pattern, str, NoneType]
+        url : Union[Pattern[str], str, NoneType]
             A glob pattern, regular expression or predicate to match the request URL. Only requests with URL matching the pattern
             will be served from the HAR file. If not specified, all requests are served from the HAR file.
         not_found : Union["abort", "fallback", NoneType]
@@ -10823,7 +10827,7 @@ class Browser(AsyncContextManager):
         base_url: str = None,
         strict_selectors: bool = None,
         service_workers: Literal["allow", "block"] = None,
-        record_har_url_filter: typing.Union[str, typing.Pattern] = None,
+        record_har_url_filter: typing.Union[str, typing.Pattern[str]] = None,
         record_har_mode: Literal["full", "minimal"] = None,
         record_har_content: Literal["attach", "embed", "omit"] = None
     ) -> "BrowserContext":
@@ -10943,7 +10947,7 @@ class Browser(AsyncContextManager):
             Whether to allow sites to register Service workers. Defaults to `'allow'`.
             - `'allow'`: [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) can be registered.
             - `'block'`: Playwright will block all registration of Service Workers.
-        record_har_url_filter : Union[Pattern, str, NoneType]
+        record_har_url_filter : Union[Pattern[str], str, NoneType]
         record_har_mode : Union["full", "minimal", NoneType]
             When set to `minimal`, only record information necessary for routing from HAR. This omits sizes, timing, page, cookies,
             security and other types of HAR information that are not used when replaying from HAR. Defaults to `full`.
@@ -11030,7 +11034,7 @@ class Browser(AsyncContextManager):
         base_url: str = None,
         strict_selectors: bool = None,
         service_workers: Literal["allow", "block"] = None,
-        record_har_url_filter: typing.Union[str, typing.Pattern] = None,
+        record_har_url_filter: typing.Union[str, typing.Pattern[str]] = None,
         record_har_mode: Literal["full", "minimal"] = None,
         record_har_content: Literal["attach", "embed", "omit"] = None
     ) -> "Page":
@@ -11136,7 +11140,7 @@ class Browser(AsyncContextManager):
             Whether to allow sites to register Service workers. Defaults to `'allow'`.
             - `'allow'`: [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) can be registered.
             - `'block'`: Playwright will block all registration of Service Workers.
-        record_har_url_filter : Union[Pattern, str, NoneType]
+        record_har_url_filter : Union[Pattern[str], str, NoneType]
         record_har_mode : Union["full", "minimal", NoneType]
             When set to `minimal`, only record information necessary for routing from HAR. This omits sizes, timing, page, cookies,
             security and other types of HAR information that are not used when replaying from HAR. Defaults to `full`.
@@ -11486,7 +11490,7 @@ class BrowserType(AsyncBase):
         base_url: str = None,
         strict_selectors: bool = None,
         service_workers: Literal["allow", "block"] = None,
-        record_har_url_filter: typing.Union[str, typing.Pattern] = None,
+        record_har_url_filter: typing.Union[str, typing.Pattern[str]] = None,
         record_har_mode: Literal["full", "minimal"] = None,
         record_har_content: Literal["attach", "embed", "omit"] = None
     ) -> "BrowserContext":
@@ -11632,7 +11636,7 @@ class BrowserType(AsyncBase):
             Whether to allow sites to register Service workers. Defaults to `'allow'`.
             - `'allow'`: [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) can be registered.
             - `'block'`: Playwright will block all registration of Service Workers.
-        record_har_url_filter : Union[Pattern, str, NoneType]
+        record_har_url_filter : Union[Pattern[str], str, NoneType]
         record_har_mode : Union["full", "minimal", NoneType]
             When set to `minimal`, only record information necessary for routing from HAR. This omits sizes, timing, page, cookies,
             security and other types of HAR information that are not used when replaying from HAR. Defaults to `full`.
@@ -12498,7 +12502,7 @@ class Locator(AsyncBase):
         self,
         selector: str,
         *,
-        has_text: typing.Union[str, typing.Pattern] = None,
+        has_text: typing.Union[str, typing.Pattern[str]] = None,
         has: "Locator" = None
     ) -> "Locator":
         """Locator.locator
@@ -12510,7 +12514,7 @@ class Locator(AsyncBase):
         ----------
         selector : str
             A selector to use when resolving DOM element. See [working with selectors](../selectors.md) for more details.
-        has_text : Union[Pattern, str, NoneType]
+        has_text : Union[Pattern[str], str, NoneType]
             Matches elements containing specified text somewhere inside, possibly in a child or a descendant element. When passed a
             [string], matching is case-insensitive and searches for a substring. For example, `"Playwright"` matches
             `<article><div>Playwright</div></article>`.
@@ -12604,7 +12608,7 @@ class Locator(AsyncBase):
     def filter(
         self,
         *,
-        has_text: typing.Union[str, typing.Pattern] = None,
+        has_text: typing.Union[str, typing.Pattern[str]] = None,
         has: "Locator" = None
     ) -> "Locator":
         """Locator.filter
@@ -12623,7 +12627,7 @@ class Locator(AsyncBase):
 
         Parameters
         ----------
-        has_text : Union[Pattern, str, NoneType]
+        has_text : Union[Pattern[str], str, NoneType]
             Matches elements containing specified text somewhere inside, possibly in a child or a descendant element. When passed a
             [string], matching is case-insensitive and searches for a substring. For example, `"Playwright"` matches
             `<article><div>Playwright</div></article>`.
@@ -14245,7 +14249,7 @@ mapping.register(APIRequestImpl, APIRequest)
 class PageAssertions(AsyncBase):
     async def to_have_title(
         self,
-        title_or_reg_exp: typing.Union[typing.Pattern, str],
+        title_or_reg_exp: typing.Union[typing.Pattern[str], str],
         *,
         timeout: float = None
     ) -> NoneType:
@@ -14263,7 +14267,7 @@ class PageAssertions(AsyncBase):
 
         Parameters
         ----------
-        title_or_reg_exp : Union[Pattern, str]
+        title_or_reg_exp : Union[Pattern[str], str]
             Expected title or RegExp.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -14278,7 +14282,7 @@ class PageAssertions(AsyncBase):
 
     async def not_to_have_title(
         self,
-        title_or_reg_exp: typing.Union[typing.Pattern, str],
+        title_or_reg_exp: typing.Union[typing.Pattern[str], str],
         *,
         timeout: float = None
     ) -> NoneType:
@@ -14288,7 +14292,7 @@ class PageAssertions(AsyncBase):
 
         Parameters
         ----------
-        title_or_reg_exp : Union[Pattern, str]
+        title_or_reg_exp : Union[Pattern[str], str]
             Expected title or RegExp.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -14303,7 +14307,7 @@ class PageAssertions(AsyncBase):
 
     async def to_have_url(
         self,
-        url_or_reg_exp: typing.Union[str, typing.Pattern],
+        url_or_reg_exp: typing.Union[str, typing.Pattern[str]],
         *,
         timeout: float = None
     ) -> NoneType:
@@ -14321,7 +14325,7 @@ class PageAssertions(AsyncBase):
 
         Parameters
         ----------
-        url_or_reg_exp : Union[Pattern, str]
+        url_or_reg_exp : Union[Pattern[str], str]
             Expected URL string or RegExp.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -14336,7 +14340,7 @@ class PageAssertions(AsyncBase):
 
     async def not_to_have_url(
         self,
-        url_or_reg_exp: typing.Union[typing.Pattern, str],
+        url_or_reg_exp: typing.Union[typing.Pattern[str], str],
         *,
         timeout: float = None
     ) -> NoneType:
@@ -14346,7 +14350,7 @@ class PageAssertions(AsyncBase):
 
         Parameters
         ----------
-        url_or_reg_exp : Union[Pattern, str]
+        url_or_reg_exp : Union[Pattern[str], str]
             Expected URL string or RegExp.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -14367,7 +14371,9 @@ class LocatorAssertions(AsyncBase):
     async def to_contain_text(
         self,
         expected: typing.Union[
-            typing.List[typing.Union[typing.Pattern, str]], typing.Pattern, str
+            typing.List[typing.Union[typing.Pattern[str], str]],
+            typing.Pattern[str],
+            str,
         ],
         *,
         use_inner_text: bool = None,
@@ -14400,7 +14406,7 @@ class LocatorAssertions(AsyncBase):
 
         Parameters
         ----------
-        expected : Union[List[Union[Pattern, str]], Pattern, str]
+        expected : Union[List[Union[Pattern[str], str]], Pattern[str], str]
             Expected substring or RegExp or a list of those.
         use_inner_text : Union[bool, NoneType]
             Whether to use `element.innerText` instead of `element.textContent` when retrieving DOM node text.
@@ -14424,7 +14430,9 @@ class LocatorAssertions(AsyncBase):
     async def not_to_contain_text(
         self,
         expected: typing.Union[
-            typing.List[typing.Union[typing.Pattern, str]], typing.Pattern, str
+            typing.List[typing.Union[typing.Pattern[str], str]],
+            typing.Pattern[str],
+            str,
         ],
         *,
         use_inner_text: bool = None,
@@ -14437,7 +14445,7 @@ class LocatorAssertions(AsyncBase):
 
         Parameters
         ----------
-        expected : Union[List[Union[Pattern, str]], Pattern, str]
+        expected : Union[List[Union[Pattern[str], str]], Pattern[str], str]
             Expected substring or RegExp or a list of those.
         use_inner_text : Union[bool, NoneType]
             Whether to use `element.innerText` instead of `element.textContent` when retrieving DOM node text.
@@ -14461,7 +14469,7 @@ class LocatorAssertions(AsyncBase):
     async def to_have_attribute(
         self,
         name: str,
-        value: typing.Union[str, typing.Pattern],
+        value: typing.Union[str, typing.Pattern[str]],
         *,
         timeout: float = None
     ) -> NoneType:
@@ -14480,7 +14488,7 @@ class LocatorAssertions(AsyncBase):
         ----------
         name : str
             Attribute name.
-        value : Union[Pattern, str]
+        value : Union[Pattern[str], str]
             Expected attribute value.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -14496,7 +14504,7 @@ class LocatorAssertions(AsyncBase):
     async def not_to_have_attribute(
         self,
         name: str,
-        value: typing.Union[str, typing.Pattern],
+        value: typing.Union[str, typing.Pattern[str]],
         *,
         timeout: float = None
     ) -> NoneType:
@@ -14508,7 +14516,7 @@ class LocatorAssertions(AsyncBase):
         ----------
         name : str
             Attribute name.
-        value : Union[Pattern, str]
+        value : Union[Pattern[str], str]
             Expected attribute value.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -14524,7 +14532,9 @@ class LocatorAssertions(AsyncBase):
     async def to_have_class(
         self,
         expected: typing.Union[
-            typing.List[typing.Union[typing.Pattern, str]], typing.Pattern, str
+            typing.List[typing.Union[typing.Pattern[str], str]],
+            typing.Pattern[str],
+            str,
         ],
         *,
         timeout: float = None
@@ -14557,7 +14567,7 @@ class LocatorAssertions(AsyncBase):
 
         Parameters
         ----------
-        expected : Union[List[Union[Pattern, str]], Pattern, str]
+        expected : Union[List[Union[Pattern[str], str]], Pattern[str], str]
             Expected class or RegExp or a list of those.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -14573,7 +14583,9 @@ class LocatorAssertions(AsyncBase):
     async def not_to_have_class(
         self,
         expected: typing.Union[
-            typing.List[typing.Union[typing.Pattern, str]], typing.Pattern, str
+            typing.List[typing.Union[typing.Pattern[str], str]],
+            typing.Pattern[str],
+            str,
         ],
         *,
         timeout: float = None
@@ -14584,7 +14596,7 @@ class LocatorAssertions(AsyncBase):
 
         Parameters
         ----------
-        expected : Union[List[Union[Pattern, str]], Pattern, str]
+        expected : Union[List[Union[Pattern[str], str]], Pattern[str], str]
             Expected class or RegExp or a list of those.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -14643,7 +14655,7 @@ class LocatorAssertions(AsyncBase):
     async def to_have_css(
         self,
         name: str,
-        value: typing.Union[str, typing.Pattern],
+        value: typing.Union[str, typing.Pattern[str]],
         *,
         timeout: float = None
     ) -> NoneType:
@@ -14662,7 +14674,7 @@ class LocatorAssertions(AsyncBase):
         ----------
         name : str
             CSS property name.
-        value : Union[Pattern, str]
+        value : Union[Pattern[str], str]
             CSS property value.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -14676,7 +14688,7 @@ class LocatorAssertions(AsyncBase):
     async def not_to_have_css(
         self,
         name: str,
-        value: typing.Union[str, typing.Pattern],
+        value: typing.Union[str, typing.Pattern[str]],
         *,
         timeout: float = None
     ) -> NoneType:
@@ -14688,7 +14700,7 @@ class LocatorAssertions(AsyncBase):
         ----------
         name : str
             CSS property name.
-        value : Union[Pattern, str]
+        value : Union[Pattern[str], str]
             CSS property value.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -14702,7 +14714,7 @@ class LocatorAssertions(AsyncBase):
         )
 
     async def to_have_id(
-        self, id: typing.Union[str, typing.Pattern], *, timeout: float = None
+        self, id: typing.Union[str, typing.Pattern[str]], *, timeout: float = None
     ) -> NoneType:
         """LocatorAssertions.to_have_id
 
@@ -14717,7 +14729,7 @@ class LocatorAssertions(AsyncBase):
 
         Parameters
         ----------
-        id : Union[Pattern, str]
+        id : Union[Pattern[str], str]
             Element id.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -14729,7 +14741,7 @@ class LocatorAssertions(AsyncBase):
         )
 
     async def not_to_have_id(
-        self, id: typing.Union[str, typing.Pattern], *, timeout: float = None
+        self, id: typing.Union[str, typing.Pattern[str]], *, timeout: float = None
     ) -> NoneType:
         """LocatorAssertions.not_to_have_id
 
@@ -14737,7 +14749,7 @@ class LocatorAssertions(AsyncBase):
 
         Parameters
         ----------
-        id : Union[Pattern, str]
+        id : Union[Pattern[str], str]
             Element id.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -14805,7 +14817,7 @@ class LocatorAssertions(AsyncBase):
         )
 
     async def to_have_value(
-        self, value: typing.Union[str, typing.Pattern], *, timeout: float = None
+        self, value: typing.Union[str, typing.Pattern[str]], *, timeout: float = None
     ) -> NoneType:
         """LocatorAssertions.to_have_value
 
@@ -14822,7 +14834,7 @@ class LocatorAssertions(AsyncBase):
 
         Parameters
         ----------
-        value : Union[Pattern, str]
+        value : Union[Pattern[str], str]
             Expected value.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -14834,7 +14846,7 @@ class LocatorAssertions(AsyncBase):
         )
 
     async def not_to_have_value(
-        self, value: typing.Union[str, typing.Pattern], *, timeout: float = None
+        self, value: typing.Union[str, typing.Pattern[str]], *, timeout: float = None
     ) -> NoneType:
         """LocatorAssertions.not_to_have_value
 
@@ -14842,7 +14854,7 @@ class LocatorAssertions(AsyncBase):
 
         Parameters
         ----------
-        value : Union[Pattern, str]
+        value : Union[Pattern[str], str]
             Expected value.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -14855,7 +14867,7 @@ class LocatorAssertions(AsyncBase):
 
     async def to_have_values(
         self,
-        values: typing.List[typing.Union[typing.Pattern, str]],
+        values: typing.List[typing.Union[typing.Pattern[str], str]],
         *,
         timeout: float = None
     ) -> NoneType:
@@ -14885,7 +14897,7 @@ class LocatorAssertions(AsyncBase):
 
         Parameters
         ----------
-        values : List[Union[Pattern, str]]
+        values : List[Union[Pattern[str], str]]
             Expected options currently selected.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -14900,7 +14912,7 @@ class LocatorAssertions(AsyncBase):
 
     async def not_to_have_values(
         self,
-        values: typing.List[typing.Union[typing.Pattern, str]],
+        values: typing.List[typing.Union[typing.Pattern[str], str]],
         *,
         timeout: float = None
     ) -> NoneType:
@@ -14910,7 +14922,7 @@ class LocatorAssertions(AsyncBase):
 
         Parameters
         ----------
-        values : List[Union[Pattern, str]]
+        values : List[Union[Pattern[str], str]]
             Expected options currently selected.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -14926,7 +14938,9 @@ class LocatorAssertions(AsyncBase):
     async def to_have_text(
         self,
         expected: typing.Union[
-            typing.List[typing.Union[typing.Pattern, str]], typing.Pattern, str
+            typing.List[typing.Union[typing.Pattern[str], str]],
+            typing.Pattern[str],
+            str,
         ],
         *,
         use_inner_text: bool = None,
@@ -14957,7 +14971,7 @@ class LocatorAssertions(AsyncBase):
 
         Parameters
         ----------
-        expected : Union[List[Union[Pattern, str]], Pattern, str]
+        expected : Union[List[Union[Pattern[str], str]], Pattern[str], str]
             Expected substring or RegExp or a list of those.
         use_inner_text : Union[bool, NoneType]
             Whether to use `element.innerText` instead of `element.textContent` when retrieving DOM node text.
@@ -14981,7 +14995,9 @@ class LocatorAssertions(AsyncBase):
     async def not_to_have_text(
         self,
         expected: typing.Union[
-            typing.List[typing.Union[typing.Pattern, str]], typing.Pattern, str
+            typing.List[typing.Union[typing.Pattern[str], str]],
+            typing.Pattern[str],
+            str,
         ],
         *,
         use_inner_text: bool = None,
@@ -14994,7 +15010,7 @@ class LocatorAssertions(AsyncBase):
 
         Parameters
         ----------
-        expected : Union[List[Union[Pattern, str]], Pattern, str]
+        expected : Union[List[Union[Pattern[str], str]], Pattern[str], str]
             Expected substring or RegExp or a list of those.
         use_inner_text : Union[bool, NoneType]
             Whether to use `element.innerText` instead of `element.textContent` when retrieving DOM node text.

--- a/playwright/sync_api/_generated.py
+++ b/playwright/sync_api/_generated.py
@@ -3060,7 +3060,9 @@ class Frame(SyncBase):
     def expect_navigation(
         self,
         *,
-        url: typing.Union[str, typing.Pattern, typing.Callable[[str], bool]] = None,
+        url: typing.Union[
+            str, typing.Pattern[str], typing.Callable[[str], bool]
+        ] = None,
         wait_until: Literal["commit", "domcontentloaded", "load", "networkidle"] = None,
         timeout: float = None
     ) -> EventContextManager["Response"]:
@@ -3084,7 +3086,7 @@ class Frame(SyncBase):
 
         Parameters
         ----------
-        url : Union[Callable[[str], bool], Pattern, str, NoneType]
+        url : Union[Callable[[str], bool], Pattern[str], str, NoneType]
             A glob pattern, regex pattern or predicate receiving [URL] to match while waiting for the navigation. Note that if the
             parameter is a string without wildcard characters, the method will wait for navigation to URL that is exactly equal to
             the string.
@@ -3113,7 +3115,7 @@ class Frame(SyncBase):
 
     def wait_for_url(
         self,
-        url: typing.Union[str, typing.Pattern, typing.Callable[[str], bool]],
+        url: typing.Union[str, typing.Pattern[str], typing.Callable[[str], bool]],
         *,
         wait_until: Literal["commit", "domcontentloaded", "load", "networkidle"] = None,
         timeout: float = None
@@ -3129,7 +3131,7 @@ class Frame(SyncBase):
 
         Parameters
         ----------
-        url : Union[Callable[[str], bool], Pattern, str]
+        url : Union[Callable[[str], bool], Pattern[str], str]
             A glob pattern, regex pattern or predicate receiving [URL] to match while waiting for the navigation. Note that if the
             parameter is a string without wildcard characters, the method will wait for navigation to URL that is exactly equal to
             the string.
@@ -4237,7 +4239,7 @@ class Frame(SyncBase):
         self,
         selector: str,
         *,
-        has_text: typing.Union[str, typing.Pattern] = None,
+        has_text: typing.Union[str, typing.Pattern[str]] = None,
         has: "Locator" = None
     ) -> "Locator":
         """Frame.locator
@@ -4252,7 +4254,7 @@ class Frame(SyncBase):
         ----------
         selector : str
             A selector to use when resolving DOM element. See [working with selectors](../selectors.md) for more details.
-        has_text : Union[Pattern, str, NoneType]
+        has_text : Union[Pattern[str], str, NoneType]
             Matches elements containing specified text somewhere inside, possibly in a child or a descendant element. When passed a
             [string], matching is case-insensitive and searches for a substring. For example, `"Playwright"` matches
             `<article><div>Playwright</div></article>`.
@@ -5203,7 +5205,7 @@ class FrameLocator(SyncBase):
         self,
         selector: str,
         *,
-        has_text: typing.Union[str, typing.Pattern] = None,
+        has_text: typing.Union[str, typing.Pattern[str]] = None,
         has: "Locator" = None
     ) -> "Locator":
         """FrameLocator.locator
@@ -5214,7 +5216,7 @@ class FrameLocator(SyncBase):
         ----------
         selector : str
             A selector to use when resolving DOM element. See [working with selectors](../selectors.md) for more details.
-        has_text : Union[Pattern, str, NoneType]
+        has_text : Union[Pattern[str], str, NoneType]
             Matches elements containing specified text somewhere inside, possibly in a child or a descendant element. When passed a
             [string], matching is case-insensitive and searches for a substring. For example, `"Playwright"` matches
             `<article><div>Playwright</div></article>`.
@@ -6278,7 +6280,7 @@ class Page(SyncContextManager):
         self,
         name: str = None,
         *,
-        url: typing.Union[str, typing.Pattern, typing.Callable[[str], bool]] = None
+        url: typing.Union[str, typing.Pattern[str], typing.Callable[[str], bool]] = None
     ) -> typing.Optional["Frame"]:
         """Page.frame
 
@@ -6296,7 +6298,7 @@ class Page(SyncContextManager):
         ----------
         name : Union[str, NoneType]
             Frame name specified in the `iframe`'s `name` attribute. Optional.
-        url : Union[Callable[[str], bool], Pattern, str, NoneType]
+        url : Union[Callable[[str], bool], Pattern[str], str, NoneType]
             A glob pattern, regex pattern or predicate receiving frame's `url` as a [URL] object. Optional.
 
         Returns
@@ -7371,7 +7373,7 @@ class Page(SyncContextManager):
 
     def wait_for_url(
         self,
-        url: typing.Union[str, typing.Pattern, typing.Callable[[str], bool]],
+        url: typing.Union[str, typing.Pattern[str], typing.Callable[[str], bool]],
         *,
         wait_until: Literal["commit", "domcontentloaded", "load", "networkidle"] = None,
         timeout: float = None
@@ -7389,7 +7391,7 @@ class Page(SyncContextManager):
 
         Parameters
         ----------
-        url : Union[Callable[[str], bool], Pattern, str]
+        url : Union[Callable[[str], bool], Pattern[str], str]
             A glob pattern, regex pattern or predicate receiving [URL] to match while waiting for the navigation. Note that if the
             parameter is a string without wildcard characters, the method will wait for navigation to URL that is exactly equal to
             the string.
@@ -7664,7 +7666,7 @@ class Page(SyncContextManager):
 
     def route(
         self,
-        url: typing.Union[str, typing.Pattern, typing.Callable[[str], bool]],
+        url: typing.Union[str, typing.Pattern[str], typing.Callable[[str], bool]],
         handler: typing.Union[
             typing.Callable[["Route"], typing.Any],
             typing.Callable[["Route", "Request"], typing.Any],
@@ -7722,7 +7724,7 @@ class Page(SyncContextManager):
 
         Parameters
         ----------
-        url : Union[Callable[[str], bool], Pattern, str]
+        url : Union[Callable[[str], bool], Pattern[str], str]
             A glob pattern, regex pattern or predicate receiving [URL] to match while routing. When a `baseURL` via the context
             options was provided and the passed URL is a path, it gets merged via the
             [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor.
@@ -7744,7 +7746,7 @@ class Page(SyncContextManager):
 
     def unroute(
         self,
-        url: typing.Union[str, typing.Pattern, typing.Callable[[str], bool]],
+        url: typing.Union[str, typing.Pattern[str], typing.Callable[[str], bool]],
         handler: typing.Union[
             typing.Callable[["Route"], typing.Any],
             typing.Callable[["Route", "Request"], typing.Any],
@@ -7756,7 +7758,7 @@ class Page(SyncContextManager):
 
         Parameters
         ----------
-        url : Union[Callable[[str], bool], Pattern, str]
+        url : Union[Callable[[str], bool], Pattern[str], str]
             A glob pattern, regex pattern or predicate receiving [URL] to match while routing.
         handler : Union[Callable[[Route, Request], Any], Callable[[Route], Any], NoneType]
             Optional handler function to route the request.
@@ -7774,7 +7776,7 @@ class Page(SyncContextManager):
         self,
         har: typing.Union[pathlib.Path, str],
         *,
-        url: typing.Union[str, typing.Pattern] = None,
+        url: typing.Union[str, typing.Pattern[str]] = None,
         not_found: Literal["abort", "fallback"] = None,
         update: bool = None
     ) -> NoneType:
@@ -7792,7 +7794,7 @@ class Page(SyncContextManager):
         har : Union[pathlib.Path, str]
             Path to a [HAR](http://www.softwareishard.com/blog/har-12-spec) file with prerecorded network data. If `path` is a
             relative path, then it is resolved relative to the current working directory.
-        url : Union[Pattern, str, NoneType]
+        url : Union[Pattern[str], str, NoneType]
             A glob pattern, regular expression or predicate to match the request URL. Only requests with URL matching the pattern
             will be served from the HAR file. If not specified, all requests are served from the HAR file.
         not_found : Union["abort", "fallback", NoneType]
@@ -8245,7 +8247,7 @@ class Page(SyncContextManager):
         self,
         selector: str,
         *,
-        has_text: typing.Union[str, typing.Pattern] = None,
+        has_text: typing.Union[str, typing.Pattern[str]] = None,
         has: "Locator" = None
     ) -> "Locator":
         """Page.locator
@@ -8262,7 +8264,7 @@ class Page(SyncContextManager):
         ----------
         selector : str
             A selector to use when resolving DOM element. See [working with selectors](../selectors.md) for more details.
-        has_text : Union[Pattern, str, NoneType]
+        has_text : Union[Pattern[str], str, NoneType]
             Matches elements containing specified text somewhere inside, possibly in a child or a descendant element. When passed a
             [string], matching is case-insensitive and searches for a substring. For example, `"Playwright"` matches
             `<article><div>Playwright</div></article>`.
@@ -9407,7 +9409,9 @@ class Page(SyncContextManager):
     def expect_navigation(
         self,
         *,
-        url: typing.Union[str, typing.Pattern, typing.Callable[[str], bool]] = None,
+        url: typing.Union[
+            str, typing.Pattern[str], typing.Callable[[str], bool]
+        ] = None,
         wait_until: Literal["commit", "domcontentloaded", "load", "networkidle"] = None,
         timeout: float = None
     ) -> EventContextManager["Response"]:
@@ -9434,7 +9438,7 @@ class Page(SyncContextManager):
 
         Parameters
         ----------
-        url : Union[Callable[[str], bool], Pattern, str, NoneType]
+        url : Union[Callable[[str], bool], Pattern[str], str, NoneType]
             A glob pattern, regex pattern or predicate receiving [URL] to match while waiting for the navigation. Note that if the
             parameter is a string without wildcard characters, the method will wait for navigation to URL that is exactly equal to
             the string.
@@ -9495,7 +9499,7 @@ class Page(SyncContextManager):
     def expect_request(
         self,
         url_or_predicate: typing.Union[
-            str, typing.Pattern, typing.Callable[["Request"], bool]
+            str, typing.Pattern[str], typing.Callable[["Request"], bool]
         ],
         *,
         timeout: float = None
@@ -9518,7 +9522,7 @@ class Page(SyncContextManager):
 
         Parameters
         ----------
-        url_or_predicate : Union[Callable[[Request], bool], Pattern, str]
+        url_or_predicate : Union[Callable[[Request], bool], Pattern[str], str]
             Request URL string, regex or predicate receiving `Request` object. When a `baseURL` via the context options was provided
             and the passed URL is a path, it gets merged via the
             [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor.
@@ -9571,7 +9575,7 @@ class Page(SyncContextManager):
     def expect_response(
         self,
         url_or_predicate: typing.Union[
-            str, typing.Pattern, typing.Callable[["Response"], bool]
+            str, typing.Pattern[str], typing.Callable[["Response"], bool]
         ],
         *,
         timeout: float = None
@@ -9595,7 +9599,7 @@ class Page(SyncContextManager):
 
         Parameters
         ----------
-        url_or_predicate : Union[Callable[[Response], bool], Pattern, str]
+        url_or_predicate : Union[Callable[[Response], bool], Pattern[str], str]
             Request URL string, regex or predicate receiving `Response` object. When a `baseURL` via the context options was
             provided and the passed URL is a path, it gets merged via the
             [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor.
@@ -10400,7 +10404,7 @@ class BrowserContext(SyncContextManager):
 
     def route(
         self,
-        url: typing.Union[str, typing.Pattern, typing.Callable[[str], bool]],
+        url: typing.Union[str, typing.Pattern[str], typing.Callable[[str], bool]],
         handler: typing.Union[
             typing.Callable[["Route"], typing.Any],
             typing.Callable[["Route", "Request"], typing.Any],
@@ -10460,7 +10464,7 @@ class BrowserContext(SyncContextManager):
 
         Parameters
         ----------
-        url : Union[Callable[[str], bool], Pattern, str]
+        url : Union[Callable[[str], bool], Pattern[str], str]
             A glob pattern, regex pattern or predicate receiving [URL] to match while routing. When a `baseURL` via the context
             options was provided and the passed URL is a path, it gets merged via the
             [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor.
@@ -10482,7 +10486,7 @@ class BrowserContext(SyncContextManager):
 
     def unroute(
         self,
-        url: typing.Union[str, typing.Pattern, typing.Callable[[str], bool]],
+        url: typing.Union[str, typing.Pattern[str], typing.Callable[[str], bool]],
         handler: typing.Union[
             typing.Callable[["Route"], typing.Any],
             typing.Callable[["Route", "Request"], typing.Any],
@@ -10495,7 +10499,7 @@ class BrowserContext(SyncContextManager):
 
         Parameters
         ----------
-        url : Union[Callable[[str], bool], Pattern, str]
+        url : Union[Callable[[str], bool], Pattern[str], str]
             A glob pattern, regex pattern or predicate receiving [URL] used to register a routing with
             `browser_context.route()`.
         handler : Union[Callable[[Route, Request], Any], Callable[[Route], Any], NoneType]
@@ -10514,7 +10518,7 @@ class BrowserContext(SyncContextManager):
         self,
         har: typing.Union[pathlib.Path, str],
         *,
-        url: typing.Union[str, typing.Pattern] = None,
+        url: typing.Union[str, typing.Pattern[str]] = None,
         not_found: Literal["abort", "fallback"] = None,
         update: bool = None
     ) -> NoneType:
@@ -10532,7 +10536,7 @@ class BrowserContext(SyncContextManager):
         har : Union[pathlib.Path, str]
             Path to a [HAR](http://www.softwareishard.com/blog/har-12-spec) file with prerecorded network data. If `path` is a
             relative path, then it is resolved relative to the current working directory.
-        url : Union[Pattern, str, NoneType]
+        url : Union[Pattern[str], str, NoneType]
             A glob pattern, regular expression or predicate to match the request URL. Only requests with URL matching the pattern
             will be served from the HAR file. If not specified, all requests are served from the HAR file.
         not_found : Union["abort", "fallback", NoneType]
@@ -10851,7 +10855,7 @@ class Browser(SyncContextManager):
         base_url: str = None,
         strict_selectors: bool = None,
         service_workers: Literal["allow", "block"] = None,
-        record_har_url_filter: typing.Union[str, typing.Pattern] = None,
+        record_har_url_filter: typing.Union[str, typing.Pattern[str]] = None,
         record_har_mode: Literal["full", "minimal"] = None,
         record_har_content: Literal["attach", "embed", "omit"] = None
     ) -> "BrowserContext":
@@ -10971,7 +10975,7 @@ class Browser(SyncContextManager):
             Whether to allow sites to register Service workers. Defaults to `'allow'`.
             - `'allow'`: [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) can be registered.
             - `'block'`: Playwright will block all registration of Service Workers.
-        record_har_url_filter : Union[Pattern, str, NoneType]
+        record_har_url_filter : Union[Pattern[str], str, NoneType]
         record_har_mode : Union["full", "minimal", NoneType]
             When set to `minimal`, only record information necessary for routing from HAR. This omits sizes, timing, page, cookies,
             security and other types of HAR information that are not used when replaying from HAR. Defaults to `full`.
@@ -11060,7 +11064,7 @@ class Browser(SyncContextManager):
         base_url: str = None,
         strict_selectors: bool = None,
         service_workers: Literal["allow", "block"] = None,
-        record_har_url_filter: typing.Union[str, typing.Pattern] = None,
+        record_har_url_filter: typing.Union[str, typing.Pattern[str]] = None,
         record_har_mode: Literal["full", "minimal"] = None,
         record_har_content: Literal["attach", "embed", "omit"] = None
     ) -> "Page":
@@ -11166,7 +11170,7 @@ class Browser(SyncContextManager):
             Whether to allow sites to register Service workers. Defaults to `'allow'`.
             - `'allow'`: [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) can be registered.
             - `'block'`: Playwright will block all registration of Service Workers.
-        record_har_url_filter : Union[Pattern, str, NoneType]
+        record_har_url_filter : Union[Pattern[str], str, NoneType]
         record_har_mode : Union["full", "minimal", NoneType]
             When set to `minimal`, only record information necessary for routing from HAR. This omits sizes, timing, page, cookies,
             security and other types of HAR information that are not used when replaying from HAR. Defaults to `full`.
@@ -11522,7 +11526,7 @@ class BrowserType(SyncBase):
         base_url: str = None,
         strict_selectors: bool = None,
         service_workers: Literal["allow", "block"] = None,
-        record_har_url_filter: typing.Union[str, typing.Pattern] = None,
+        record_har_url_filter: typing.Union[str, typing.Pattern[str]] = None,
         record_har_mode: Literal["full", "minimal"] = None,
         record_har_content: Literal["attach", "embed", "omit"] = None
     ) -> "BrowserContext":
@@ -11668,7 +11672,7 @@ class BrowserType(SyncBase):
             Whether to allow sites to register Service workers. Defaults to `'allow'`.
             - `'allow'`: [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) can be registered.
             - `'block'`: Playwright will block all registration of Service Workers.
-        record_har_url_filter : Union[Pattern, str, NoneType]
+        record_har_url_filter : Union[Pattern[str], str, NoneType]
         record_har_mode : Union["full", "minimal", NoneType]
             When set to `minimal`, only record information necessary for routing from HAR. This omits sizes, timing, page, cookies,
             security and other types of HAR information that are not used when replaying from HAR. Defaults to `full`.
@@ -12553,7 +12557,7 @@ class Locator(SyncBase):
         self,
         selector: str,
         *,
-        has_text: typing.Union[str, typing.Pattern] = None,
+        has_text: typing.Union[str, typing.Pattern[str]] = None,
         has: "Locator" = None
     ) -> "Locator":
         """Locator.locator
@@ -12565,7 +12569,7 @@ class Locator(SyncBase):
         ----------
         selector : str
             A selector to use when resolving DOM element. See [working with selectors](../selectors.md) for more details.
-        has_text : Union[Pattern, str, NoneType]
+        has_text : Union[Pattern[str], str, NoneType]
             Matches elements containing specified text somewhere inside, possibly in a child or a descendant element. When passed a
             [string], matching is case-insensitive and searches for a substring. For example, `"Playwright"` matches
             `<article><div>Playwright</div></article>`.
@@ -12661,7 +12665,7 @@ class Locator(SyncBase):
     def filter(
         self,
         *,
-        has_text: typing.Union[str, typing.Pattern] = None,
+        has_text: typing.Union[str, typing.Pattern[str]] = None,
         has: "Locator" = None
     ) -> "Locator":
         """Locator.filter
@@ -12680,7 +12684,7 @@ class Locator(SyncBase):
 
         Parameters
         ----------
-        has_text : Union[Pattern, str, NoneType]
+        has_text : Union[Pattern[str], str, NoneType]
             Matches elements containing specified text somewhere inside, possibly in a child or a descendant element. When passed a
             [string], matching is case-insensitive and searches for a substring. For example, `"Playwright"` matches
             `<article><div>Playwright</div></article>`.
@@ -14352,7 +14356,7 @@ mapping.register(APIRequestImpl, APIRequest)
 class PageAssertions(SyncBase):
     def to_have_title(
         self,
-        title_or_reg_exp: typing.Union[typing.Pattern, str],
+        title_or_reg_exp: typing.Union[typing.Pattern[str], str],
         *,
         timeout: float = None
     ) -> NoneType:
@@ -14370,7 +14374,7 @@ class PageAssertions(SyncBase):
 
         Parameters
         ----------
-        title_or_reg_exp : Union[Pattern, str]
+        title_or_reg_exp : Union[Pattern[str], str]
             Expected title or RegExp.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -14387,7 +14391,7 @@ class PageAssertions(SyncBase):
 
     def not_to_have_title(
         self,
-        title_or_reg_exp: typing.Union[typing.Pattern, str],
+        title_or_reg_exp: typing.Union[typing.Pattern[str], str],
         *,
         timeout: float = None
     ) -> NoneType:
@@ -14397,7 +14401,7 @@ class PageAssertions(SyncBase):
 
         Parameters
         ----------
-        title_or_reg_exp : Union[Pattern, str]
+        title_or_reg_exp : Union[Pattern[str], str]
             Expected title or RegExp.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -14414,7 +14418,7 @@ class PageAssertions(SyncBase):
 
     def to_have_url(
         self,
-        url_or_reg_exp: typing.Union[str, typing.Pattern],
+        url_or_reg_exp: typing.Union[str, typing.Pattern[str]],
         *,
         timeout: float = None
     ) -> NoneType:
@@ -14432,7 +14436,7 @@ class PageAssertions(SyncBase):
 
         Parameters
         ----------
-        url_or_reg_exp : Union[Pattern, str]
+        url_or_reg_exp : Union[Pattern[str], str]
             Expected URL string or RegExp.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -14449,7 +14453,7 @@ class PageAssertions(SyncBase):
 
     def not_to_have_url(
         self,
-        url_or_reg_exp: typing.Union[typing.Pattern, str],
+        url_or_reg_exp: typing.Union[typing.Pattern[str], str],
         *,
         timeout: float = None
     ) -> NoneType:
@@ -14459,7 +14463,7 @@ class PageAssertions(SyncBase):
 
         Parameters
         ----------
-        url_or_reg_exp : Union[Pattern, str]
+        url_or_reg_exp : Union[Pattern[str], str]
             Expected URL string or RegExp.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -14482,7 +14486,9 @@ class LocatorAssertions(SyncBase):
     def to_contain_text(
         self,
         expected: typing.Union[
-            typing.List[typing.Union[typing.Pattern, str]], typing.Pattern, str
+            typing.List[typing.Union[typing.Pattern[str], str]],
+            typing.Pattern[str],
+            str,
         ],
         *,
         use_inner_text: bool = None,
@@ -14515,7 +14521,7 @@ class LocatorAssertions(SyncBase):
 
         Parameters
         ----------
-        expected : Union[List[Union[Pattern, str]], Pattern, str]
+        expected : Union[List[Union[Pattern[str], str]], Pattern[str], str]
             Expected substring or RegExp or a list of those.
         use_inner_text : Union[bool, NoneType]
             Whether to use `element.innerText` instead of `element.textContent` when retrieving DOM node text.
@@ -14541,7 +14547,9 @@ class LocatorAssertions(SyncBase):
     def not_to_contain_text(
         self,
         expected: typing.Union[
-            typing.List[typing.Union[typing.Pattern, str]], typing.Pattern, str
+            typing.List[typing.Union[typing.Pattern[str], str]],
+            typing.Pattern[str],
+            str,
         ],
         *,
         use_inner_text: bool = None,
@@ -14554,7 +14562,7 @@ class LocatorAssertions(SyncBase):
 
         Parameters
         ----------
-        expected : Union[List[Union[Pattern, str]], Pattern, str]
+        expected : Union[List[Union[Pattern[str], str]], Pattern[str], str]
             Expected substring or RegExp or a list of those.
         use_inner_text : Union[bool, NoneType]
             Whether to use `element.innerText` instead of `element.textContent` when retrieving DOM node text.
@@ -14580,7 +14588,7 @@ class LocatorAssertions(SyncBase):
     def to_have_attribute(
         self,
         name: str,
-        value: typing.Union[str, typing.Pattern],
+        value: typing.Union[str, typing.Pattern[str]],
         *,
         timeout: float = None
     ) -> NoneType:
@@ -14599,7 +14607,7 @@ class LocatorAssertions(SyncBase):
         ----------
         name : str
             Attribute name.
-        value : Union[Pattern, str]
+        value : Union[Pattern[str], str]
             Expected attribute value.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -14617,7 +14625,7 @@ class LocatorAssertions(SyncBase):
     def not_to_have_attribute(
         self,
         name: str,
-        value: typing.Union[str, typing.Pattern],
+        value: typing.Union[str, typing.Pattern[str]],
         *,
         timeout: float = None
     ) -> NoneType:
@@ -14629,7 +14637,7 @@ class LocatorAssertions(SyncBase):
         ----------
         name : str
             Attribute name.
-        value : Union[Pattern, str]
+        value : Union[Pattern[str], str]
             Expected attribute value.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -14647,7 +14655,9 @@ class LocatorAssertions(SyncBase):
     def to_have_class(
         self,
         expected: typing.Union[
-            typing.List[typing.Union[typing.Pattern, str]], typing.Pattern, str
+            typing.List[typing.Union[typing.Pattern[str], str]],
+            typing.Pattern[str],
+            str,
         ],
         *,
         timeout: float = None
@@ -14680,7 +14690,7 @@ class LocatorAssertions(SyncBase):
 
         Parameters
         ----------
-        expected : Union[List[Union[Pattern, str]], Pattern, str]
+        expected : Union[List[Union[Pattern[str], str]], Pattern[str], str]
             Expected class or RegExp or a list of those.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -14698,7 +14708,9 @@ class LocatorAssertions(SyncBase):
     def not_to_have_class(
         self,
         expected: typing.Union[
-            typing.List[typing.Union[typing.Pattern, str]], typing.Pattern, str
+            typing.List[typing.Union[typing.Pattern[str], str]],
+            typing.Pattern[str],
+            str,
         ],
         *,
         timeout: float = None
@@ -14709,7 +14721,7 @@ class LocatorAssertions(SyncBase):
 
         Parameters
         ----------
-        expected : Union[List[Union[Pattern, str]], Pattern, str]
+        expected : Union[List[Union[Pattern[str], str]], Pattern[str], str]
             Expected class or RegExp or a list of those.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -14770,7 +14782,7 @@ class LocatorAssertions(SyncBase):
     def to_have_css(
         self,
         name: str,
-        value: typing.Union[str, typing.Pattern],
+        value: typing.Union[str, typing.Pattern[str]],
         *,
         timeout: float = None
     ) -> NoneType:
@@ -14789,7 +14801,7 @@ class LocatorAssertions(SyncBase):
         ----------
         name : str
             CSS property name.
-        value : Union[Pattern, str]
+        value : Union[Pattern[str], str]
             CSS property value.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -14805,7 +14817,7 @@ class LocatorAssertions(SyncBase):
     def not_to_have_css(
         self,
         name: str,
-        value: typing.Union[str, typing.Pattern],
+        value: typing.Union[str, typing.Pattern[str]],
         *,
         timeout: float = None
     ) -> NoneType:
@@ -14817,7 +14829,7 @@ class LocatorAssertions(SyncBase):
         ----------
         name : str
             CSS property name.
-        value : Union[Pattern, str]
+        value : Union[Pattern[str], str]
             CSS property value.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -14831,7 +14843,7 @@ class LocatorAssertions(SyncBase):
         )
 
     def to_have_id(
-        self, id: typing.Union[str, typing.Pattern], *, timeout: float = None
+        self, id: typing.Union[str, typing.Pattern[str]], *, timeout: float = None
     ) -> NoneType:
         """LocatorAssertions.to_have_id
 
@@ -14846,7 +14858,7 @@ class LocatorAssertions(SyncBase):
 
         Parameters
         ----------
-        id : Union[Pattern, str]
+        id : Union[Pattern[str], str]
             Element id.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -14858,7 +14870,7 @@ class LocatorAssertions(SyncBase):
         )
 
     def not_to_have_id(
-        self, id: typing.Union[str, typing.Pattern], *, timeout: float = None
+        self, id: typing.Union[str, typing.Pattern[str]], *, timeout: float = None
     ) -> NoneType:
         """LocatorAssertions.not_to_have_id
 
@@ -14866,7 +14878,7 @@ class LocatorAssertions(SyncBase):
 
         Parameters
         ----------
-        id : Union[Pattern, str]
+        id : Union[Pattern[str], str]
             Element id.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -14938,7 +14950,7 @@ class LocatorAssertions(SyncBase):
         )
 
     def to_have_value(
-        self, value: typing.Union[str, typing.Pattern], *, timeout: float = None
+        self, value: typing.Union[str, typing.Pattern[str]], *, timeout: float = None
     ) -> NoneType:
         """LocatorAssertions.to_have_value
 
@@ -14955,7 +14967,7 @@ class LocatorAssertions(SyncBase):
 
         Parameters
         ----------
-        value : Union[Pattern, str]
+        value : Union[Pattern[str], str]
             Expected value.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -14967,7 +14979,7 @@ class LocatorAssertions(SyncBase):
         )
 
     def not_to_have_value(
-        self, value: typing.Union[str, typing.Pattern], *, timeout: float = None
+        self, value: typing.Union[str, typing.Pattern[str]], *, timeout: float = None
     ) -> NoneType:
         """LocatorAssertions.not_to_have_value
 
@@ -14975,7 +14987,7 @@ class LocatorAssertions(SyncBase):
 
         Parameters
         ----------
-        value : Union[Pattern, str]
+        value : Union[Pattern[str], str]
             Expected value.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -14988,7 +15000,7 @@ class LocatorAssertions(SyncBase):
 
     def to_have_values(
         self,
-        values: typing.List[typing.Union[typing.Pattern, str]],
+        values: typing.List[typing.Union[typing.Pattern[str], str]],
         *,
         timeout: float = None
     ) -> NoneType:
@@ -15018,7 +15030,7 @@ class LocatorAssertions(SyncBase):
 
         Parameters
         ----------
-        values : List[Union[Pattern, str]]
+        values : List[Union[Pattern[str], str]]
             Expected options currently selected.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -15035,7 +15047,7 @@ class LocatorAssertions(SyncBase):
 
     def not_to_have_values(
         self,
-        values: typing.List[typing.Union[typing.Pattern, str]],
+        values: typing.List[typing.Union[typing.Pattern[str], str]],
         *,
         timeout: float = None
     ) -> NoneType:
@@ -15045,7 +15057,7 @@ class LocatorAssertions(SyncBase):
 
         Parameters
         ----------
-        values : List[Union[Pattern, str]]
+        values : List[Union[Pattern[str], str]]
             Expected options currently selected.
         timeout : Union[float, NoneType]
             Time to retry the assertion for.
@@ -15063,7 +15075,9 @@ class LocatorAssertions(SyncBase):
     def to_have_text(
         self,
         expected: typing.Union[
-            typing.List[typing.Union[typing.Pattern, str]], typing.Pattern, str
+            typing.List[typing.Union[typing.Pattern[str], str]],
+            typing.Pattern[str],
+            str,
         ],
         *,
         use_inner_text: bool = None,
@@ -15094,7 +15108,7 @@ class LocatorAssertions(SyncBase):
 
         Parameters
         ----------
-        expected : Union[List[Union[Pattern, str]], Pattern, str]
+        expected : Union[List[Union[Pattern[str], str]], Pattern[str], str]
             Expected substring or RegExp or a list of those.
         use_inner_text : Union[bool, NoneType]
             Whether to use `element.innerText` instead of `element.textContent` when retrieving DOM node text.
@@ -15120,7 +15134,9 @@ class LocatorAssertions(SyncBase):
     def not_to_have_text(
         self,
         expected: typing.Union[
-            typing.List[typing.Union[typing.Pattern, str]], typing.Pattern, str
+            typing.List[typing.Union[typing.Pattern[str], str]],
+            typing.Pattern[str],
+            str,
         ],
         *,
         use_inner_text: bool = None,
@@ -15133,7 +15149,7 @@ class LocatorAssertions(SyncBase):
 
         Parameters
         ----------
-        expected : Union[List[Union[Pattern, str]], Pattern, str]
+        expected : Union[List[Union[Pattern[str], str]], Pattern[str], str]
             Expected substring or RegExp or a list of those.
         use_inner_text : Union[bool, NoneType]
             Whether to use `element.innerText` instead of `element.textContent` when retrieving DOM node text.

--- a/scripts/documentation_provider.py
+++ b/scripts/documentation_provider.py
@@ -372,8 +372,7 @@ class DocumentationProvider:
             args = get_args(value)
             return f"Callable[{', '.join(list(map(lambda a: self.serialize_python_type(a), args)))}]"
         if str(origin) == "<class 're.Pattern'>":
-            args = get_args(value)
-            return f"Pattern[{', '.join(list(map(lambda a: self.serialize_python_type(a), args)))}]"
+            return "Pattern[str]"
         if str(origin) == "typing.Literal":
             args = get_args(value)
             if len(args) == 1:

--- a/scripts/documentation_provider.py
+++ b/scripts/documentation_provider.py
@@ -371,6 +371,9 @@ class DocumentationProvider:
         if str(origin) == "<class 'collections.abc.Callable'>":
             args = get_args(value)
             return f"Callable[{', '.join(list(map(lambda a: self.serialize_python_type(a), args)))}]"
+        if str(origin) == "<class 're.Pattern'>":
+            args = get_args(value)
+            return f"Pattern[{', '.join(list(map(lambda a: self.serialize_python_type(a), args)))}]"
         if str(origin) == "typing.Literal":
             args = get_args(value)
             if len(args) == 1:
@@ -451,7 +454,7 @@ class DocumentationProvider:
         if type_name == "URL":
             return "str"
         if type_name == "RegExp":
-            return "Pattern"
+            return "Pattern[str]"
         if type_name == "null":
             return "NoneType"
         if type_name == "EvaluationArgument":


### PR DESCRIPTION
Fixes #1415.

Most of this change was generated. The actual changed code (aside from find and replace) is in `//scripts/documentation_provider.py`.

NB: Using bytes in patterns with our code will currently explode, so
this constrains to hint to users to use str patterns:

```py
# OK
await expect(page).to_have_url(re.compile(r".*/grid\.html"))
# BAD
await expect(page).to_have_url(re.compile(rb".*/grid\.html"))
```

This change opts to constrain the type rather than allow for bytes, too. If a user wants to use bytes, they can encode/decode explicitly.