### PR TITLE
fix: do not export scripts package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -205,7 +205,7 @@ setup(
     long_description=Path("README.md").read_text(encoding="utf-8"),
     long_description_content_type="text/markdown",
     url="https://github.com/Microsoft/playwright-python",
-    packages=find_packages(exclude=["tests*"]),
+    packages=find_packages(exclude=["tests*", "scripts"]),
     include_package_data=True,
     install_requires=[
         "websockets==10.1",


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-python/issues/1500

```
>>> find_packages(exclude=["tests*"])
['playwright', 'scripts', 'playwright._impl', 'playwright.async_api', 'playwright.sync_api', 'playwright._impl.__pyinstaller']
>>> find_packages(exclude=["tests*", "scripts"])
['playwright', 'playwright._impl', 'playwright.async_api', 'playwright.sync_api', 'playwright._impl.__pyinstaller']
>>> 
```