### PR TITLE
expose `PlaywrightContextManager` in the public API

### DIFF
--- a/playwright/sync_api/__init__.py
+++ b/playwright/sync_api/__init__.py
@@ -146,6 +146,7 @@ __all__ = [
     "PdfMargins",
     "Position",
     "Playwright",
+    "PlaywrightContextManager",
     "ProxySettings",
     "Request",
     "ResourceTiming",


### PR DESCRIPTION
closes #1492.  This exports `PlaywrightContextManager` officially in the public API to stop complaints from tools/IDE's when trying to type wrapper code, inherit from it etc etc, given `sync_playwright()` is public, I think the type of it should be too.

`async` api is likely to also complain similarly