### PR TITLE
test: add test for Command + C does not terminate driver connection

### DIFF
--- a/playwright/_impl/_transport.py
+++ b/playwright/_impl/_transport.py
@@ -121,6 +121,7 @@ class PipeTransport(Transport):
                 stderr=_get_stderr_fileno(),
                 limit=32768,
                 env=env,
+                preexec_fn=os.setpgrp if sys.platform != "win32" else None,
             )
         except Exception as exc:
             self.on_error_future.set_exception(exc)

--- a/playwright/_impl/_transport.py
+++ b/playwright/_impl/_transport.py
@@ -121,7 +121,6 @@ class PipeTransport(Transport):
                 stderr=_get_stderr_fileno(),
                 limit=32768,
                 env=env,
-                preexec_fn=os.setpgrp if sys.platform != "win32" else None,
             )
         except Exception as exc:
             self.on_error_future.set_exception(exc)

--- a/tests/common/test_signals.py
+++ b/tests/common/test_signals.py
@@ -2,7 +2,10 @@ import asyncio
 import multiprocessing
 import os
 import signal
+import sys
 from typing import Any, Dict
+
+import pytest
 
 from playwright.async_api import async_playwright
 from playwright.sync_api import sync_playwright
@@ -110,9 +113,11 @@ def _create_signals_test(
     assert process.exitcode == 0
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="there is no SIGINT on Windows")
 def test_signals_sync(browser_name: str, launch_arguments: Dict) -> None:
     _create_signals_test(_test_signals_sync, browser_name, launch_arguments)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="there is no SIGINT on Windows")
 def test_signals_async(browser_name: str, launch_arguments: Dict) -> None:
     _create_signals_test(_test_signals_async, browser_name, launch_arguments)

--- a/tests/common/test_signals.py
+++ b/tests/common/test_signals.py
@@ -1,0 +1,118 @@
+import asyncio
+import multiprocessing
+import os
+import signal
+from typing import Any, Dict
+
+from playwright.async_api import async_playwright
+from playwright.sync_api import sync_playwright
+
+
+def _test_signals_async(
+    browser_name: str, launch_arguments: Dict, wait_queue: "multiprocessing.Queue[str]"
+) -> None:
+    sigint_received = False
+
+    def my_sig_handler(signum: int, frame: Any) -> None:
+        nonlocal sigint_received
+        sigint_received = True
+
+    signal.signal(signal.SIGINT, my_sig_handler)
+
+    async def main() -> None:
+        playwright = await async_playwright().start()
+        browser = await playwright[browser_name].launch(
+            handle_sighup=False,
+            handle_sigint=False,
+            handle_sigterm=False,
+            **launch_arguments
+        )
+        context = await browser.new_context()
+        page = await context.new_page()
+        notified = False
+        try:
+            nonlocal sigint_received
+            while not sigint_received:
+                if not notified:
+                    wait_queue.put("ready")
+                    notified = True
+                await page.wait_for_timeout(100)
+        finally:
+            wait_queue.put("close context")
+            await context.close()
+            wait_queue.put("close browser")
+            await browser.close()
+            wait_queue.put("close playwright")
+            await playwright.stop()
+            wait_queue.put("all done")
+
+    asyncio.run(main())
+
+
+def _test_signals_sync(
+    browser_name: str, launch_arguments: Dict, wait_queue: "multiprocessing.Queue[str]"
+) -> None:
+    sigint_received = False
+
+    def my_sig_handler(signum: int, frame: Any) -> None:
+        nonlocal sigint_received
+        sigint_received = True
+
+    signal.signal(signal.SIGINT, my_sig_handler)
+
+    playwright = sync_playwright().start()
+    browser = playwright[browser_name].launch(
+        handle_sighup=False,
+        handle_sigint=False,
+        handle_sigterm=False,
+        **launch_arguments
+    )
+    context = browser.new_context()
+    page = context.new_page()
+    notified = False
+    try:
+        while not sigint_received:
+            if not notified:
+                wait_queue.put("ready")
+                notified = True
+            page.wait_for_timeout(100)
+    finally:
+        wait_queue.put("close context")
+        context.close()
+        wait_queue.put("close browser")
+        browser.close()
+        wait_queue.put("close playwright")
+        playwright.stop()
+        wait_queue.put("all done")
+
+
+def _create_signals_test(
+    target: Any, browser_name: str, launch_arguments: Dict
+) -> None:
+    wait_queue: "multiprocessing.Queue[str]" = multiprocessing.Queue()
+    process = multiprocessing.Process(
+        target=target, args=[browser_name, launch_arguments, wait_queue]
+    )
+    process.start()
+    assert process.pid is not None
+    wait_queue.get()
+    os.kill(process.pid, signal.SIGINT)
+    process.join()
+    logs = []
+    while not wait_queue.empty():
+        logs.append(wait_queue.get())
+    assert logs == [
+        "close context",
+        "close browser",
+        "close playwright",
+        "all done",
+    ]
+    assert process.exitcode == 0
+
+
+def test_signals_sync(browser_name: str, launch_arguments: Dict) -> None:
+    _create_signals_test(_test_signals_sync, browser_name, launch_arguments)
+
+
+def test_signals_async(browser_name: str, launch_arguments: Dict) -> None:
+    _create_signals_test(_test_signals_async, browser_name, launch_arguments)

--- a/tests/common/test_signals.py
+++ b/tests/common/test_signals.py
@@ -96,13 +96,13 @@ def _create_signals_test(
     )
     process.start()
     assert process.pid is not None
-    wait_queue.get()
+    logs = [wait_queue.get()]
     os.killpg(os.getpgid(process.pid), signal.SIGINT)
     process.join()
-    logs = []
     while not wait_queue.empty():
         logs.append(wait_queue.get())
     assert logs == [
+        "ready",
         "close context",
         "close browser",
         "close playwright",


### PR DESCRIPTION
Issue what this solves is that by default if a user presses Command + C it will send it to the `main.py` script (good) but also to the `driver` (bad) which will instantly close the browsers etc. This is because the driver is getting launched as the same process group, we should launch it as a separate process group imo.

See https://unix.stackexchange.com/a/149756

Since upstream we can do the following:

```ts
(async () => {
  const browser = await chromium.launch({ handleSIGINT: false, handleSIGHUP: false, handleSIGTERM: false, headless: false });
  const context = await browser.newContext();
  const page = await context.newPage();

  let exited = false;

  process.on('SIGINT', async () => {
    exited = true;
    console.log('SIGINT signal received, graceful shutdown!');
    await context.close();
    await browser.close();
  });
  console.log(`Process Command + C to exit`);
  while (!exited)
    await page.waitForTimeout(1000);

})();
```

we should be able to do the same in Python. It should be an implementation detail that we are launching a subprocess internally.

https://github.com/microsoft/playwright-python/issues/1843