### PR TITLE
devops: do not publish conda packages with v prefix

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: playwright
-  version: "{{ environ.get('GIT_DESCRIBE_TAG') }}"
+  version: "{{ environ.get('GIT_DESCRIBE_TAG') | replace('v', '') }}"
 
 source:
   path: .


### PR DESCRIPTION
Conda version identifier should not have a v prefix, we did this by accident.