### PR TITLE
fix: inherit context timeout correctly

### DIFF
--- a/playwright/_impl/_helper.py
+++ b/playwright/_impl/_helper.py
@@ -177,8 +177,8 @@ class HarLookupResult(TypedDict, total=False):
 class TimeoutSettings:
     def __init__(self, parent: Optional["TimeoutSettings"]) -> None:
         self._parent = parent
-        self._timeout = 30000.0
-        self._navigation_timeout = 30000.0
+        self._timeout: Optional[float] = None
+        self._navigation_timeout: Optional[float] = None
 
     def set_timeout(self, timeout: float) -> None:
         self._timeout = timeout

--- a/tests/async/test_page.py
+++ b/tests/async/test_page.py
@@ -18,7 +18,7 @@ import re
 
 import pytest
 
-from playwright.async_api import Error, Page, Route, TimeoutError
+from playwright.async_api import BrowserContext, Error, Page, Route, TimeoutError
 from tests.server import Server
 
 
@@ -329,6 +329,19 @@ async def test_wait_for_response_should_work_with_no_timeout(page, server):
         )
     response = await response_info.value
     assert response.url == server.PREFIX + "/digits/2.png"
+
+
+async def test_wait_for_response_should_use_context_timeout(
+    page: Page, context: BrowserContext, server: Server
+) -> None:
+    await page.goto(server.EMPTY_PAGE)
+
+    context.set_default_timeout(1_000)
+    with pytest.raises(Error) as exc_info:
+        async with page.expect_response("https://playwright.dev"):
+            pass
+    assert exc_info.type is TimeoutError
+    assert "Timeout 1000ms exceeded" in exc_info.value.message
 
 
 async def test_expose_binding(page):

--- a/tests/sync/test_sync.py
+++ b/tests/sync/test_sync.py
@@ -277,3 +277,16 @@ def test_expect_response_should_work(page: Page, server: Server) -> None:
     assert resp.value.status == 200
     assert resp.value.ok
     assert resp.value.request
+
+
+def test_expect_response_should_use_context_timeout(
+    page: Page, context: BrowserContext, server: Server
+) -> None:
+    page.goto(server.EMPTY_PAGE)
+
+    context.set_default_timeout(1_000)
+    with pytest.raises(Error) as exc_info:
+        with page.expect_response("https://playwright.dev"):
+            pass
+    assert exc_info.type is TimeoutError
+    assert "Timeout 1000ms exceeded" in exc_info.value.message


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-python/issues/1883