### PR TITLE
test: ensure device descriptor tests pass on chrome bots

### DIFF
--- a/tests/async/test_device_descriptors.py
+++ b/tests/async/test_device_descriptors.py
@@ -2,10 +2,10 @@ import pytest
 
 
 @pytest.mark.only_browser("chromium")
-async def test_should_work(playwright) -> None:
+async def test_should_work(playwright, launch_arguments) -> None:
     device_descriptor = playwright.devices["Pixel 2"]
     device_type = device_descriptor["default_browser_type"]
-    browser = await playwright[device_type].launch()
+    browser = await playwright[device_type].launch(**launch_arguments)
     context = await browser.new_context(
         **device_descriptor,
     )


### PR DESCRIPTION
Follow-up to #1497.

Fixes https://github.com/microsoft/playwright-python/runs/7843392919?check_suite_focus=true.