### PR TITLE
fix: inherit expect context managers from contextlib

### DIFF
--- a/playwright/_impl/_async_base.py
+++ b/playwright/_impl/_async_base.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 import asyncio
+from contextlib import AbstractAsyncContextManager
 from types import TracebackType
-from typing import Any, Callable, Generic, Type, TypeVar
+from typing import Any, Callable, Generic, Optional, Type, TypeVar
 
 from playwright._impl._impl_to_api_mapping import ImplToApiMapping, ImplWrapper
 
@@ -40,7 +41,7 @@ class AsyncEventInfo(Generic[T]):
         return self._future.done()
 
 
-class AsyncEventContextManager(Generic[T]):
+class AsyncEventContextManager(Generic[T], AbstractAsyncContextManager):
     def __init__(self, future: "asyncio.Future[T]") -> None:
         self._event = AsyncEventInfo[T](future)
 
@@ -49,9 +50,9 @@ class AsyncEventContextManager(Generic[T]):
 
     async def __aexit__(
         self,
-        exc_type: Type[BaseException],
-        exc_val: BaseException,
-        exc_tb: TracebackType,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
     ) -> None:
         if exc_val:
             self._event._cancel()

--- a/playwright/_impl/_sync_base.py
+++ b/playwright/_impl/_sync_base.py
@@ -15,6 +15,7 @@
 import asyncio
 import inspect
 import traceback
+from contextlib import AbstractContextManager
 from types import TracebackType
 from typing import (
     Any,
@@ -22,6 +23,7 @@ from typing import (
     Coroutine,
     Generator,
     Generic,
+    Optional,
     Type,
     TypeVar,
     Union,
@@ -64,7 +66,7 @@ class EventInfo(Generic[T]):
         return self._future.done()
 
 
-class EventContextManager(Generic[T]):
+class EventContextManager(Generic[T], AbstractContextManager):
     def __init__(self, sync_base: "SyncBase", future: "asyncio.Future[T]") -> None:
         self._event = EventInfo[T](sync_base, future)
 
@@ -73,9 +75,9 @@ class EventContextManager(Generic[T]):
 
     def __exit__(
         self,
-        exc_type: Type[BaseException],
-        exc_val: BaseException,
-        exc_tb: TracebackType,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
     ) -> None:
         if exc_val:
             self._event._cancel()


### PR DESCRIPTION
Looking at the class we are [inheriting from](https://github.com/python/cpython/blob/63d6f2623ef2aa90f51c6a928b96845b9b380d89/Lib/contextlib.py#L41), this should not have any negative side effects.

Fixes https://github.com/microsoft/playwright-python/issues/2368