### PR TITLE
fix: throw when driver crashes

### DIFF
--- a/playwright/_impl/_transport.py
+++ b/playwright/_impl/_transport.py
@@ -153,7 +153,10 @@ class PipeTransport(Transport):
 
                 obj = self.deserialize_message(buffer)
                 self.on_message(obj)
-            except asyncio.IncompleteReadError:
+            except asyncio.IncompleteReadError as exc:
+                self.on_error_future.set_exception(
+                    Exception("Connection closed while reading from the driver")
+                )
                 break
             await asyncio.sleep(0)
 

--- a/playwright/_impl/_transport.py
+++ b/playwright/_impl/_transport.py
@@ -153,10 +153,11 @@ class PipeTransport(Transport):
 
                 obj = self.deserialize_message(buffer)
                 self.on_message(obj)
-            except asyncio.IncompleteReadError as exc:
-                self.on_error_future.set_exception(
-                    Exception("Connection closed while reading from the driver")
-                )
+            except asyncio.IncompleteReadError:
+                if not self._stopped:
+                    self.on_error_future.set_exception(
+                        Exception("Connection closed while reading from the driver")
+                    )
                 break
             await asyncio.sleep(0)
 


### PR DESCRIPTION
Before that the transport used to hang when the process died.

Fixes https://github.com/microsoft/playwright-python/issues/1779