### PR TITLE
`test_to_have_js_property_assertions_locator_to_have_text` => `test_assertions_locator_to_have_text`

### DIFF
--- a/tests/sync/test_assertions.py
+++ b/tests/sync/test_assertions.py
@@ -227,7 +227,7 @@ def test_to_have_js_property_pass_null(page: Page) -> None:
     expect(locator).to_have_js_property("foo", None)
 
 
-def test_to_have_js_property_assertions_locator_to_have_text(
+def test_assertions_locator_to_have_text(
     page: Page, server: Server
 ) -> None:
     page.goto(server.EMPTY_PAGE)


### PR DESCRIPTION
I don't think this case has anything to do with `to_have_js_property`?