### PR TITLE
Draft: Upgrade to pyee>=9.0.0

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -24,7 +24,7 @@ requirements:
   run:
     - python
     - greenlet ==1.1.3
-    - pyee ==8.1.0
+    - pyee ==9.0.4
     - typing_extensions # [py<39]
 test:
   requires:

--- a/meta.yaml
+++ b/meta.yaml
@@ -24,7 +24,7 @@ requirements:
   run:
     - python
     - greenlet ==1.1.3
-    - pyee ==9.0.4
+    - pyee >=9.0.0
     - typing_extensions # [py<39]
 test:
   requires:

--- a/playwright/_impl/_connection.py
+++ b/playwright/_impl/_connection.py
@@ -24,7 +24,6 @@ from greenlet import greenlet
 from pyee import EventEmitter
 from pyee.asyncio import AsyncIOEventEmitter
 
-
 import playwright
 from playwright._impl._helper import ParsedMessagePayload, parse_error
 from playwright._impl._transport import Transport

--- a/playwright/_impl/_connection.py
+++ b/playwright/_impl/_connection.py
@@ -21,7 +21,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, cast
 
 from greenlet import greenlet
-from pyee import AsyncIOEventEmitter, EventEmitter
+from pyee import EventEmitter
+from pyee.asyncio import AsyncIOEventEmitter
+
 
 import playwright
 from playwright._impl._helper import ParsedMessagePayload, parse_error

--- a/playwright/_impl/_json_pipe.py
+++ b/playwright/_impl/_json_pipe.py
@@ -15,7 +15,7 @@
 import asyncio
 from typing import Dict, Optional, cast
 
-from pyee import AsyncIOEventEmitter
+from pyee.asyncio import AsyncIOEventEmitter
 
 from playwright._impl._api_types import Error
 from playwright._impl._connection import Channel

--- a/setup.py
+++ b/setup.py
@@ -212,7 +212,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "greenlet==1.1.3",
-        "pyee==8.1.0",
+        "pyee>=9.0.0",
         "typing-extensions;python_version<='3.8'",
     ],
     classifiers=[


### PR DESCRIPTION
Python playwright uses an old-ish version of `pyee` (8.1.0) - this PR upgrades to >=9.0.0. There was a previous attempt [here](https://github.com/microsoft/playwright-python/pull/1117) but was never merged because of pyee >=9.0.0 was not available in conda at that time. This is no longer the case:

```
❯ conda search -f pyee
Loading channels: done
# Name                       Version           Build  Channel
...
pyee                           8.0.1    pyh9f0ad1d_0  conda-forge
pyee                           8.1.0    pyh9f0ad1d_0  conda-forge
pyee                           8.1.0    pyhd8ed1ab_0  conda-forge
pyee                           9.0.2    pyhd8ed1ab_0  conda-forge
pyee                           9.0.4    pyhd8ed1ab_0  conda-forge
```

No regression between main and this branch.

Thanks for taking a look 🙏 