### PR TITLE
chore: restore setup_requires in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -222,6 +222,7 @@ setup(
         "pyee==11.0.1",
         "typing-extensions;python_version<='3.8'",
     ],
+    setup_requires=["setuptools-scm==8.0.4", "wheel==0.41.2"],
     classifiers=[
         "Topic :: Software Development :: Testing",
         "Topic :: Internet :: WWW/HTTP :: Browsers",

--- a/setup.py
+++ b/setup.py
@@ -222,6 +222,7 @@ setup(
         "pyee==11.0.1",
         "typing-extensions;python_version<='3.8'",
     ],
+    # TODO: Can be removed once we migrate to pypa/build or pypa/installer.
     setup_requires=["setuptools-scm==8.0.4", "wheel==0.41.2"],
     classifiers=[
         "Topic :: Software Development :: Testing",


### PR DESCRIPTION
This got by accident removed [here](https://github.com/microsoft/playwright-python/commit/9f042eca1ce2f29b662b442d61462b1c5a87fdaf#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L238).

Since we are not (yet) using the [isolated build system](https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html), we need to install setuptools_scm from the outside. If we would have used it, it would have picked up the build system dependencies from [here](https://github.com/microsoft/playwright-python/blob/147e4a3a3f6ffa19ad6639cbcc27323fc3163fe9/pyproject.toml#L1-L3).