### PR TITLE
chore: don't use a function call in default initializer

### DIFF
--- a/playwright/_impl/_impl_to_api_mapping.py
+++ b/playwright/_impl/_impl_to_api_mapping.py
@@ -87,7 +87,11 @@ class ImplToApiMapping:
     def from_impl_dict(self, map: Dict[str, Any]) -> Dict[str, Any]:
         return {name: self.from_impl(value) for name, value in map.items()}
 
-    def to_impl(self, obj: Any, visited: Map[Any, Union[List, Dict]] = Map()) -> Any:
+    def to_impl(
+        self, obj: Any, visited: Optional[Map[Any, Union[List, Dict]]] = None
+    ) -> Any:
+        if visited is None:
+            visited = Map()
         try:
             if not obj:
                 return obj

--- a/playwright/_impl/_js_handle.py
+++ b/playwright/_impl/_js_handle.py
@@ -105,8 +105,10 @@ class JSHandle(ChannelOwner):
 
 
 def serialize_value(
-    value: Any, handles: List[JSHandle], visitor_info: VisitorInfo = VisitorInfo()
+    value: Any, handles: List[JSHandle], visitor_info: Optional[VisitorInfo] = None
 ) -> Any:
+    if visitor_info is None:
+        visitor_info = VisitorInfo()
     if isinstance(value, JSHandle):
         h = len(handles)
         handles.append(value._channel)
@@ -160,7 +162,9 @@ def serialize_argument(arg: Serializable = None) -> Any:
     return dict(value=value, handles=handles)
 
 
-def parse_value(value: Any, refs: Dict[int, Any] = {}) -> Any:
+def parse_value(value: Any, refs: Optional[Dict[int, Any]] = None) -> Any:
+    if refs is None:
+        refs = {}
     if value is None:
         return None
     if isinstance(value, dict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,4 @@ ignore = ["tests/async/", "scripts/", "examples/"]
 pythonVersion = "3.7"
 reportMissingImports = false
 reportTypedDictNotRequiredAccess = false
+reportCallInDefaultInitializer = true


### PR DESCRIPTION
Also verified that https://github.com/microsoft/playwright-python/pull/1604 was reported with this linting rule before.