### PR TITLE
Introduce list of strings instead of strings at `scripts/generate_api.py`

### DIFF
--- a/scripts/generate_api.py
+++ b/scripts/generate_api.py
@@ -145,12 +145,7 @@ def arguments(func: FunctionType, indent: int) -> str:
             continue
         if "Callable" in value_str:
             tokens.append(f"{name}=self._wrap_handler({to_snake_case(name)})")
-        elif (
-            "typing.Any" in value_str
-            or "typing.Dict" in value_str
-            or "typing.List" in value_str
-            or "Handle" in value_str
-        ):
+        elif value_str in ["typing.Any", "typing.Dict", "typing.List", "Handle"]:
             tokens.append(f"{name}=mapping.to_impl({to_snake_case(name)})")
         elif (
             re.match(r"<class 'playwright\._impl\.[\w]+\.[\w]+", value_str)


### PR DESCRIPTION
Hello,

What about if new string object types appear on the left side?, seems to me that you have to add more `or` operators.

Example:

```python
# Adding `typing.Tuple` as a valid string value.

if (
    "typing.Any" in value_str
    or "typing.Dict" in value_str
    or "typing.List" in value_str
    or "typing.Tuple" in value_str
    or "Handle" in value_str
)
```

To avoid the `or` operands you could introduce the `in` operator, the left side will be your `value_str` string variable and the right side will be the container of strings that will fulfill your condition.

Examples:

```python
# One-time variable definition:
value_str: str = 'Handle'

typing_or_handle: List[str] = [
    "typing.Any",
    "typing.Dict",
    "typing.List",
    "Handle",
]

if value_str in typing_or_handle:
    # More logics go here.


# Inline definition:
value_str: str = 'Handle'

if value_str in ['typing.Any', 'typing.Dict', 'typing.List', 'Handle']:
    # More logics go here.
```

I opt for the "inline definition".