### PR TITLE
chore: publish official jammy image

### DIFF
--- a/.github/workflows/test_docker.yml
+++ b/.github/workflows/test_docker.yml
@@ -20,6 +20,12 @@ jobs:
   build:
     timeout-minutes: 60
     runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        docker-image-variant:
+          - focal
+          - jammy
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -32,10 +38,10 @@ jobs:
         pip install -r local-requirements.txt
         pip install -e .
     - name: Build Docker image
-      run: bash utils/docker/build.sh --amd64 focal playwright-python:localbuild-focal
+      run: bash utils/docker/build.sh --amd64 ${{ matrix.docker-image-variant }} playwright-python:localbuild-${{ matrix.docker-image-variant }}
     - name: Test
       run: |
-        CONTAINER_ID="$(docker run --rm -v $(pwd):/root/playwright --name playwright-docker-test --workdir /root/playwright/ -d -t playwright-python:localbuild-focal /bin/bash)"
+        CONTAINER_ID="$(docker run --rm -v $(pwd):/root/playwright --name playwright-docker-test --workdir /root/playwright/ -d -t playwright-python:localbuild-${{ matrix.docker-image-variant }} /bin/bash)"
         # Fix permissions for Git inside the container
         docker exec "${CONTAINER_ID}" chown -R root:root /root/playwright
         docker exec "${CONTAINER_ID}" pip install -r local-requirements.txt

