### PR TITLE
chore: marke pathAfterFinished return value optional

### DIFF
--- a/playwright/_impl/_artifact.py
+++ b/playwright/_impl/_artifact.py
@@ -33,7 +33,8 @@ class Artifact(ChannelOwner):
             raise Error(
                 "Path is not available when using browser_type.connect(). Use save_as() to save a local copy."
             )
-        return pathlib.Path(await self._channel.send("pathAfterFinished"))
+        path = await self._channel.send("pathAfterFinished")
+        return pathlib.Path(path) if path else None
 
     async def save_as(self, path: Union[str, Path]) -> None:
         stream = cast(Stream, from_channel(await self._channel.send("saveAsStream")))


### PR DESCRIPTION
Relates https://github.com/microsoft/playwright-python/issues/1557

This aligns it with the upstream implementation: https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/client/artifact.ts#L32