### PR TITLE
fix: ignore exceptions from updateInterceptorPatterns

### DIFF
--- a/playwright/_impl/_page.py
+++ b/playwright/_impl/_page.py
@@ -262,9 +262,16 @@ class Page(ChannelOwner):
                 handled = await route_handler.handle(route)
             finally:
                 if len(self._routes) == 0:
+
+                    async def _update_interceptor_patterns_ignore_exceptions() -> None:
+                        try:
+                            await self._update_interception_patterns()
+                        except Error:
+                            pass
+
                     asyncio.create_task(
                         self._connection.wrap_api_call(
-                            lambda: self._update_interception_patterns(), True
+                            _update_interceptor_patterns_ignore_exceptions, True
                         )
                     )
             if handled:


### PR DESCRIPTION
Motivation:

```
Task exception was never retrieved
future: <Task finished name='Task-9032' coro=<Connection.wrap_api_call() done, defined at /home/runner/work/playwright-python/playwright-python/playwright/_impl/_connection.py:481> exception=TargetClosedError('Target page, context or browser has been closed')>
Traceback (most recent call last):
  File "/home/runner/work/playwright-python/playwright-python/playwright/_impl/_connection.py", line 490, in wrap_api_call
    return await cb()
           ^^^^^^^^^^
  File "/home/runner/work/playwright-python/playwright-python/playwright/_impl/_page.py", line 673, in _update_interception_patterns
    await self._channel.send(
  File "/home/runner/work/playwright-python/playwright-python/playwright/_impl/_connection.py", line 58, in send
    return await self._connection.wrap_api_call(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/playwright-python/playwright-python/playwright/_impl/_connection.py", line 485, in wrap_api_call
    return await cb()
           ^^^^^^^^^^
  File "/home/runner/work/playwright-python/playwright-python/playwright/_impl/_connection.py", line 96, in inner_send
    result = next(iter(done)).result()
             ^^^^^^^^^^^^^^^^^^^^^^^^^
playwright._impl._errors.TargetClosedError: Target page, context or browser has been closed
```

Motivation: We saw this error in the [logs](https://github.com/microsoft/playwright-python/actions/runs/8016325868/job/21898061699#step:11:1392) and follow what we do upstream.