### PR TITLE
chore: hide Window always on Windows

### DIFF
--- a/playwright/_impl/_transport.py
+++ b/playwright/_impl/_transport.py
@@ -107,9 +107,8 @@ class PipeTransport(Transport):
 
     async def connect(self) -> None:
         self._stopped_future: asyncio.Future = asyncio.Future()
-        # Hide the command-line window on Windows when using Pythonw.exe
         creationflags = 0
-        if sys.platform == "win32" and sys.stdout is None:
+        if sys.platform == "win32":
             creationflags = subprocess.CREATE_NO_WINDOW
 
         try:


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-python/issues/1646

Saw this popping up multiple times in the past from different customers. In .NET we e.g. set this bit also always on Windows: https://github.com/microsoft/playwright-dotnet/blob/main/src/Playwright/Transport/StdIOTransport.cs#L120