### PR TITLE
chore: improve expect.set_options timeout reset handling

### DIFF
--- a/playwright/async_api/__init__.py
+++ b/playwright/async_api/__init__.py
@@ -18,7 +18,7 @@ Firefox and WebKit with a single API. Playwright is built to enable cross-browse
 web automation that is ever-green, capable, reliable and fast.
 """
 
-from typing import Optional, Union, overload
+from typing import Any, Optional, Union, overload
 
 import playwright._impl._api_structures
 import playwright._impl._api_types
@@ -88,10 +88,12 @@ def async_playwright() -> PlaywrightContextManager:
 
 
 class Expect:
+    _unset: Any = object()
+
     def __init__(self) -> None:
         self._timeout: Optional[float] = None
 
-    def set_options(self, timeout: float = None) -> None:
+    def set_options(self, timeout: Optional[float] = _unset) -> None:
         """
         This method sets global `expect()` options.
 
@@ -101,7 +103,7 @@ class Expect:
         Returns:
             None
         """
-        if timeout is not None:
+        if timeout is not self._unset:
             self._timeout = timeout
 
     @overload

--- a/playwright/sync_api/__init__.py
+++ b/playwright/sync_api/__init__.py
@@ -18,7 +18,7 @@ Firefox and WebKit with a single API. Playwright is built to enable cross-browse
 web automation that is ever-green, capable, reliable and fast.
 """
 
-from typing import Optional, Union, overload
+from typing import Any, Optional, Union, overload
 
 import playwright._impl._api_structures
 import playwright._impl._api_types
@@ -88,10 +88,12 @@ def sync_playwright() -> PlaywrightContextManager:
 
 
 class Expect:
+    _unset: Any = object()
+
     def __init__(self) -> None:
         self._timeout: Optional[float] = None
 
-    def set_options(self, timeout: float = None) -> None:
+    def set_options(self, timeout: Optional[float] = _unset) -> None:
         """
         This method sets global `expect()` options.
 
@@ -101,7 +103,7 @@ class Expect:
         Returns:
             None
         """
-        if timeout is not None:
+        if timeout is not self._unset:
             self._timeout = timeout
 
     @overload


### PR DESCRIPTION
We do a good job in resetting the expect timeout here:

https://github.com/microsoft/playwright-python/blob/d4a874f3eebbb70dfc6f915dc607e27d079cc5fb/tests/async/test_assertions.py#L801-L810

but it gets ignored here, which ends up that the timeout is not getting reset to the default:

https://github.com/microsoft/playwright-python/blob/f1c11fbd3000ee072b117ddebed9da1e0c2226b3/playwright/async_api/__init__.py#L104-L105

So lets check if the param got actually passed over as per [here](https://stackoverflow.com/a/14749388/6512681).

Fixes https://github.com/microsoft/playwright-python/issues/1973