### PR TITLE
fix: Update to greenlet 3.0.3

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - setuptools_scm
   run:
     - python
-    - greenlet ==3.0.1
+    - greenlet ==3.0.3
     - pyee ==11.0.1
     - typing_extensions # [py<39]
 test:

--- a/setup.py
+++ b/setup.py
@@ -218,7 +218,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        "greenlet==3.0.1",
+        "greenlet==3.0.3",
         "pyee==11.0.1",
         "typing-extensions;python_version<='3.8'",
     ],


### PR DESCRIPTION
Dear lovely maintainers of Playwright,

first of all, a happy new year 🍀, and thank you so much for conceiving and maintaining this excellent piece of software.

Coming from https://github.com/crate/cratedb-examples/pull/217#pullrequestreview-1807657044, we discovered that the `greenlet` package in version 3.0.1 breaks Apache Superset, tripping a segmentation fault. Thus, it is not possible to install both Playwright and Apache Superset into the same virtualenv without further ado.

This patch fixes the problem by upgrading to greenlet version 3.0.3.

With kind regards,
Andreas.
