### PR TITLE
chore(build): have allow-list in setup.py included packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -205,7 +205,7 @@ setup(
     long_description=Path("README.md").read_text(encoding="utf-8"),
     long_description_content_type="text/markdown",
     url="https://github.com/Microsoft/playwright-python",
-    packages=["playwright", "playwright.async_api", "playwright.sync_api"],
+    packages=["playwright"],
     include_package_data=True,
     install_requires=[
         "websockets==10.1",

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ import zipfile
 from pathlib import Path
 from typing import Dict, List
 
-from setuptools import find_packages, setup
+from setuptools import setup
 
 try:
     from auditwheel.wheeltools import InWheel
@@ -205,7 +205,7 @@ setup(
     long_description=Path("README.md").read_text(encoding="utf-8"),
     long_description_content_type="text/markdown",
     url="https://github.com/Microsoft/playwright-python",
-    packages=find_packages(exclude=["tests*"]),
+    packages=["playwright", "playwright.async_api", "playwright.sync_api"],
     include_package_data=True,
     install_requires=[
         "websockets==10.1",


### PR DESCRIPTION
Before it was the following:

```
>>> find_packages(exclude=["tests*"])
['playwright', 'playwright._impl', 'playwright.async_api', 'playwright.sync_api', 'playwright._impl.__pyinstaller']
```

after reducing it to the shown in the PR, it was still fine with my local integration tests (build wheel, install from wheel).

Fixes https://github.com/microsoft/playwright-python/issues/1504.