### PR TITLE
Add release notes link to PyPI page

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -205,6 +205,9 @@ setup(
     long_description=Path("README.md").read_text(encoding="utf-8"),
     long_description_content_type="text/markdown",
     url="https://github.com/Microsoft/playwright-python",
+    project_urls={
+        "Release notes": "https://playwright.dev/python/docs/release-notes",
+    },
     packages=["playwright"],
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
Gives you a nice link in the left "Project links" section like on e.g. https://pypi.org/project/django-cors-headers/ . Will make it easier for those upgrading the package to find the release notes.