### PR TITLE
fix: report route handler errors to the user after they completed

### DIFF
--- a/playwright/_impl/_browser_context.py
+++ b/playwright/_impl/_browser_context.py
@@ -123,7 +123,7 @@ class BrowserContext(ChannelOwner):
         )
         self._channel.on(
             "route",
-            lambda params: asyncio.create_task(
+            lambda params: self._loop.create_task(
                 self._on_route(
                     from_channel(params.get("route")),
                 )

--- a/playwright/_impl/_connection.py
+++ b/playwright/_impl/_connection.py
@@ -78,14 +78,13 @@ class Channel(AsyncIOEventEmitter):
     ) -> Any:
         if params is None:
             params = {}
-        callback = self._connection._send_message_to_server(
-            self._object, method, _filter_none(params)
-        )
         if self._connection._error:
             error = self._connection._error
             self._connection._error = None
-            callback.future.cancel()
             raise error
+        callback = self._connection._send_message_to_server(
+            self._object, method, _filter_none(params)
+        )
         done, _ = await asyncio.wait(
             {
                 self._connection._transport.on_error_future,

--- a/playwright/_impl/_connection.py
+++ b/playwright/_impl/_connection.py
@@ -451,6 +451,7 @@ class Connection(EventEmitter):
     def _on_event_listener_error(self, exc: BaseException) -> None:
         print("Error occurred in event listener", file=sys.stderr)
         traceback.print_exception(type(exc), exc, exc.__traceback__, file=sys.stderr)
+        # Save the error to throw at the next API call. This "replicates" unhandled rejection in Node.js.
         self._error = exc
 
     def _create_remote_object(

--- a/playwright/_impl/_helper.py
+++ b/playwright/_impl/_helper.py
@@ -299,10 +299,20 @@ class RouteHandler:
 
         self._handled_count += 1
         if self._is_sync:
+            handler_finished_future = route._loop.create_future()
+
+            def _handler() -> None:
+                try:
+                    self.handler(route, route.request)  # type: ignore
+                    handler_finished_future.set_result(None)
+                except Exception as e:
+                    handler_finished_future.set_exception(e)
+
             # As with event handlers, each route handler is a potentially blocking context
             # so it needs a fiber.
-            g = RouteGreenlet(lambda: self.handler(route, route.request))  # type: ignore
+            g = RouteGreenlet(_handler)
             g.switch()
+            await handler_finished_future
         else:
             coro_or_future = self.handler(route, route.request)  # type: ignore
             if coro_or_future:

--- a/playwright/_impl/_page.py
+++ b/playwright/_impl/_page.py
@@ -180,13 +180,13 @@ class Page(ChannelOwner):
         )
         self._channel.on(
             "locatorHandlerTriggered",
-            lambda params: asyncio.create_task(
+            lambda params: self._loop.create_task(
                 self._on_locator_handler_triggered(params["uid"])
             ),
         )
         self._channel.on(
             "route",
-            lambda params: asyncio.create_task(
+            lambda params: self._loop.create_task(
                 self._on_route(from_channel(params["route"]))
             ),
         )

--- a/tests/async/test_browsercontext_request_intercept.py
+++ b/tests/async/test_browsercontext_request_intercept.py
@@ -189,5 +189,6 @@ async def test_should_show_exception_after_fulfill(page: Page, server: Server) -
 
     await page.route("*/**", _handle)
     await page.goto(server.EMPTY_PAGE)
+    # Any next API call should throw because handler did throw during previous goto()
     with pytest.raises(Exception, match="Exception text!?"):
         await page.goto(server.EMPTY_PAGE)

--- a/tests/async/test_browsercontext_request_intercept.py
+++ b/tests/async/test_browsercontext_request_intercept.py
@@ -15,6 +15,7 @@
 import asyncio
 from pathlib import Path
 
+import pytest
 from twisted.web import http
 
 from playwright.async_api import BrowserContext, Page, Route
@@ -179,3 +180,14 @@ async def test_should_give_access_to_the_intercepted_response_body(
         route.fulfill(response=response),
         eval_task,
     )
+
+
+async def test_should_show_exception_after_fulfill(page: Page, server: Server) -> None:
+    async def _handle(route: Route) -> None:
+        await route.continue_()
+        raise Exception("Exception text!?")
+
+    await page.route("*/**", _handle)
+    await page.goto(server.EMPTY_PAGE)
+    with pytest.raises(Exception, match="Exception text!?"):
+        await page.goto(server.EMPTY_PAGE)

--- a/tests/sync/test_browsercontext_request_intercept.py
+++ b/tests/sync/test_browsercontext_request_intercept.py
@@ -14,6 +14,7 @@
 
 from pathlib import Path
 
+import pytest
 from twisted.web import http
 
 from playwright.sync_api import BrowserContext, Page, Route
@@ -121,3 +122,14 @@ def test_should_support_fulfill_after_intercept(
     assert request.uri.decode() == "/title.html"
     original = (assetdir / "title.html").read_text()
     assert response.text() == original
+
+
+def test_should_show_exception_after_fulfill(page: Page, server: Server) -> None:
+    def _handle(route: Route) -> None:
+        route.continue_()
+        raise Exception("Exception text!?")
+
+    page.route("*/**", _handle)
+    page.goto(server.EMPTY_PAGE)
+    with pytest.raises(Exception, match="Exception text!?"):
+        page.goto(server.EMPTY_PAGE)

--- a/tests/sync/test_browsercontext_request_intercept.py
+++ b/tests/sync/test_browsercontext_request_intercept.py
@@ -131,5 +131,6 @@ def test_should_show_exception_after_fulfill(page: Page, server: Server) -> None
 
     page.route("*/**", _handle)
     page.goto(server.EMPTY_PAGE)
+    # Any next API call should throw because handler did throw during previous goto()
     with pytest.raises(Exception, match="Exception text!?"):
         page.goto(server.EMPTY_PAGE)


### PR DESCRIPTION
Issue: Exceptions which will get thrown in route handlers after route.{fulfill,continue,abort} got called,
won't get surfaced to the user in the sync and async version of Playwright for Python.

Scope: Event handlers which use asyncio.create_task
  - {BrowserContext,Page}.on("route")
  - {Page}.on({"route", "locatorHandlerTriggered"})

There were multiple issues in the implementation:

1. `playwright/_impl/_helper.py` (sync only): we were only waiting until a handler's {continue,fulfill,abort} got called, and did not wait until the actual callback completed. Fix: Wait until the handler completed.
2. `playwright/_impl/_connection.py:423` (sync only): We call event listeners manually, this means that `pyee`'s `"error"` event is not working there. Fix: attach a done callback manually, like pyee is doing inside their library.
3. `playwright/_impl/_connection.py:56` (async): attach an `"error"` event handler for the async error reporting
4. `playwright/_impl/_connection.py:90` if we report an error to the user, we should cancel the underlying future otherwise a warning gets emitted, that there was a future exception never received.

This should resolve https://github.com/microsoft/playwright-python/issues/2136.