### PR TITLE
cherry-pick(#1700): fix: fulfill with json

### DIFF
--- a/playwright/_impl/_network.py
+++ b/playwright/_impl/_network.py
@@ -16,6 +16,7 @@ import asyncio
 import base64
 import inspect
 import json
+import json as json_utils
 import mimetypes
 import sys
 from collections import defaultdict
@@ -288,6 +289,12 @@ class Route(ChannelOwner):
     ) -> None:
         self._check_not_handled()
         params = locals_to_params(locals())
+
+        if json is not None:
+            if body is not None:
+                raise Error("Can specify either body or json parameters")
+            body = json_utils.dumps(json)
+
         if response:
             del params["response"]
             params["status"] = (
@@ -298,8 +305,6 @@ class Route(ChannelOwner):
             )
             from playwright._impl._fetch import APIResponse
 
-            if json is not None:
-                body = json.dumps(json)
             if body is None and path is None and isinstance(response, APIResponse):
                 if response._request._connection is self._connection:
                     params["fetchResponseUid"] = response._fetch_uid

--- a/tests/async/test_request_fulfill.py
+++ b/tests/async/test_request_fulfill.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+
 from playwright.async_api import Page, Route
 from tests.server import Server
 
@@ -25,3 +27,52 @@ async def test_should_fetch_original_request_and_fulfill(page: Page, server: Ser
     response = await page.goto(server.PREFIX + "/title.html")
     assert response.status == 200
     assert await page.title() == "Woof-Woof"
+
+
+async def test_should_fulfill_json(page: Page, server: Server) -> None:
+    async def handle(route: Route) -> None:
+        await route.fulfill(status=201, headers={"foo": "bar"}, json={"bar": "baz"})
+
+    await page.route("**/*", handle)
+
+    response = await page.goto(server.EMPTY_PAGE)
+    assert response
+    assert response.status == 201
+    assert response.headers["content-type"] == "application/json"
+    assert json.loads(await page.evaluate("document.body.textContent")) == {
+        "bar": "baz"
+    }
+
+
+async def test_should_fulfill_json_overriding_existing_response(
+    page: Page, server: Server
+) -> None:
+    server.set_route(
+        "/tags",
+        lambda request: (
+            request.setHeader("foo", "bar"),
+            request.write('{"tags": ["a", "b"]}'.encode()),
+            request.finish(),
+        ),
+    )
+
+    original = {}
+
+    async def handle(route: Route) -> None:
+        response = await route.fetch()
+        json = await response.json()
+        original["tags"] = json["tags"]
+        json["tags"] = ["c"]
+        await route.fulfill(response=response, json=json)
+
+    await page.route("**/*", handle)
+
+    response = await page.goto(server.PREFIX + "/tags")
+    assert response
+    assert response.status == 200
+    assert response.headers["content-type"] == "application/json"
+    assert response.headers["foo"] == "bar"
+    assert original["tags"] == ["a", "b"]
+    assert json.loads(await page.evaluate("document.body.textContent")) == {
+        "tags": ["c"]
+    }


### PR DESCRIPTION
Resolves #1693.

Relates microsoft/playwright#19184 (original upstream change). Relates #1684 (original Python rolling introducing the feature to the port).