### PR TITLE
fix #2215 (NameError in /_impl/frame.py)

### DIFF
--- a/playwright/_impl/_frame.py
+++ b/playwright/_impl/_frame.py
@@ -156,7 +156,7 @@ class Frame(ChannelOwner):
         waiter.reject_on_event(
             self._page,
             "close",
-            lambda: cast(Page, self._page)._close_error_with_reason(),
+            lambda: cast("Page", self._page)._close_error_with_reason(),
         )
         waiter.reject_on_event(
             self._page, "crash", Error("Navigation failed because page crashed!")


### PR DESCRIPTION

This bad `cast()` was introduced either in 1.39.0 or 1.40.0 (probably 1.40.0) - 1.38.0 works.
Fixes [#2215](https://github.com/microsoft/playwright-python/issues/2215).