### PR TITLE
chore: do not continue with no_reply messages

### DIFF
--- a/playwright/_impl/_connection.py
+++ b/playwright/_impl/_connection.py
@@ -68,8 +68,7 @@ class Channel(AsyncIOEventEmitter):
         )
 
     def send_no_reply(self, method: str, params: Dict = None) -> None:
-        # No reply messages are used to e.g. waitForEventInfo(after) which returns exceptions on page close.
-        # To prevent 'Future exception was never retrieved' we just ignore such messages.
+        # No reply messages are used to e.g. waitForEventInfo(after).
         self._connection.wrap_api_call_sync(
             lambda: self._connection._send_message_to_server(
                 self._guid, method, {} if params is None else params, True

--- a/playwright/_impl/_connection.py
+++ b/playwright/_impl/_connection.py
@@ -68,6 +68,8 @@ class Channel(AsyncIOEventEmitter):
         )
 
     def send_no_reply(self, method: str, params: Dict = None) -> None:
+        # No reply messages are used to e.g. waitForEventInfo(after) which returns exceptions on page close.
+        # To prevent 'Future exception was never retrieved' we just ignore such messages.
         self._connection.wrap_api_call_sync(
             lambda: self._connection._send_message_to_server(
                 self._guid, method, {} if params is None else params, True
@@ -359,6 +361,8 @@ class Connection(EventEmitter):
             callback = self._callbacks.pop(id)
             if callback.future.cancelled():
                 return
+            # No reply messages are used to e.g. waitForEventInfo(after) which returns exceptions on page close.
+            # To prevent 'Future exception was never retrieved' we just ignore such messages.
             if callback.no_reply:
                 return
             error = msg.get("error")


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-python/issues/1903

Tricky to test that a warning does not get displayed. Before the following:

```python
from playwright.sync_api import sync_playwright

with sync_playwright() as playwright:
    browser = playwright.chromium.launch()
    page = browser.new_page()
    page.goto('http://example.com/')
    with page.expect_popup() as popup_info:
        page.evaluate('window.open("http://example.com/")')
    popup = popup_info.value
    with popup.expect_event('close') as popup_info:
        popup.evaluate('window.close()')
    browser.close()
```

resulted in:

```
(env) ➜  playwright-python git:(main) ✗ python test.py
Future exception was never retrieved
future: <Future finished exception=Error('Target page, context or browser has been closed')>
playwright._impl._api_types.Error: Target page, context or browser has been closed
```

because the "after" `"waitForEventInfo"` call was returning an exception and in Python you need to await all the exceptions.

Ways thought about fixing it:
a) never add it to the self._callbacks
b) add a special no_reply flag to the callbacks - did this for now.