### PR TITLE
test: make wheel tests pass on CR/darwin

### DIFF
--- a/tests/async/test_input.py
+++ b/tests/async/test_input.py
@@ -14,8 +14,8 @@
 
 import asyncio
 import os
-import sys
 import re
+import sys
 
 import pytest
 


### PR DESCRIPTION
This mirrors the following upstream logic: https://github.com/microsoft/playwright/blob/3ff3567c89a774a9e2086af07a858266d84d41fe/tests/page/wheel.spec.ts#L25-L34