### PR TITLE
fix: ignore non-awaited _update_interception_patterns warning

### DIFF
--- a/playwright/_impl/_browser_context.py
+++ b/playwright/_impl/_browser_context.py
@@ -67,7 +67,12 @@ from playwright._impl._helper import (
     to_impl,
 )
 from playwright._impl._network import Request, Response, Route, serialize_headers
-from playwright._impl._page import BindingCall, Page, Worker
+from playwright._impl._page import (
+    BindingCall,
+    Page,
+    Worker,
+    create_task_and_ignore_exceptions,
+)
 from playwright._impl._tracing import Tracing
 from playwright._impl._wait_helper import WaitHelper
 
@@ -216,9 +221,9 @@ class BrowserContext(ChannelOwner):
                 handled = await route_handler.handle(route)
             finally:
                 if len(self._routes) == 0:
-                    asyncio.create_task(
+                    create_task_and_ignore_exceptions(
                         self._connection.wrap_api_call(
-                            lambda: self._update_interception_patterns(), True
+                            lambda: self._update_interception_patterns()
                         )
                     )
             if handled:

--- a/playwright/_impl/_page.py
+++ b/playwright/_impl/_page.py
@@ -23,6 +23,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Coroutine,
     Dict,
     List,
     Optional,
@@ -249,9 +250,9 @@ class Page(ChannelOwner):
                 handled = await route_handler.handle(route)
             finally:
                 if len(self._routes) == 0:
-                    asyncio.create_task(
+                    create_task_and_ignore_exceptions(
                         self._connection.wrap_api_call(
-                            lambda: self._update_interception_patterns(), True
+                            lambda: self._update_interception_patterns()
                         )
                     )
             if handled:
@@ -1272,3 +1273,13 @@ def trim_end(s: str) -> str:
     if len(s) > 50:
         return s[:50] + "\u2026"
     return s
+
+
+def create_task_and_ignore_exceptions(coroutine: Coroutine) -> None:
+    async def _wrapper() -> None:
+        try:
+            await coroutine
+        except Exception:
+            pass
+
+    asyncio.create_task(_wrapper())


### PR DESCRIPTION
This fixes: 

>   /Users/maxschmitt/.pyenv/versions/3.11.2/lib/python3.11/asyncio/base_events.py:678: RuntimeWarning: coroutine 'Connection.wrap_api_call' was never awaited

Fixes https://github.com/microsoft/playwright-python/issues/1950
Relates https://github.com/microsoft/playwright-python/pull/1864