--- a/.github/workflows/test_docker.yml
+++ b/.github/workflows/test_docker.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   build:
     timeout-minutes: 60
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/trigger_internal_tests.yml
+++ b/.github/workflows/trigger_internal_tests.yml
@@ -1,0 +1,21 @@
+name: "Internal Tests"
+
+on:
+  push:
+    branches:
+      - main
+      - release-*
+
+jobs:
+  trigger:
+    name: "trigger"
+    runs-on: ubuntu-20.04
+    steps:
+    - run: |
+        curl -X POST \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: token ${GH_TOKEN}" \
+          --data "{\"event_type\": \"playwright_tests_python\", \"client_payload\": {\"ref\": \"${GITHUB_SHA}\"}}" \
+          https://api.github.com/repos/microsoft/playwright-internal/dispatches
+      env:
+        GH_TOKEN: ${{ secrets.REPOSITORY_DISPATCH_PERSONAL_ACCESS_TOKEN }}

--- a/utils/docker/Dockerfile.jammy
+++ b/utils/docker/Dockerfile.jammy
@@ -1,0 +1,46 @@
+FROM ubuntu:jammy
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG TZ=America/Los_Angeles
+ARG DOCKER_IMAGE_NAME_TEMPLATE="mcr.microsoft.com/playwright/python:v%version%-jammy"
+
+# === INSTALL Python ===
+
+RUN apt-get update && \
+    # Install Python
+    apt-get install -y python3 python3-distutils curl && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
+    curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+    python get-pip.py && \
+    rm get-pip.py && \
+    # Feature-parity with node.js base images.
+    apt-get install -y --no-install-recommends git openssh-client gpg && \
+    # clean apt cache
+    rm -rf /var/lib/apt/lists/* && \
+    # Create the pwuser
+    adduser pwuser
+
+# === BAKE BROWSERS INTO IMAGE ===
+
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+# 1. Add tip-of-tree Playwright package to install its browsers.
+#    The package should be built beforehand from tip-of-tree Playwright.
+COPY ./dist/*-manylinux*.whl /tmp/
+
+# 2. Bake in browsers & deps.
+#    Browsers will be downloaded in `/ms-playwright`.
+#    Note: make sure to set 777 to the registry so that any user can access
+#    registry.
+RUN mkdir /ms-playwright && \
+    mkdir /ms-playwright-agent && \
+    cd /ms-playwright-agent && \
+    # if its amd64 then install the manylinux1_x86_64 pip package
+    if [ "$(uname -m)" = "x86_64" ]; then pip install /tmp/*manylinux1_x86_64*.whl; fi && \
+    # if its arm64 then install the manylinux1_aarch64 pip package
+    if [ "$(uname -m)" = "aarch64" ]; then pip install /tmp/*manylinux_2_17_aarch64*.whl; fi && \
+    playwright mark-docker-image "${DOCKER_IMAGE_NAME_TEMPLATE}" && \
+    playwright install --with-deps && rm -rf /var/lib/apt/lists/* && \
+    rm /tmp/*.whl && \
+    rm -rf /ms-playwright-agent && \
+    chmod -R 777 /ms-playwright

--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -3,7 +3,7 @@ set -e
 set +x
 
 if [[ ($1 == '--help') || ($1 == '-h') || ($1 == '') || ($2 == '') ]]; then
-  echo "usage: $(basename $0) {--arm64,--amd64} {bionic,focal} playwright:localbuild-focal"
+  echo "usage: $(basename $0) {--arm64,--amd64} {bionic,focal,jammy} playwright:localbuild-focal"
   echo
   echo "Build Playwright docker image and tag it as 'playwright:localbuild-focal'."
   echo "Once image is built, you can run it with"

--- a/utils/docker/publish_docker.sh
+++ b/utils/docker/publish_docker.sh
@@ -123,11 +123,16 @@ publish_docker_manifest () {
   done
 }
 
+# Bionic
 publish_docker_images_with_arch_suffix bionic amd64
 publish_docker_manifest bionic amd64
 
+# Focal
 publish_docker_images_with_arch_suffix focal amd64
 publish_docker_images_with_arch_suffix focal arm64
+publish_docker_manifest focal amd64 arm64
+
+# Jammy
 publish_docker_images_with_arch_suffix jammy amd64
 publish_docker_images_with_arch_suffix jammy arm64
-publish_docker_manifest focal amd64 arm64
+publish_docker_manifest jammy amd64 arm64

--- a/utils/docker/publish_docker.sh
+++ b/utils/docker/publish_docker.sh
@@ -44,6 +44,13 @@ FOCAL_TAGS=(
   "next-focal"
 )
 
+JAMMY_TAGS=(
+  "next-jammy"
+)
+if [[ "$RELEASE_CHANNEL" == "stable" ]]; then
+  JAMMY_TAGS+=("jammy")
+fi
+
 if [[ "$RELEASE_CHANNEL" == "stable" ]]; then
   FOCAL_TAGS+=("latest")
   FOCAL_TAGS+=("focal")
@@ -66,8 +73,10 @@ publish_docker_images_with_arch_suffix() {
     TAGS=("${BIONIC_TAGS[@]}")
   elif [[ "$FLAVOR" == "focal" ]]; then
     TAGS=("${FOCAL_TAGS[@]}")
+  elif [[ "$FLAVOR" == "jammy" ]]; then
+    TAGS=("${JAMMY_TAGS[@]}")
   else
-    echo "ERROR: unknown flavor - $FLAVOR. Must be either 'bionic' or 'focal'"
+    echo "ERROR: unknown flavor - $FLAVOR. Must be either 'bionic', 'focal', or 'jammy'"
     exit 1
   fi
   local ARCH="$2"
@@ -92,8 +101,10 @@ publish_docker_manifest () {
     TAGS=("${BIONIC_TAGS[@]}")
   elif [[ "$FLAVOR" == "focal" ]]; then
     TAGS=("${FOCAL_TAGS[@]}")
+  elif [[ "$FLAVOR" == "jammy" ]]; then
+    TAGS=("${JAMMY_TAGS[@]}")
   else
-    echo "ERROR: unknown flavor - $FLAVOR. Must be either 'bionic' or 'focal'"
+    echo "ERROR: unknown flavor - $FLAVOR. Must be either 'bionic', 'focal', or 'jammy'"
     exit 1
   fi
 

--- a/utils/docker/publish_docker.sh
+++ b/utils/docker/publish_docker.sh
@@ -128,4 +128,6 @@ publish_docker_manifest bionic amd64
 
 publish_docker_images_with_arch_suffix focal amd64
 publish_docker_images_with_arch_suffix focal arm64
+publish_docker_images_with_arch_suffix jammy amd64
+publish_docker_images_with_arch_suffix jammy arm64
 publish_docker_manifest focal amd64 arm64


### PR DESCRIPTION
Resolves https://github.com/microsoft/playwright-python/issues/1294.

For now, we leave `focal` as the default docker image. When v1.25 is announced, we can notify users the default base image will be changing in some future release (v1.26?) to jammy. (We should coordinate this across language ports.)

As of this writing, Python 3.10 is what ships in our jammy image.

Testing:
- Until jammy is our default base image, we'll run our tests in both focal and jammy in CI.
- This repo's tests covers amd; internal bots will cover arm. 