### PR TITLE
devops: migrate to 1ES PT templates

### DIFF
--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -12,9 +12,14 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     pool:
-      name: Azure-Pipelines-1ESPT-ExDShared
-      image: ubuntu-latest
+      name: DevDivPlaywrightAzurePipelinesUbuntu2204
       os: linux
+    sdl:
+      sourceAnalysisPool:
+        name: DevDivPlaywrightAzurePipelinesWindows2022
+        # The image must be windows-based due to restrictions of the SDL tools. See: https://aka.ms/AAo6v8e
+        # In the case of a windows build, this can be the same as the above pool image.
+        os: windows
     stages:
     - stage: Stage
       jobs:

--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -1,38 +1,48 @@
-# don't trigger for Pull Requests
-pr: none
+trigger: none
 
-trigger:
-  tags:
-    include:
-    - '*'
+# The `resources` specify the location and version of the 1ES PT.
+resources:
+  repositories:
+  - repository: 1esPipelines
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
 
-pool:
-  vmImage: ubuntu-latest
-
-steps:
-- task: UsePythonVersion@0
-  inputs:
-    versionSpec: '3.8'
-  displayName: 'Use Python'
-
-- script: |
-    python -m pip install --upgrade pip
-    pip install -r local-requirements.txt
-    pip install -e .
-    python setup.py bdist_wheel --all
-  displayName: 'Install & Build'
-
-- task: EsrpRelease@4
-  inputs:
-    ConnectedServiceName: 'Playwright-ESRP'
-    Intent: 'PackageDistribution'
-    ContentType: 'PyPi'
-    ContentSource: 'Folder'
-    FolderLocation: './dist/'
-    WaitForReleaseCompletion: true
-    Owners: 'maxschmitt@microsoft.com'
-    Approvers: 'maxschmitt@microsoft.com'
-    ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
-    MainPublisher: 'Playwright'
-    DomainTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47'
-  displayName: 'ESRP Release to PIP'
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  parameters:
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      image: ubuntu-latest
+      os: linux
+    stages:
+    - stage: Stage
+      jobs:
+      - job: HostJob
+        steps:
+        - task: UsePythonVersion@0
+          inputs:
+            versionSpec: '3.8'
+          displayName: 'Use Python'
+        
+        - script: |
+            python -m pip install --upgrade pip
+            pip install -r local-requirements.txt
+            pip install -e .
+            python setup.py bdist_wheel --all
+          displayName: 'Install & Build'
+        
+        - task: EsrpRelease@4
+          inputs:
+            ConnectedServiceName: 'Playwright-ESRP'
+            Intent: 'PackageDistribution'
+            ContentType: 'PyPi'
+            ContentSource: 'Folder'
+            FolderLocation: './dist/'
+            WaitForReleaseCompletion: true
+            Owners: 'maxschmitt@microsoft.com'
+            Approvers: 'maxschmitt@microsoft.com'
+            ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
+            MainPublisher: 'Playwright'
+            DomainTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47'
+          displayName: 'ESRP Release to PIP'

--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -1,6 +1,6 @@
 trigger: none
+pr: none
 
-# The `resources` specify the location and version of the 1ES PT.
 resources:
   repositories:
   - repository: 1esPipelines
@@ -24,14 +24,12 @@ extends:
           inputs:
             versionSpec: '3.8'
           displayName: 'Use Python'
-        
         - script: |
             python -m pip install --upgrade pip
             pip install -r local-requirements.txt
             pip install -e .
             python setup.py bdist_wheel --all
           displayName: 'Install & Build'
-        
         - task: EsrpRelease@4
           inputs:
             ConnectedServiceName: 'Playwright-ESRP'


### PR DESCRIPTION
Doing the same as in https://github.com/microsoft/playwright-browsers/compare/a2078c881d89ae334ee6609b86e39f48c1cd653c...c4b851fa133aaf6097cd4d6fa3c7e7bbb53bf800.