### PR TITLE
Allow entry point to be called from a script

### DIFF
--- a/playwright/__main__.py
+++ b/playwright/__main__.py
@@ -18,10 +18,12 @@ import sys
 from playwright._impl._driver import compute_driver_executable, get_driver_env
 
 
-def main() -> None:
+def main(*args) -> None:
+    if len(args) == 0:
+        args = sys.argv[1:]
     driver_executable = compute_driver_executable()
     completed_process = subprocess.run(
-        [str(driver_executable), *sys.argv[1:]], env=get_driver_env()
+        [str(driver_executable), *args], env=get_driver_env()
     )
     sys.exit(completed_process.returncode)
 


### PR DESCRIPTION
Adds arguments to `main()` to support being called directly by a script.