### PR TITLE
feat: make `TimeoutError` extend  `builtins.TimeoutError`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ coverage.xml
 junit/
 htmldocs/
 utils/docker/dist/
+.venv/
+Pipfile*

--- a/playwright/_impl/_errors.py
+++ b/playwright/_impl/_errors.py
@@ -16,6 +16,7 @@
 # stable API.
 
 
+from builtins import TimeoutError as TimeoutErrorBuiltin
 from typing import Optional
 
 
@@ -43,7 +44,7 @@ class Error(Exception):
         return self._stack
 
 
-class TimeoutError(Error):
+class TimeoutError(Error, TimeoutErrorBuiltin):
     pass
 
 

--- a/tests/async/test_click.py
+++ b/tests/async/test_click.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import builtins
 from typing import Optional
 
 import pytest
@@ -638,6 +639,9 @@ async def test_timeout_waiting_for_hit_target(page: Page, server: Server) -> Non
     assert "Timeout 5000ms exceeded." in error.message
     assert '<div id="blocker"></div> intercepts pointer events' in error.message
     assert "retrying click action" in error.message
+    assert isinstance(error, Error)
+    assert isinstance(error, TimeoutError)
+    assert isinstance(error, builtins.TimeoutError)
 
 
 async def test_fail_when_obscured_and_not_waiting_for_hit_target(


### PR DESCRIPTION
Addressing issue [#1495](https://github.com/microsoft/playwright-python/issues/1495).

Note, depending on the  Python implementation `__builtins__` references either the module `builtins` or the dictionary `builtins.__dict__`. ([Ref](https://docs.python.org/3/library/builtins.html)). Therefore, I am importing `TimeoutError` as `TimeOutErrorBuiltin` from `builtins` to account for this implementation detail.

Additionally, I modified `.gitignore` to ignore Pipenv artifacts.