### PR TITLE
chore: re-write connect to use driver

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -25,7 +25,6 @@ requirements:
     - python
     - greenlet ==1.1.2
     - pyee ==8.1.0
-    - websockets ==10.1
     - typing_extensions # [py<39]
 test:
   requires:

--- a/playwright/_impl/_browser.py
+++ b/playwright/_impl/_browser.py
@@ -191,7 +191,7 @@ class Browser(ChannelOwner):
             if not is_safe_close_error(e):
                 raise e
         if self._should_close_connection_on_close:
-            await self._connection.stop_async()
+            await self._connection.stop()
 
     @property
     def version(self) -> str:

--- a/playwright/_impl/_browser_type.py
+++ b/playwright/_impl/_browser_type.py
@@ -23,7 +23,6 @@ from playwright._impl._api_structures import (
     ProxySettings,
     ViewportSize,
 )
-from playwright._impl._api_types import Error
 from playwright._impl._browser import Browser, normalize_context_params
 from playwright._impl._browser_context import BrowserContext
 from playwright._impl._connection import (
@@ -42,8 +41,7 @@ from playwright._impl._helper import (
     ServiceWorkersPolicy,
     locals_to_params,
 )
-from playwright._impl._transport import WebSocketTransport
-from playwright._impl._wait_helper import throw_on_timeout
+from playwright._impl._json_pipe import JsonPipe
 
 if TYPE_CHECKING:
     from playwright._impl._playwright import Playwright
@@ -181,59 +179,50 @@ class BrowserType(ChannelOwner):
 
     async def connect(
         self,
-        ws_endpoint: str,
+        wsEndpoint: str,
         timeout: float = None,
-        slow_mo: float = None,
+        slowMo: float = None,
         headers: Dict[str, str] = None,
     ) -> Browser:
-        if timeout is None:
-            timeout = 30000
-
+        pipe: JsonPipe = from_channel(
+            await self._channel.send("connect", locals_to_params(locals()))
+        )
         headers = {**(headers if headers else {}), "x-playwright-browser": self.name}
 
-        transport = WebSocketTransport(
-            self._connection._loop, ws_endpoint, headers, slow_mo
-        )
         connection = Connection(
             self._connection._dispatcher_fiber,
             self._connection._object_factory,
-            transport,
-            self._connection._loop,
+            asyncio.get_running_loop(),
+            pipe.close,
             local_utils=self._connection.local_utils,
         )
         connection.mark_as_remote()
         connection._is_sync = self._connection._is_sync
-        connection._loop.create_task(connection.run())
-        playwright_future = connection.playwright_future
 
-        timeout_future = throw_on_timeout(timeout, Error("Connection timed out"))
-        done, pending = await asyncio.wait(
-            {transport.on_error_future, playwright_future, timeout_future},
-            return_when=asyncio.FIRST_COMPLETED,
-        )
-        if not playwright_future.done():
-            playwright_future.cancel()
-        if not timeout_future.done():
-            timeout_future.cancel()
-        playwright: "Playwright" = next(iter(done)).result()
-        playwright._set_selectors(self._playwright.selectors)
-        self._connection._child_ws_connections.append(connection)
-        pre_launched_browser = playwright._initializer.get("preLaunchedBrowser")
-        assert pre_launched_browser
-        browser = cast(Browser, from_channel(pre_launched_browser))
-        browser._should_close_connection_on_close = True
-
-        def handle_transport_close() -> None:
+        def pipe_closed() -> None:
             for context in browser.contexts:
                 for page in context.pages:
                     page._on_close()
                 context._on_close()
             browser._on_close()
-            connection.cleanup()
 
-        transport.once("close", handle_transport_close)
+        pipe.on("closed", pipe_closed)
 
-        browser._set_browser_type(self)
+        async def on_message(message: Dict) -> None:
+            try:
+                await pipe.send(message)
+            except Exception:
+                if not browser.is_connected:
+                    pipe_closed()
+                raise
+
+        connection.on_message = on_message
+        pipe.on("message", connection.dispatch)
+        await connection.init()
+        playwright = await connection.playwright_future
+        browser: Browser = from_channel(playwright._initializer["preLaunchedBrowser"])
+        browser._is_remote = True
+        browser._should_close_connection_on_close = True
         return browser
 
 

--- a/playwright/_impl/_connection.py
+++ b/playwright/_impl/_connection.py
@@ -215,7 +215,6 @@ class Connection(EventEmitter):
             self.playwright_future.set_result(await self._root_object.initialize())
 
         asyncio.create_task(init())
-        # self.emit("close")
 
     def call_on_object_with_known_name(
         self, guid: str, callback: Callable[[ChannelOwner], None]

--- a/playwright/_impl/_connection.py
+++ b/playwright/_impl/_connection.py
@@ -184,7 +184,9 @@ class Connection(EventEmitter):
         self._objects: Dict[str, ChannelOwner] = {}
         self._callbacks: Dict[int, ProtocolCallback] = {}
         self._is_sync = False
-        self.playwright_future: asyncio.Future["Playwright"] = asyncio.Future()
+        self.playwright_future: asyncio.Future[
+            "Playwright"
+        ] = self._loop.create_future()
         self.on_message: Callable[[Dict], Union[Awaitable[None], None]]
         self.on_close = on_close
         self._error: Optional[BaseException] = None

--- a/playwright/_impl/_json_pipe.py
+++ b/playwright/_impl/_json_pipe.py
@@ -1,0 +1,34 @@
+from types import SimpleNamespace
+from typing import Dict
+
+from playwright._impl._connection import ChannelOwner
+from playwright._impl._helper import locals_to_params
+
+
+class JsonPipe(ChannelOwner):
+    Events = SimpleNamespace(
+        Message="message",
+        Closed="closed",
+    )
+
+    def __init__(
+        self,
+        parent: ChannelOwner,
+        type: str,
+        guid: str,
+        initializer: Dict,
+    ) -> None:
+        super().__init__(parent, type, guid, initializer)
+        self._channel.on(
+            JsonPipe.Events.Message,
+            lambda msg: self.emit(JsonPipe.Events.Message, msg["message"]),
+        )
+        self._channel.on(
+            JsonPipe.Events.Closed, lambda _: self.emit(JsonPipe.Events.Closed)
+        )
+
+    async def send(self, message: Dict) -> None:
+        await self._channel.send("send", locals_to_params(locals()))
+
+    async def close(self) -> None:
+        await self._channel.send("close")

--- a/playwright/_impl/_object_factory.py
+++ b/playwright/_impl/_object_factory.py
@@ -26,6 +26,7 @@ from playwright._impl._element_handle import ElementHandle
 from playwright._impl._fetch import APIRequestContext
 from playwright._impl._frame import Frame
 from playwright._impl._js_handle import JSHandle
+from playwright._impl._json_pipe import JsonPipe
 from playwright._impl._local_utils import LocalUtils
 from playwright._impl._network import Request, Response, Route, WebSocket
 from playwright._impl._page import BindingCall, Page, Worker
@@ -40,7 +41,7 @@ class DummyObject(ChannelOwner):
     def __init__(
         self, parent: ChannelOwner, type: str, guid: str, initializer: Dict
     ) -> None:
-        super().__init__(parent, type, guid, initializer)
+        pass
 
 
 def create_remote_object(
@@ -70,6 +71,8 @@ def create_remote_object(
         return Frame(parent, type, guid, initializer)
     if type == "JSHandle":
         return JSHandle(parent, type, guid, initializer)
+    if type == "JsonPipe":
+        return JsonPipe(parent, type, guid, initializer)
     if type == "LocalUtils":
         local_utils = LocalUtils(parent, type, guid, initializer)
         if not local_utils._connection._local_utils:

--- a/playwright/_impl/_transport.py
+++ b/playwright/_impl/_transport.py
@@ -55,8 +55,6 @@ class PipeTransport:
 
         self.on_message: Callable[[ParsedMessagePayload], None]
         self._stopped_event = asyncio.Event()
-        # self.on_message: Callable[[ParsedMessagePayload], None] = lambda _: None
-        # self.on_error_future: asyncio.Future = loop.create_future()
 
     def request_stop(self) -> None:
         assert self._output

--- a/playwright/_impl/_transport.py
+++ b/playwright/_impl/_transport.py
@@ -54,7 +54,10 @@ class PipeTransport:
         self._loop = loop
 
         self.on_message: Callable[[ParsedMessagePayload], None]
-        self._stopped_event = asyncio.Event(loop=self._loop)
+        if sys.version_info >= (3, 10):
+            self._stopped_event = asyncio.Event()
+        else:
+            self._stopped_event = asyncio.Event(loop=self._loop)
 
     def request_stop(self) -> None:
         assert self._output

--- a/playwright/_impl/_transport.py
+++ b/playwright/_impl/_transport.py
@@ -54,7 +54,7 @@ class PipeTransport:
         self._loop = loop
 
         self.on_message: Callable[[ParsedMessagePayload], None]
-        self._stopped_event = asyncio.Event()
+        self._stopped_event = asyncio.Event(loop=self._loop)
 
     def request_stop(self) -> None:
         assert self._output

--- a/playwright/async_api/_generated.py
+++ b/playwright/async_api/_generated.py
@@ -11778,9 +11778,9 @@ class BrowserType(AsyncBase):
 
         return mapping.from_impl(
             await self._impl_obj.connect(
-                ws_endpoint=ws_endpoint,
+                wsEndpoint=ws_endpoint,
                 timeout=timeout,
-                slow_mo=slow_mo,
+                slowMo=slow_mo,
                 headers=mapping.to_impl(headers),
             )
         )

--- a/playwright/sync_api/_context_manager.py
+++ b/playwright/sync_api/_context_manager.py
@@ -101,7 +101,6 @@ Please use the Async API instead."""
         return self.__enter__()
 
     def __exit__(self, *args: Any) -> None:
-        # self._connection.stop_sync()
         self._transport.request_stop()
         self._dispatcher_fiber.switch()
         if self._watcher:

--- a/playwright/sync_api/_context_manager.py
+++ b/playwright/sync_api/_context_manager.py
@@ -68,7 +68,6 @@ Please use the Async API instead."""
         def greenlet_main() -> None:
             self._loop.run_until_complete(self._transport.run())
 
-
         self._dispatcher_fiber = dispatcher_fiber = greenlet(greenlet_main)
         self._connection = connection = Connection(
             dispatcher_fiber, create_remote_object, self._loop

--- a/playwright/sync_api/_context_manager.py
+++ b/playwright/sync_api/_context_manager.py
@@ -68,7 +68,6 @@ Please use the Async API instead."""
         def greenlet_main() -> None:
             self._loop.run_until_complete(self._transport.run())
 
-        # dispatcher_fiber = greenlet(greenlet_main)
 
         self._dispatcher_fiber = dispatcher_fiber = greenlet(greenlet_main)
         self._connection = connection = Connection(

--- a/playwright/sync_api/_generated.py
+++ b/playwright/sync_api/_generated.py
@@ -11819,9 +11819,9 @@ class BrowserType(SyncBase):
         return mapping.from_impl(
             self._sync(
                 self._impl_obj.connect(
-                    ws_endpoint=ws_endpoint,
+                    wsEndpoint=ws_endpoint,
                     timeout=timeout,
-                    slow_mo=slow_mo,
+                    slowMo=slow_mo,
                     headers=mapping.to_impl(headers),
                 )
             )

--- a/setup.py
+++ b/setup.py
@@ -208,7 +208,6 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     install_requires=[
-        "websockets==10.1",
         "greenlet==1.1.2",
         "pyee==8.1.0",
         "typing-extensions;python_version<='3.8'",

--- a/tests/async/test_browsertype_connect.py
+++ b/tests/async/test_browsertype_connect.py
@@ -144,7 +144,7 @@ async def test_browser_type_connect_should_throw_when_used_after_is_connected_re
 
     with pytest.raises(Error) as exc_info:
         await page.evaluate("1 + 1")
-    assert "Playwright connection closed" == exc_info.value.message
+    assert "Target page, context or browser has been closed" == exc_info.value.message
     assert browser.is_connected() is False
 
 
@@ -158,7 +158,7 @@ async def test_browser_type_connect_should_reject_navigation_when_browser_closes
 
     with pytest.raises(Error) as exc_info:
         await page.goto(server.PREFIX + "/one-style.html")
-    assert "Playwright connection closed" in exc_info.value.message
+    assert "Target page, context or browser has been closed" in exc_info.value.message
 
 
 async def test_should_not_allow_getting_the_path(
@@ -213,7 +213,7 @@ async def test_connect_to_closed_server_without_hangs(
     remote_server.kill()
     with pytest.raises(Error) as exc:
         await browser_type.connect(remote_server.ws_endpoint)
-    assert "websocket.connect: " in exc.value.message
+    assert "WebSocket error: connect ECONNREFUSED" in exc.value.message
 
 
 async def test_should_fulfill_with_global_fetch_result(

--- a/tests/sync/test_browsertype_connect.py
+++ b/tests/sync/test_browsertype_connect.py
@@ -140,7 +140,7 @@ def test_browser_type_connect_should_throw_when_used_after_is_connected_returns_
 
     with pytest.raises(Error) as exc_info:
         page.evaluate("1 + 1")
-    assert "Playwright connection closed" == exc_info.value.message
+    assert "Target page, context or browser has been closed" == exc_info.value.message
     assert browser.is_connected() is False
 
 
@@ -192,7 +192,7 @@ def test_connect_to_closed_server_without_hangs(
     remote_server.kill()
     with pytest.raises(Error) as exc:
         browser_type.connect(remote_server.ws_endpoint)
-    assert "websocket.connect: " in exc.value.message
+    assert "WebSocket error: connect ECONNREFUSED" in exc.value.message
 
 
 def test_browser_type_connect_should_fulfill_with_global_fetch_result(


### PR DESCRIPTION
Remove dependency on websocket lib, and use shared connect impl.

This aligns the implementation with .NET and Java by moving connect over to the server side.

Resolves #1177.