### PR TITLE
Use SPDX license expression in project metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -204,6 +204,7 @@ setup(
     description="A high-level API to automate web browsers",
     long_description=Path("README.md").read_text(encoding="utf-8"),
     long_description_content_type="text/markdown",
+    license="Apache-2.0",
     url="https://github.com/Microsoft/playwright-python",
     project_urls={
         "Release notes": "https://github.com/microsoft/playwright-python/releases",


### PR DESCRIPTION
As a downstream user it is desirable to be able to programmatically determine the precise licenses used by our dependencies. The emerging convention for this is the [SPDX License List](https://spdx.org/licenses/). SPDX License Expressions are already used in the JavaScript (npm) and Rust (crates.io) ecosystems, for example.

In Python, there is [PEP 639](https://peps.python.org/pep-0639/) which would add a standard 'License-Expression' metadata field. The discussion around this PEP seems to have gone stale in 2021.

This merge request is in lieu of that PEP coming soon. Unless you as project maintainers think the proposed change in this PR has downsides (which you are entitled to!), I would ask that you accept this change so that it's possible for users to attempt to parse your license metadata as an SPDX License Expression.

If PEP 639 is accepted, this package would be ready for the change just by changing the `license` key to `license_expression` or whatever key the PEP lands on.