### PR TITLE
chore(roll): roll Playwright to v1.36.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Playwright is a Python library to automate [Chromium](https://www.chromium.org/H
 
 |          | Linux | macOS | Windows |
 |   :---   | :---: | :---: | :---:   |
-| Chromium <!-- GEN:chromium-version -->115.0.5790.24<!-- GEN:stop --> | ✅ | ✅ | ✅ |
-| WebKit <!-- GEN:webkit-version -->16.4<!-- GEN:stop --> | ✅ | ✅ | ✅ |
-| Firefox <!-- GEN:firefox-version -->113.0<!-- GEN:stop --> | ✅ | ✅ | ✅ |
+| Chromium <!-- GEN:chromium-version -->115.0.5790.75<!-- GEN:stop --> | ✅ | ✅ | ✅ |
+| WebKit <!-- GEN:webkit-version -->17.0<!-- GEN:stop --> | ✅ | ✅ | ✅ |
+| Firefox <!-- GEN:firefox-version -->115.0<!-- GEN:stop --> | ✅ | ✅ | ✅ |
 
 ## Documentation
 

--- a/playwright/_impl/_js_handle.py
+++ b/playwright/_impl/_js_handle.py
@@ -192,6 +192,9 @@ def parse_value(value: Any, refs: Optional[Dict[int, Any]] = None) -> Any:
         if "u" in value:
             return urlparse(value["u"])
 
+        if "bi" in value:
+            return int(value["bi"])
+
         if "a" in value:
             a: List = []
             refs[value["id"]] = a

--- a/playwright/async_api/_generated.py
+++ b/playwright/async_api/_generated.py
@@ -896,7 +896,7 @@ class Route(AsyncBase):
             # override headers
             headers = {
                 **request.headers,
-                \"foo\": \"foo-value\" # set \"foo\" header
+                \"foo\": \"foo-value\", # set \"foo\" header
                 \"bar\": None # remove \"bar\" header
             }
             await route.fallback(headers=headers)
@@ -909,7 +909,7 @@ class Route(AsyncBase):
             # override headers
             headers = {
                 **request.headers,
-                \"foo\": \"foo-value\" # set \"foo\" header
+                \"foo\": \"foo-value\", # set \"foo\" header
                 \"bar\": None # remove \"bar\" header
             }
             route.fallback(headers=headers)
@@ -958,7 +958,7 @@ class Route(AsyncBase):
             # override headers
             headers = {
                 **request.headers,
-                \"foo\": \"foo-value\" # set \"foo\" header
+                \"foo\": \"foo-value\", # set \"foo\" header
                 \"bar\": None # remove \"bar\" header
             }
             await route.continue_(headers=headers)
@@ -971,7 +971,7 @@ class Route(AsyncBase):
             # override headers
             headers = {
                 **request.headers,
-                \"foo\": \"foo-value\" # set \"foo\" header
+                \"foo\": \"foo-value\", # set \"foo\" header
                 \"bar\": None # remove \"bar\" header
             }
             route.continue_(headers=headers)
@@ -1650,7 +1650,7 @@ class JSHandle(AsyncBase):
         **Usage**
 
         ```py
-        handle = await page.evaluate_handle(\"({window, document})\")
+        handle = await page.evaluate_handle(\"({ window, document })\")
         properties = await handle.get_properties()
         window_handle = properties.get(\"window\")
         document_handle = properties.get(\"document\")
@@ -1658,7 +1658,7 @@ class JSHandle(AsyncBase):
         ```
 
         ```py
-        handle = page.evaluate_handle(\"({window, document})\")
+        handle = page.evaluate_handle(\"({ window, document })\")
         properties = handle.get_properties()
         window_handle = properties.get(\"window\")
         document_handle = properties.get(\"document\")
@@ -2896,13 +2896,13 @@ class ElementHandle(JSHandle):
         ```py
         tweet_handle = await page.query_selector(\".tweet\")
         assert await tweet_handle.eval_on_selector(\".like\", \"node => node.innerText\") == \"100\"
-        assert await tweet_handle.eval_on_selector(\".retweets\", \"node => node.innerText\") = \"10\"
+        assert await tweet_handle.eval_on_selector(\".retweets\", \"node => node.innerText\") == \"10\"
         ```
 
         ```py
         tweet_handle = page.query_selector(\".tweet\")
         assert tweet_handle.eval_on_selector(\".like\", \"node => node.innerText\") == \"100\"
-        assert tweet_handle.eval_on_selector(\".retweets\", \"node => node.innerText\") = \"10\"
+        assert tweet_handle.eval_on_selector(\".retweets\", \"node => node.innerText\") == \"10\"
         ```
 
         Parameters
@@ -3124,11 +3124,11 @@ class Accessibility(AsyncBase):
 
         ```py
         def find_focused_node(node):
-            if (node.get(\"focused\"))
+            if node.get(\"focused\"):
                 return node
             for child in (node.get(\"children\") or []):
                 found_node = find_focused_node(child)
-                if (found_node)
+                if found_node:
                     return found_node
             return None
 
@@ -3140,11 +3140,11 @@ class Accessibility(AsyncBase):
 
         ```py
         def find_focused_node(node):
-            if (node.get(\"focused\"))
+            if node.get(\"focused\"):
                 return node
             for child in (node.get(\"children\") or []):
                 found_node = find_focused_node(child)
-                if (found_node)
+                if found_node:
                     return found_node
             return None
 
@@ -7396,6 +7396,7 @@ class Page(AsyncContextManager):
             # or while waiting for an event.
             await page.wait_for_event(\"popup\")
         except Error as e:
+            pass
             # when the page crashes, exception message contains \"crash\".
         ```
 
@@ -7406,6 +7407,7 @@ class Page(AsyncContextManager):
             # or while waiting for an event.
             page.wait_for_event(\"popup\")
         except Error as e:
+            pass
             # when the page crashes, exception message contains \"crash\".
         ```"""
 
@@ -7698,6 +7700,7 @@ class Page(AsyncContextManager):
             # or while waiting for an event.
             await page.wait_for_event(\"popup\")
         except Error as e:
+            pass
             # when the page crashes, exception message contains \"crash\".
         ```
 
@@ -7708,6 +7711,7 @@ class Page(AsyncContextManager):
             # or while waiting for an event.
             page.wait_for_event(\"popup\")
         except Error as e:
+            pass
             # when the page crashes, exception message contains \"crash\".
         ```"""
 
@@ -9765,18 +9769,18 @@ class Page(AsyncContextManager):
 
         ```py
         def handle_route(route):
-          if (\"my-string\" in route.request.post_data)
+          if (\"my-string\" in route.request.post_data):
             route.fulfill(body=\"mocked-data\")
-          else
+          else:
             route.continue_()
         await page.route(\"/api/**\", handle_route)
         ```
 
         ```py
         def handle_route(route):
-          if (\"my-string\" in route.request.post_data)
+          if (\"my-string\" in route.request.post_data):
             route.fulfill(body=\"mocked-data\")
-          else
+          else:
             route.continue_()
         page.route(\"/api/**\", handle_route)
         ```
@@ -13502,18 +13506,18 @@ class BrowserContext(AsyncContextManager):
 
         ```py
         def handle_route(route):
-          if (\"my-string\" in route.request.post_data)
+          if (\"my-string\" in route.request.post_data):
             route.fulfill(body=\"mocked-data\")
-          else
+          else:
             route.continue_()
         await context.route(\"/api/**\", handle_route)
         ```
 
         ```py
         def handle_route(route):
-          if (\"my-string\" in route.request.post_data)
+          if (\"my-string\" in route.request.post_data):
             route.fulfill(body=\"mocked-data\")
-          else
+          else:
             route.continue_()
         context.route(\"/api/**\", handle_route)
         ```
@@ -15188,17 +15192,17 @@ class Playwright(AsyncBase):
         in REPL applications.
 
         ```py
-        >>> from playwright.sync_api import sync_playwright
+        from playwright.sync_api import sync_playwright
 
-        >>> playwright = sync_playwright().start()
+        playwright = sync_playwright().start()
 
-        >>> browser = playwright.chromium.launch()
-        >>> page = browser.new_page()
-        >>> page.goto(\"https://playwright.dev/\")
-        >>> page.screenshot(path=\"example.png\")
-        >>> browser.close()
+        browser = playwright.chromium.launch()
+        page = browser.new_page()
+        page.goto(\"https://playwright.dev/\")
+        page.screenshot(path=\"example.png\")
+        browser.close()
 
-        >>> playwright.stop()
+        playwright.stop()
         ```
         """
 
@@ -16681,19 +16685,18 @@ class Locator(AsyncBase):
         ```py
         row_locator = page.locator(\"tr\")
         # ...
-        await row_locator
-            .filter(has_text=\"text in column 1\")
-            .filter(has=page.get_by_role(\"button\", name=\"column 2 button\"))
-            .screenshot()
+        await row_locator.filter(has_text=\"text in column 1\").filter(
+            has=page.get_by_role(\"button\", name=\"column 2 button\")
+        ).screenshot()
+
         ```
 
         ```py
         row_locator = page.locator(\"tr\")
         # ...
-        row_locator
-            .filter(has_text=\"text in column 1\")
-            .filter(has=page.get_by_role(\"button\", name=\"column 2 button\"))
-            .screenshot()
+        row_locator.filter(has_text=\"text in column 1\").filter(
+            has=page.get_by_role(\"button\", name=\"column 2 button\")
+        ).screenshot()
         ```
 
         Parameters
@@ -16744,7 +16747,7 @@ class Locator(AsyncBase):
         new_email = page.get_by_role(\"button\", name=\"New\")
         dialog = page.get_by_text(\"Confirm security settings\")
         await expect(new_email.or_(dialog)).to_be_visible()
-        if (await dialog.is_visible())
+        if (await dialog.is_visible()):
           await page.get_by_role(\"button\", name=\"Dismiss\").click()
         await new_email.click()
         ```
@@ -16753,7 +16756,7 @@ class Locator(AsyncBase):
         new_email = page.get_by_role(\"button\", name=\"New\")
         dialog = page.get_by_text(\"Confirm security settings\")
         expect(new_email.or_(dialog)).to_be_visible()
-        if (dialog.is_visible())
+        if (dialog.is_visible()):
           page.get_by_role(\"button\", name=\"Dismiss\").click()
         new_email.click()
         ```

--- a/playwright/sync_api/_generated.py
+++ b/playwright/sync_api/_generated.py
@@ -908,7 +908,7 @@ class Route(SyncBase):
             # override headers
             headers = {
                 **request.headers,
-                \"foo\": \"foo-value\" # set \"foo\" header
+                \"foo\": \"foo-value\", # set \"foo\" header
                 \"bar\": None # remove \"bar\" header
             }
             await route.fallback(headers=headers)
@@ -921,7 +921,7 @@ class Route(SyncBase):
             # override headers
             headers = {
                 **request.headers,
-                \"foo\": \"foo-value\" # set \"foo\" header
+                \"foo\": \"foo-value\", # set \"foo\" header
                 \"bar\": None # remove \"bar\" header
             }
             route.fallback(headers=headers)
@@ -972,7 +972,7 @@ class Route(SyncBase):
             # override headers
             headers = {
                 **request.headers,
-                \"foo\": \"foo-value\" # set \"foo\" header
+                \"foo\": \"foo-value\", # set \"foo\" header
                 \"bar\": None # remove \"bar\" header
             }
             await route.continue_(headers=headers)
@@ -985,7 +985,7 @@ class Route(SyncBase):
             # override headers
             headers = {
                 **request.headers,
-                \"foo\": \"foo-value\" # set \"foo\" header
+                \"foo\": \"foo-value\", # set \"foo\" header
                 \"bar\": None # remove \"bar\" header
             }
             route.continue_(headers=headers)
@@ -1654,7 +1654,7 @@ class JSHandle(SyncBase):
         **Usage**
 
         ```py
-        handle = await page.evaluate_handle(\"({window, document})\")
+        handle = await page.evaluate_handle(\"({ window, document })\")
         properties = await handle.get_properties()
         window_handle = properties.get(\"window\")
         document_handle = properties.get(\"document\")
@@ -1662,7 +1662,7 @@ class JSHandle(SyncBase):
         ```
 
         ```py
-        handle = page.evaluate_handle(\"({window, document})\")
+        handle = page.evaluate_handle(\"({ window, document })\")
         properties = handle.get_properties()
         window_handle = properties.get(\"window\")
         document_handle = properties.get(\"document\")
@@ -2932,13 +2932,13 @@ class ElementHandle(JSHandle):
         ```py
         tweet_handle = await page.query_selector(\".tweet\")
         assert await tweet_handle.eval_on_selector(\".like\", \"node => node.innerText\") == \"100\"
-        assert await tweet_handle.eval_on_selector(\".retweets\", \"node => node.innerText\") = \"10\"
+        assert await tweet_handle.eval_on_selector(\".retweets\", \"node => node.innerText\") == \"10\"
         ```
 
         ```py
         tweet_handle = page.query_selector(\".tweet\")
         assert tweet_handle.eval_on_selector(\".like\", \"node => node.innerText\") == \"100\"
-        assert tweet_handle.eval_on_selector(\".retweets\", \"node => node.innerText\") = \"10\"
+        assert tweet_handle.eval_on_selector(\".retweets\", \"node => node.innerText\") == \"10\"
         ```
 
         Parameters
@@ -3168,11 +3168,11 @@ class Accessibility(SyncBase):
 
         ```py
         def find_focused_node(node):
-            if (node.get(\"focused\"))
+            if node.get(\"focused\"):
                 return node
             for child in (node.get(\"children\") or []):
                 found_node = find_focused_node(child)
-                if (found_node)
+                if found_node:
                     return found_node
             return None
 
@@ -3184,11 +3184,11 @@ class Accessibility(SyncBase):
 
         ```py
         def find_focused_node(node):
-            if (node.get(\"focused\"))
+            if node.get(\"focused\"):
                 return node
             for child in (node.get(\"children\") or []):
                 found_node = find_focused_node(child)
-                if (found_node)
+                if found_node:
                     return found_node
             return None
 
@@ -7504,6 +7504,7 @@ class Page(SyncContextManager):
             # or while waiting for an event.
             await page.wait_for_event(\"popup\")
         except Error as e:
+            pass
             # when the page crashes, exception message contains \"crash\".
         ```
 
@@ -7514,6 +7515,7 @@ class Page(SyncContextManager):
             # or while waiting for an event.
             page.wait_for_event(\"popup\")
         except Error as e:
+            pass
             # when the page crashes, exception message contains \"crash\".
         ```"""
 
@@ -7756,6 +7758,7 @@ class Page(SyncContextManager):
             # or while waiting for an event.
             await page.wait_for_event(\"popup\")
         except Error as e:
+            pass
             # when the page crashes, exception message contains \"crash\".
         ```
 
@@ -7766,6 +7769,7 @@ class Page(SyncContextManager):
             # or while waiting for an event.
             page.wait_for_event(\"popup\")
         except Error as e:
+            pass
             # when the page crashes, exception message contains \"crash\".
         ```"""
 
@@ -9827,18 +9831,18 @@ class Page(SyncContextManager):
 
         ```py
         def handle_route(route):
-          if (\"my-string\" in route.request.post_data)
+          if (\"my-string\" in route.request.post_data):
             route.fulfill(body=\"mocked-data\")
-          else
+          else:
             route.continue_()
         await page.route(\"/api/**\", handle_route)
         ```
 
         ```py
         def handle_route(route):
-          if (\"my-string\" in route.request.post_data)
+          if (\"my-string\" in route.request.post_data):
             route.fulfill(body=\"mocked-data\")
-          else
+          else:
             route.continue_()
         page.route(\"/api/**\", handle_route)
         ```
@@ -13558,18 +13562,18 @@ class BrowserContext(SyncContextManager):
 
         ```py
         def handle_route(route):
-          if (\"my-string\" in route.request.post_data)
+          if (\"my-string\" in route.request.post_data):
             route.fulfill(body=\"mocked-data\")
-          else
+          else:
             route.continue_()
         await context.route(\"/api/**\", handle_route)
         ```
 
         ```py
         def handle_route(route):
-          if (\"my-string\" in route.request.post_data)
+          if (\"my-string\" in route.request.post_data):
             route.fulfill(body=\"mocked-data\")
-          else
+          else:
             route.continue_()
         context.route(\"/api/**\", handle_route)
         ```
@@ -15264,17 +15268,17 @@ class Playwright(SyncBase):
         in REPL applications.
 
         ```py
-        >>> from playwright.sync_api import sync_playwright
+        from playwright.sync_api import sync_playwright
 
-        >>> playwright = sync_playwright().start()
+        playwright = sync_playwright().start()
 
-        >>> browser = playwright.chromium.launch()
-        >>> page = browser.new_page()
-        >>> page.goto(\"https://playwright.dev/\")
-        >>> page.screenshot(path=\"example.png\")
-        >>> browser.close()
+        browser = playwright.chromium.launch()
+        page = browser.new_page()
+        page.goto(\"https://playwright.dev/\")
+        page.screenshot(path=\"example.png\")
+        browser.close()
 
-        >>> playwright.stop()
+        playwright.stop()
         ```
         """
 
@@ -16779,19 +16783,18 @@ class Locator(SyncBase):
         ```py
         row_locator = page.locator(\"tr\")
         # ...
-        await row_locator
-            .filter(has_text=\"text in column 1\")
-            .filter(has=page.get_by_role(\"button\", name=\"column 2 button\"))
-            .screenshot()
+        await row_locator.filter(has_text=\"text in column 1\").filter(
+            has=page.get_by_role(\"button\", name=\"column 2 button\")
+        ).screenshot()
+
         ```
 
         ```py
         row_locator = page.locator(\"tr\")
         # ...
-        row_locator
-            .filter(has_text=\"text in column 1\")
-            .filter(has=page.get_by_role(\"button\", name=\"column 2 button\"))
-            .screenshot()
+        row_locator.filter(has_text=\"text in column 1\").filter(
+            has=page.get_by_role(\"button\", name=\"column 2 button\")
+        ).screenshot()
         ```
 
         Parameters
@@ -16842,7 +16845,7 @@ class Locator(SyncBase):
         new_email = page.get_by_role(\"button\", name=\"New\")
         dialog = page.get_by_text(\"Confirm security settings\")
         await expect(new_email.or_(dialog)).to_be_visible()
-        if (await dialog.is_visible())
+        if (await dialog.is_visible()):
           await page.get_by_role(\"button\", name=\"Dismiss\").click()
         await new_email.click()
         ```
@@ -16851,7 +16854,7 @@ class Locator(SyncBase):
         new_email = page.get_by_role(\"button\", name=\"New\")
         dialog = page.get_by_text(\"Confirm security settings\")
         expect(new_email.or_(dialog)).to_be_visible()
-        if (dialog.is_visible())
+        if (dialog.is_visible()):
           page.get_by_role(\"button\", name=\"Dismiss\").click()
         new_email.click()
         ```

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ except ImportError:
     InWheel = None
 from wheel.bdist_wheel import bdist_wheel as BDistWheelCommand
 
-driver_version = "1.35.0"
+driver_version = "1.36.0"
 
 
 def extractall(zip: zipfile.ZipFile, path: str) -> None:

--- a/tests/async/test_evaluate.py
+++ b/tests/async/test_evaluate.py
@@ -16,7 +16,7 @@ import math
 from datetime import datetime
 from urllib.parse import ParseResult, urlparse
 
-from playwright.async_api import Error
+from playwright.async_api import Error, Page
 
 
 async def test_evaluate_work(page):
@@ -62,6 +62,11 @@ async def test_evaluate_roundtrip_unserializable_values(page):
 async def test_evaluate_transfer_arrays(page):
     result = await page.evaluate("a => a", [1, 2, 3])
     assert result == [1, 2, 3]
+
+
+async def test_evaluate_transfer_bigint(page: Page) -> None:
+    assert await page.evaluate("() => 42n") == 42
+    assert await page.evaluate("a => a", 17) == 17
 
 
 async def test_evaluate_return_undefined_for_objects_with_symbols(page):


### PR DESCRIPTION
Playwright for Python does not have its own glob to regex implementation, we rely on Python stdlib see here:

https://github.com/microsoft/playwright-python/blob/6980e901849b6fd551e53cd5e2d298f60ac8977b/playwright/_impl/_helper.py

Fixes https://github.com/microsoft/playwright-python/issues/1986