### PR TITLE
`pre-commit` version upgrades

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.3.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -15,16 +15,16 @@ repos:
       - id: check-executables-have-shebangs
       - id: check-merge-conflict
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.6.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.942
+    rev: v0.971
     hooks:
       - id: mypy
         additional_dependencies: [types-pyOpenSSL==21.0.3]
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
       - id: flake8
   - repo: https://github.com/pycqa/isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.1.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -15,16 +15,16 @@ repos:
       - id: check-executables-have-shebangs
       - id: check-merge-conflict
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.971
+    rev: v0.942
     hooks:
       - id: mypy
         additional_dependencies: [types-pyOpenSSL==21.0.3]
   - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+    rev: 4.0.1
     hooks:
       - id: flake8
   - repo: https://github.com/pycqa/isort

--- a/playwright/_impl/_sync_base.py
+++ b/playwright/_impl/_sync_base.py
@@ -16,7 +16,19 @@ import asyncio
 import inspect
 import traceback
 from types import TracebackType
-from typing import Any, Awaitable, Callable, Dict, Generic, List, Type, TypeVar, cast
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    Dict,
+    Generator,
+    Generic,
+    List,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+)
 
 import greenlet
 
@@ -75,10 +87,13 @@ class SyncBase(ImplWrapper):
     def __str__(self) -> str:
         return self._impl_obj.__str__()
 
-    def _sync(self, coro: Awaitable) -> Any:
+    def _sync(
+        self,
+        coro: Union[Coroutine[Any, Any, Any], Generator[Any, Any, Any]],
+    ) -> Any:
         __tracebackhide__ = True
         g_self = greenlet.getcurrent()
-        task = self._loop.create_task(coro)
+        task: asyncio.tasks.Task[Any] = self._loop.create_task(coro)
         setattr(task, "__pw_stack__", inspect.stack())
         setattr(task, "__pw_stack_trace__", traceback.extract_stack())
 


### PR DESCRIPTION
Hi, small patch to bump pre-commit hook versions and silence the current `mypy` complaints about the sync api base.

Thanks