### PR TITLE
chore: don't have Playwright globally installed in Docker image

### DIFF
--- a/utils/docker/Dockerfile.focal
+++ b/utils/docker/Dockerfile.focal
@@ -35,6 +35,9 @@ COPY ./dist/*-manylinux*.whl /tmp/
 RUN mkdir /ms-playwright && \
     mkdir /ms-playwright-agent && \
     cd /ms-playwright-agent && \
+    pip install virtualenv && \
+    virtualenv venv && \
+    . venv/bin/activate && \
     # if its amd64 then install the manylinux1_x86_64 pip package
     if [ "$(uname -m)" = "x86_64" ]; then pip install /tmp/*manylinux1_x86_64*.whl; fi && \
     # if its arm64 then install the manylinux1_aarch64 pip package

--- a/utils/docker/Dockerfile.jammy
+++ b/utils/docker/Dockerfile.jammy
@@ -35,6 +35,9 @@ COPY ./dist/*-manylinux*.whl /tmp/
 RUN mkdir /ms-playwright && \
     mkdir /ms-playwright-agent && \
     cd /ms-playwright-agent && \
+    pip install virtualenv && \
+    virtualenv venv && \
+    . venv/bin/activate && \
     # if its amd64 then install the manylinux1_x86_64 pip package
     if [ "$(uname -m)" = "x86_64" ]; then pip install /tmp/*manylinux1_x86_64*.whl; fi && \
     # if its arm64 then install the manylinux1_aarch64 pip package


### PR DESCRIPTION
Background: We by accident were installing the temporary snapshot release globally inside the Docker container.
Fix: We instead install Playwright in a virtualenv, so only the deps + browsers are installed like we promise.

-> no global installed Playwright library anymore.

Fixes https://github.com/microsoft/playwright-pytest/issues/169