### PR TITLE
chore: roll Playwright to 1.25.0-alpha-jul-26-2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Playwright is a Python library to automate [Chromium](https://www.chromium.org/H
 
 |          | Linux | macOS | Windows |
 |   :---   | :---: | :---: | :---:   |
-| Chromium <!-- GEN:chromium-version -->104.0.5112.48<!-- GEN:stop --> | ✅ | ✅ | ✅ |
+| Chromium <!-- GEN:chromium-version -->104.0.5112.57<!-- GEN:stop --> | ✅ | ✅ | ✅ |
 | WebKit <!-- GEN:webkit-version -->16.0<!-- GEN:stop --> | ✅ | ✅ | ✅ |
 | Firefox <!-- GEN:firefox-version -->102.0<!-- GEN:stop --> | ✅ | ✅ | ✅ |
 

--- a/playwright/_impl/_browser_context.py
+++ b/playwright/_impl/_browser_context.py
@@ -100,9 +100,7 @@ class BrowserContext(ChannelOwner):
         self._service_workers: Set[Worker] = set()
         self._tracing = cast(Tracing, from_channel(initializer["tracing"]))
         self._har_recorders: Dict[str, HarRecordingMetadata] = {}
-        self._request: APIRequestContext = from_channel(
-            initializer["APIRequestContext"]
-        )
+        self._request: APIRequestContext = from_channel(initializer["requestContext"])
         self._channel.on(
             "bindingCall",
             lambda params: self._on_binding(from_channel(params["binding"])),

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ except ImportError:
     InWheel = None
 from wheel.bdist_wheel import bdist_wheel as BDistWheelCommand
 
-driver_version = "1.24.0"
+driver_version = "1.25.0-alpha-jul-26-2022"
 
 
 def extractall(zip: zipfile.ZipFile, path: str) -> None:

--- a/tests/async/test_launcher.py
+++ b/tests/async/test_launcher.py
@@ -21,7 +21,7 @@ from playwright.async_api import BrowserType, Error
 
 
 async def test_browser_type_launch_should_reject_all_promises_when_browser_is_closed(
-    browser_type: BrowserType, launch_arguments
+    browser_type: BrowserType, launch_arguments, is_chromium
 ):
     browser = await browser_type.launch(**launch_arguments)
     page = await (await browser.new_context()).new_page()
@@ -29,7 +29,10 @@ async def test_browser_type_launch_should_reject_all_promises_when_browser_is_cl
     await page.close()
     with pytest.raises(Error) as exc:
         await never_resolves
-    assert "Target closed" in exc.value.message
+    if is_chromium:
+        assert "Target page, context or browser has been closed" in exc.value.message
+    else:
+        assert "Target closed" in exc.value.message
 
 
 @pytest.mark.skip_browser("firefox")

--- a/tests/async/test_launcher.py
+++ b/tests/async/test_launcher.py
@@ -21,7 +21,7 @@ from playwright.async_api import BrowserType, Error
 
 
 async def test_browser_type_launch_should_reject_all_promises_when_browser_is_closed(
-    browser_type: BrowserType, launch_arguments, is_chromium
+    browser_type: BrowserType, launch_arguments
 ):
     browser = await browser_type.launch(**launch_arguments)
     page = await (await browser.new_context()).new_page()
@@ -29,10 +29,10 @@ async def test_browser_type_launch_should_reject_all_promises_when_browser_is_cl
     await page.close()
     with pytest.raises(Error) as exc:
         await never_resolves
-    if is_chromium:
-        assert "Target page, context or browser has been closed" in exc.value.message
-    else:
-        assert "Target closed" in exc.value.message
+    assert (
+        "Target closed" in exc.value.message
+        or "Target page, context or browser has been closed" in exc.value.message
+    )
 
 
 @pytest.mark.skip_browser("firefox")


### PR DESCRIPTION
- Roll to fix MSEdge downloads

Ports:

- [chore: reparent context objects into the object (#15689)](https://github.com/microsoft/playwright/commit/a198b6d753d7710be55236ea31256c9518fb9cf5)

Resolves #1398.