### PR TITLE
devops: fix conda build pipeline (pin conda)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,8 @@ jobs:
           python-version: 3.9
           channels: conda-forge
           # TODO: Can be removed after https://github.com/conda/conda/issues/12955 is fixed
-          conda-version: 23.5.2
+          conda-version: 23.7.2
+          conda-build-version: 3.26.0
       - name: Prepare
         run: conda install conda-build conda-verify
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,8 +168,7 @@ jobs:
           python-version: 3.9
           channels: conda-forge
           # TODO: Can be removed after https://github.com/conda/conda/issues/12955 is fixed
-          conda-version: latest
-          conda-build-version: latest
+          conda-version: 23.5.2
       - name: Prepare
         run: conda install conda-build conda-verify
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,8 @@ jobs:
         with:
           python-version: 3.9
           channels: conda-forge
+          # TODO: Can be removed after https://github.com/conda/conda/issues/12955 is fixed
+          conda-version: 23.5.2
       - name: Prepare
         run: conda install conda-build conda-verify
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,9 +168,10 @@ jobs:
           python-version: 3.9
           channels: conda-forge
           # TODO: Can be removed after https://github.com/conda/conda/issues/12955 is fixed
-          conda-version: 23.5.2
+          conda-version: 23.7.2
+          conda-build-version: 3.26.0
       - name: Prepare
-        run: conda install conda-build conda-verify
+        run: conda install conda-verify
       - name: Build
         run: conda build .
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,10 +168,10 @@ jobs:
           python-version: 3.9
           channels: conda-forge
           # TODO: Can be removed after https://github.com/conda/conda/issues/12955 is fixed
-          conda-version: 23.7.2
-          conda-build-version: 3.26.0
+          conda-version: latest
+          conda-build-version: latest
       - name: Prepare
-        run: conda install conda-verify
+        run: conda install conda-build conda-verify
       - name: Build
         run: conda build .
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,8 +168,7 @@ jobs:
           python-version: 3.9
           channels: conda-forge
           # TODO: Can be removed after https://github.com/conda/conda/issues/12955 is fixed
-          conda-version: 23.7.2
-          conda-build-version: 3.26.0
+          conda-version: 23.5.2
       - name: Prepare
         run: conda install conda-build conda-verify
       - name: Build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,8 @@ jobs:
           python-version: 3.9
           channels: conda-forge
           # TODO: Can be removed after https://github.com/conda/conda/issues/12955 is fixed
-          conda-version: 23.5.2
+          conda-version: 23.7.2
+          conda-build-version: 3.26.0
       - name: Prepare
         run: conda install anaconda-client conda-build conda-verify
       - name: Build and Upload

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,8 +39,7 @@ jobs:
           python-version: 3.9
           channels: conda-forge
           # TODO: Can be removed after https://github.com/conda/conda/issues/12955 is fixed
-          conda-version: 23.7.2
-          conda-build-version: 3.26.0
+          conda-version: 23.5.2
       - name: Prepare
         run: conda install anaconda-client conda-build conda-verify
       - name: Build and Upload

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,8 @@ jobs:
         with:
           python-version: 3.9
           channels: conda-forge
+          # TODO: Can be removed after https://github.com/conda/conda/issues/12955 is fixed
+          conda-version: 23.5.2
       - name: Prepare
         run: conda install anaconda-client conda-build conda-verify
       - name: Build and Upload


### PR DESCRIPTION
There are two issues which we experience with the latest conda version:

macos:

```
# >>>>>>>>>>>>>>>>>>>>>> ERROR REPORT <<<<<<<<<<<<<<<<<<<<<<

    Traceback (most recent call last):
      File "/usr/local/miniconda/lib/python3.10/site-packages/conda/exceptions.py", line 1132, in __call__
        return func(*args, **kwargs)
      File "/usr/local/miniconda/lib/python3.10/site-packages/conda/cli/main.py", line 6[9](https://github.com/microsoft/playwright-python/actions/runs/5797448985/job/15713019320#step:5:10), in main_subshell
        exit_code = do_call(args, p)
      File "/usr/local/miniconda/lib/python3.[10](https://github.com/microsoft/playwright-python/actions/runs/5797448985/job/15713019320#step:5:11)/site-packages/conda/cli/conda_argparse.py", line [11](https://github.com/microsoft/playwright-python/actions/runs/5797448985/job/15713019320#step:5:12)5, in do_call
        return args.plugin_subcommand.action(sys.argv[2:])
      File "/usr/local/miniconda/lib/python3.10/site-packages/conda_build/cli/main_build.py", line 5[16](https://github.com/microsoft/playwright-python/actions/runs/5797448985/job/15713019320#step:5:17), in execute
        _parser, args = parse_args(args)
      File "/usr/local/miniconda/lib/python3.10/site-packages/conda_build/cli/main_build.py", line 470, in parse_args
        check_recipe(args.recipe)
    AttributeError: 'Namespace' object has no attribute 'recipe'

`$ /usr/local/miniconda/condabin/conda build .`
```

windows:

```
Run conda build .
usage: conda-script.py [-h] [--no-plugins] [-V] COMMAND ...
conda-script.py: error: argument COMMAND: invalid choice: 'build' (choose from 'clean', 'compare', 'config', 'create', 'info', 'init', 'install', 'list', 'notices', 'package', 'remove', 'uninstall', 'rename', 'run', 'search', 'update', 'upgrade', 'doctor', 'content-trust', 'env')
Error: Process completed with exit code 1.
```

This seems already filed in https://github.com/conda/conda/issues/12955.

We can fix both by pinning to an old conda version: 23.5.2.