### PR TITLE
fix: allow sys.stderr.fileno() to throw NotImplementedError

### DIFF
--- a/playwright/_impl/_transport.py
+++ b/playwright/_impl/_transport.py
@@ -37,7 +37,7 @@ def _get_stderr_fileno() -> Optional[int]:
             return None
 
         return sys.stderr.fileno()
-    except (AttributeError, io.UnsupportedOperation):
+    except (NotImplementedError, AttributeError, io.UnsupportedOperation):
         # pytest-xdist monkeypatches sys.stderr with an object that is not an actual file.
         # https://docs.python.org/3/library/faulthandler.html#issue-with-file-descriptors
         # This is potentially dangerous, but the best we can do.


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-python/issues/2034