### PR TITLE
Revert "feat: make `TimeoutError` extend  `builtins.TimeoutError` (#2297)"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,3 @@ coverage.xml
 junit/
 htmldocs/
 utils/docker/dist/
-.venv/
-Pipfile*

--- a/playwright/_impl/_errors.py
+++ b/playwright/_impl/_errors.py
@@ -16,7 +16,6 @@
 # stable API.
 
 
-from builtins import TimeoutError as TimeoutErrorBuiltin
 from typing import Optional
 
 
@@ -44,7 +43,7 @@ class Error(Exception):
         return self._stack
 
 
-class TimeoutError(Error, TimeoutErrorBuiltin):
+class TimeoutError(Error):
     pass
 
 

--- a/tests/async/test_click.py
+++ b/tests/async/test_click.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import asyncio
-import builtins
 from typing import Optional
 
 import pytest
@@ -639,9 +638,6 @@ async def test_timeout_waiting_for_hit_target(page: Page, server: Server) -> Non
     assert "Timeout 5000ms exceeded." in error.message
     assert '<div id="blocker"></div> intercepts pointer events' in error.message
     assert "retrying click action" in error.message
-    assert isinstance(error, Error)
-    assert isinstance(error, TimeoutError)
-    assert isinstance(error, builtins.TimeoutError)
 
 
 async def test_fail_when_obscured_and_not_waiting_for_hit_target(


### PR DESCRIPTION
This reverts commit 8cd06e5190d8da8c3e6920596e5fc377d6a88c42.

We decided that the risk which it introduces overweights the issues it solves, since there is a working workaround.