### PR TITLE
Fix context manager freeze on SIGINT

### DIFF
--- a/playwright/_impl/_transport.py
+++ b/playwright/_impl/_transport.py
@@ -139,38 +139,36 @@ class PipeTransport(Transport):
     async def run(self) -> None:
         assert self._proc.stdout
         assert self._proc.stdin
-        try:
-            while not self._stopped:
-                try:
-                    buffer = await self._proc.stdout.readexactly(4)
-                    if self._stopped:
-                        break
-                    length = int.from_bytes(buffer, byteorder="little", signed=False)
-                    buffer = bytes(0)
-                    while length:
-                        to_read = min(length, 32768)
-                        data = await self._proc.stdout.readexactly(to_read)
-                        if self._stopped:
-                            break
-                        length -= to_read
-                        if len(buffer):
-                            buffer = buffer + data
-                        else:
-                            buffer = data
-                    if self._stopped:
-                        break
-
-                    obj = self.deserialize_message(buffer)
-                    self.on_message(obj)
-                except asyncio.IncompleteReadError:
-                    if not self._stopped:
-                        self.on_error_future.set_exception(
-                            Exception("Connection closed while reading from the driver")
-                        )
+        while not self._stopped:
+            try:
+                buffer = await self._proc.stdout.readexactly(4)
+                if self._stopped:
                     break
-                await asyncio.sleep(0)
+                length = int.from_bytes(buffer, byteorder="little", signed=False)
+                buffer = bytes(0)
+                while length:
+                    to_read = min(length, 32768)
+                    data = await self._proc.stdout.readexactly(to_read)
+                    if self._stopped:
+                        break
+                    length -= to_read
+                    if len(buffer):
+                        buffer = buffer + data
+                    else:
+                        buffer = data
+                if self._stopped:
+                    break
 
-        finally:
+                obj = self.deserialize_message(buffer)
+                self.on_message(obj)
+            except (asyncio.IncompleteReadError, asyncio.exceptions.CancelledError):
+                if not self._stopped:
+                    self.on_error_future.set_exception(
+                        Exception("Connection closed while reading from the driver")
+                    )
+                break
+            await asyncio.sleep(0)
+
             await self._proc.wait()
             self._stopped_future.set_result(None)
 


### PR DESCRIPTION
Current PR contains tiny changes to prevent context manager from freezing in `__aexit__` if SIGINT received. For instance, we have the following code:
```python
import asyncio
from playwright.async_api import async_playwright

async def main():
    async with async_playwright() as p:
        await asyncio.sleep(100)

asyncio.run(main())
```
We run it and interrupt with Ctrl+C, while `sleep` is being awaited. Then we have execution chain as: https://github.com/microsoft/playwright-python/blob/45b1312bda8b36c5ec546c52431d01297bd06aa9/playwright/async_api/_context_manager.py#L54-L58
https://github.com/microsoft/playwright-python/blob/45b1312bda8b36c5ec546c52431d01297bd06aa9/playwright/_impl/_connection.py#L281-L284
https://github.com/microsoft/playwright-python/blob/45b1312bda8b36c5ec546c52431d01297bd06aa9/playwright/_impl/_transport.py#L104-L105
But `self._stopped_future` would never be set, because 
https://github.com/microsoft/playwright-python/blob/45b1312bda8b36c5ec546c52431d01297bd06aa9/playwright/_impl/_transport.py#L164-L165
is never reached due to `asyncio.CancelledError` raised in the above loop.

Looks like the last lines should be executed regardless what happened in the loop. That's why I moved it to `finally` block

