### PR TITLE
fix: throw in expect() if unsupported type is passed to text matcher

### DIFF
--- a/playwright/_impl/_assertions.py
+++ b/playwright/_impl/_assertions.py
@@ -18,6 +18,7 @@ from urllib.parse import urljoin
 
 from playwright._impl._api_structures import ExpectedTextValue, FrameExpectOptions
 from playwright._impl._connection import format_call_log
+from playwright._impl._errors import Error
 from playwright._impl._fetch import APIResponse
 from playwright._impl._helper import is_textual_mime_type
 from playwright._impl._locator import Locator
@@ -795,4 +796,6 @@ def to_expected_text_values(
                     item, match_substring, normalize_white_space, ignore_case
                 )
             )
+        else:
+            raise Error("value must be a string or regular expression")
     return out

--- a/tests/async/test_assertions.py
+++ b/tests/async/test_assertions.py
@@ -96,6 +96,13 @@ async def test_assertions_locator_to_contain_text(page: Page, server: Server) ->
     await expect(page.locator("div")).to_contain_text(["ext     1", re.compile("ext3")])
 
 
+async def test_assertions_locator_to_contain_text_should_throw_if_arg_is_unsupported_type(
+    page: Page,
+) -> None:
+    with pytest.raises(Error, match="value must be a string or regular expression"):
+        await expect(page.locator("div")).to_contain_text(1)  # type: ignore
+
+
 async def test_assertions_locator_to_have_attribute(page: Page, server: Server) -> None:
     await page.goto(server.EMPTY_PAGE)
     await page.set_content("<div id=foobar>kek</div>")


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-python/issues/2220

Python / JavaScript are dynamically typed languages, so this is only required there and not in .NET/Java.