### PR TITLE
test: fix stalling future

### DIFF
--- a/tests/async/test_unroute_behavior.py
+++ b/tests/async/test_unroute_behavior.py
@@ -351,6 +351,7 @@ async def test_page_unroute_all_should_not_wait_for_pending_handlers_to_complete
 async def test_page_close_does_not_wait_for_active_route_handlers(
     page: Page, server: Server
 ) -> None:
+    stalling_future: "asyncio.Future[None]" = asyncio.Future()
     second_handler_called = False
 
     def _handler1(route: Route) -> None:
@@ -365,7 +366,7 @@ async def test_page_close_does_not_wait_for_active_route_handlers(
 
     async def _handler2(route: Route) -> None:
         route_future.set_result(route)
-        await asyncio.Future()
+        await stalling_future
 
     await page.route(
         "**/*",
@@ -383,6 +384,7 @@ async def test_page_close_does_not_wait_for_active_route_handlers(
     await page.close()
     await asyncio.sleep(0.5)
     assert not second_handler_called
+    stalling_future.cancel()
 
 
 async def test_route_continue_should_not_throw_if_page_has_been_closed(


### PR DESCRIPTION
This fixes:

Task was destroyed but it is pending!
task: <Task pending name='Task-26888' coro=<Page._on_route() running at /root/playwright/playwright/_impl/_page.py:253> wait_for=<Task pending name='Task-26889' coro=<test_page_close_does_not_wait_for_active_route_handlers.<locals>._handler2() running at /root/playwright/tests/async/test_unroute_behavior.py:368> wait_for=<Future pending cb=[<TaskWakeupMethWrapper object at 0xffff6dc6dbb0>()]> cb=[<TaskWakeupMethWrapper object at 0xffff6dc4fb20>()]> cb=[AsyncIOEventEmitter._emit_run.<locals>.callback() at /usr/local/lib/python3.8/dist-packages/pyee/asyncio.py:69]>
Task was destroyed but it is pending!
task: <Task pending name='Task-26889' coro=<test_page_close_does_not_wait_for_active_route_handlers.<locals>._handler2() running at /root/playwright/tests/async/test_unroute_behavior.py:368> wait_for=<Future pending cb=[<TaskWakeupMethWrapper object at 0xffff6dc6dbb0>()]> cb=[<TaskWakeupMethWrapper object at 0xffff6dc4fb20>()]>