### PR TITLE
fix: brush up exception messages to include apiName & call log

### DIFF
--- a/playwright/_impl/_errors.py
+++ b/playwright/_impl/_errors.py
@@ -50,3 +50,11 @@ class TimeoutError(Error):
 class TargetClosedError(Error):
     def __init__(self, message: str = None) -> None:
         super().__init__(message or "Target page, context or browser has been closed")
+
+
+def rewrite_error(error: Exception, message: str) -> Exception:
+    rewritten_exc = type(error)(message)
+    if isinstance(rewritten_exc, Error) and isinstance(error, Error):
+        rewritten_exc._name = error.name
+        rewritten_exc._stack = error.stack
+    return rewritten_exc

--- a/tests/async/test_browsercontext.py
+++ b/tests/async/test_browsercontext.py
@@ -126,7 +126,7 @@ async def test_page_event_should_not_allow_device_scale_factor_with_null_viewpor
         await browser.new_context(no_viewport=True, device_scale_factor=1)
     assert (
         exc_info.value.message
-        == '"deviceScaleFactor" option is not supported with null "viewport"'
+        == 'Browser.new_context: "deviceScaleFactor" option is not supported with null "viewport"'
     )
 
 
@@ -137,7 +137,7 @@ async def test_page_event_should_not_allow_is_mobile_with_null_viewport(
         await browser.new_context(no_viewport=True, is_mobile=True)
     assert (
         exc_info.value.message
-        == '"isMobile" option is not supported with null "viewport"'
+        == 'Browser.new_context: "isMobile" option is not supported with null "viewport"'
     )
 
 

--- a/tests/async/test_frames.py
+++ b/tests/async/test_frames.py
@@ -71,7 +71,7 @@ async def test_frame_element_throw_when_detached(
     except Error as e:
         error = e
     assert error
-    assert error.message == "Frame has been detached."
+    assert error.message == "Frame.frame_element: Frame has been detached."
 
 
 async def test_evaluate_throw_for_detached_frames(

--- a/tests/async/test_keyboard.py
+++ b/tests/async/test_keyboard.py
@@ -424,15 +424,15 @@ async def test_should_press_enter(page: Page) -> None:
 async def test_should_throw_unknown_keys(page: Page, server: Server) -> None:
     with pytest.raises(Error) as exc:
         await page.keyboard.press("NotARealKey")
-    assert exc.value.message == 'Unknown key: "NotARealKey"'
+    assert exc.value.message == 'Keyboard.press: Unknown key: "NotARealKey"'
 
     with pytest.raises(Error) as exc:
         await page.keyboard.press("ё")
-    assert exc.value.message == 'Unknown key: "ё"'
+    assert exc.value.message == 'Keyboard.press: Unknown key: "ё"'
 
     with pytest.raises(Error) as exc:
         await page.keyboard.press("😊")
-    assert exc.value.message == 'Unknown key: "😊"'
+    assert exc.value.message == 'Keyboard.press: Unknown key: "😊"'
 
 
 async def test_should_type_emoji(page: Page, server: Server) -> None:

--- a/tests/async/test_locators.py
+++ b/tests/async/test_locators.py
@@ -14,6 +14,7 @@
 
 import os
 import re
+import traceback
 from typing import Callable
 from urllib.parse import urlparse
 
@@ -1083,3 +1084,19 @@ async def test_locator_all_should_work(page: Page) -> None:
     for p in await page.locator("p").all():
         texts.append(await p.text_content())
     assert texts == ["A", "B", "C"]
+
+
+async def test_locator_click_timeout_error_should_contain_call_log(page: Page) -> None:
+    with pytest.raises(Error) as exc_info:
+        await page.get_by_role("button", name="Hello Python").click(timeout=42)
+    formatted_exception = "".join(
+        traceback.format_exception(exc_info.value)  # type: ignore
+    )
+    assert "Locator.click: Timeout 42ms exceeded." in formatted_exception
+    assert (
+        'waiting for get_by_role("button", name="Hello Python")' in formatted_exception
+    )
+    assert (
+        "During handling of the above exception, another exception occurred"
+        not in formatted_exception
+    )

--- a/tests/async/test_locators.py
+++ b/tests/async/test_locators.py
@@ -1090,7 +1090,7 @@ async def test_locator_click_timeout_error_should_contain_call_log(page: Page) -
     with pytest.raises(Error) as exc_info:
         await page.get_by_role("button", name="Hello Python").click(timeout=42)
     formatted_exception = "".join(
-        traceback.format_exception(exc_info.value)  # type: ignore
+        traceback.format_exception(type(exc_info.value), value=exc_info.value, tb=None)
     )
     assert "Locator.click: Timeout 42ms exceeded." in formatted_exception
     assert (

--- a/tests/async/test_network.py
+++ b/tests/async/test_network.py
@@ -830,7 +830,10 @@ async def test_set_extra_http_headers_should_throw_for_non_string_header_values(
     except Error as exc:
         error = exc
     assert error
-    assert error.message == "headers[0].value: expected string, got number"
+    assert (
+        error.message
+        == "Page.set_extra_http_headers: headers[0].value: expected string, got number"
+    )
 
 
 async def test_response_server_addr(page: Page, server: Server) -> None:

--- a/tests/async/test_queryselector.py
+++ b/tests/async/test_queryselector.py
@@ -182,7 +182,7 @@ async def test_selectors_register_should_handle_errors(
         await selectors.register("$", dummy_selector_engine_script)
     assert (
         exc.value.message
-        == "Selector engine name may only contain [a-zA-Z0-9_] characters"
+        == "Selectors.register: Selector engine name may only contain [a-zA-Z0-9_] characters"
     )
 
     # Selector names are case-sensitive.
@@ -195,11 +195,16 @@ async def test_selectors_register_should_handle_errors(
 
     with pytest.raises(Error) as exc:
         await selectors.register("dummy", dummy_selector_engine_script)
-    assert exc.value.message == '"dummy" selector engine has been already registered'
+    assert (
+        exc.value.message
+        == 'Selectors.register: "dummy" selector engine has been already registered'
+    )
 
     with pytest.raises(Error) as exc:
         await selectors.register("css", dummy_selector_engine_script)
-    assert exc.value.message == '"css" is a predefined selector engine'
+    assert (
+        exc.value.message == 'Selectors.register: "css" is a predefined selector engine'
+    )
 
 
 async def test_should_work_with_layout_selectors(page: Page) -> None:

--- a/tests/sync/test_locators.py
+++ b/tests/sync/test_locators.py
@@ -14,6 +14,7 @@
 
 import os
 import re
+import traceback
 from typing import Callable
 from urllib.parse import urlparse
 
@@ -937,3 +938,19 @@ def test_locator_all_should_work(page: Page) -> None:
     for p in page.locator("p").all():
         texts.append(p.text_content())
     assert texts == ["A", "B", "C"]
+
+
+def test_locator_click_timeout_error_should_contain_call_log(page: Page) -> None:
+    with pytest.raises(Error) as exc_info:
+        page.get_by_role("button", name="Hello Python").click(timeout=42)
+    formatted_exception = "".join(
+        traceback.format_exception(exc_info.value)  # type: ignore
+    )
+    assert "Locator.click: Timeout 42ms exceeded." in formatted_exception
+    assert (
+        'waiting for get_by_role("button", name="Hello Python")' in formatted_exception
+    )
+    assert (
+        "During handling of the above exception, another exception occurred"
+        not in formatted_exception
+    )

--- a/tests/sync/test_locators.py
+++ b/tests/sync/test_locators.py
@@ -944,7 +944,7 @@ def test_locator_click_timeout_error_should_contain_call_log(page: Page) -> None
     with pytest.raises(Error) as exc_info:
         page.get_by_role("button", name="Hello Python").click(timeout=42)
     formatted_exception = "".join(
-        traceback.format_exception(exc_info.value)  # type: ignore
+        traceback.format_exception(type(exc_info.value), value=exc_info.value, tb=None)
     )
     assert "Locator.click: Timeout 42ms exceeded." in formatted_exception
     assert (

--- a/tests/sync/test_queryselector.py
+++ b/tests/sync/test_queryselector.py
@@ -156,7 +156,7 @@ def test_selectors_register_should_handle_errors(
         selectors.register("$", dummy_selector_engine_script)
     assert (
         exc.value.message
-        == "Selector engine name may only contain [a-zA-Z0-9_] characters"
+        == "Selectors.register: Selector engine name may only contain [a-zA-Z0-9_] characters"
     )
 
     # Selector names are case-sensitive.
@@ -165,11 +165,16 @@ def test_selectors_register_should_handle_errors(
 
     with pytest.raises(Error) as exc:
         selectors.register("dummy", dummy_selector_engine_script)
-    assert exc.value.message == '"dummy" selector engine has been already registered'
+    assert (
+        exc.value.message
+        == 'Selectors.register: "dummy" selector engine has been already registered'
+    )
 
     with pytest.raises(Error) as exc:
         selectors.register("css", dummy_selector_engine_script)
-    assert exc.value.message == '"css" is a predefined selector engine'
+    assert (
+        exc.value.message == 'Selectors.register: "css" is a predefined selector engine'
+    )
 
 
 def test_should_work_with_layout_selectors(page: Page) -> None:


### PR DESCRIPTION
This makes the error message more aligned to how to is in Node.js:

```
node:internal/process/promises:289
            triggerUncaughtException(err, true /* fromPromise */);
            ^

locator.click: Timeout 2000ms exceeded.
Call log:
  - waiting for getByRole('link', { name: 'More asdfasdfinformation' })

    at /Users/maxschmitt/Developer/playwright/test.mjs:28:70 {
  name: 'TimeoutError'
}

Node.js v20.9.0
```

```
tests/async/test_locators.py::test_locator_click_timeout_error_should_contain_call_log[chromium] Traceback (most recent call last):
  File "/Users/maxschmitt/Developer/playwright-python/tests/async/test_locators.py", line 1090, in test_locator_click_timeout_error_should_contain_call_log
    await page.get_by_role("button", name="Hello Python").click(timeout=42)
  File "/Users/maxschmitt/Developer/playwright-python/playwright/async_api/_generated.py", line 14725, in click
    await self._impl_obj.click(
  File "/Users/maxschmitt/Developer/playwright-python/playwright/_impl/_locator.py", line 153, in click
    return await self._frame.click(self._selector, strict=True, **params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/maxschmitt/Developer/playwright-python/playwright/_impl/_frame.py", line 488, in click
    await self._channel.send("click", locals_to_params(locals()))
  File "/Users/maxschmitt/Developer/playwright-python/playwright/_impl/_connection.py", line 59, in send
    return await self._connection.wrap_api_call(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/maxschmitt/Developer/playwright-python/playwright/_impl/_connection.py", line 511, in wrap_api_call
    raise rewrite_error(exc, f"{parsed_st["apiName"]}: {exc.message}") from None
playwright._impl._errors.TimeoutError: Locator.click: Timeout 42ms exceeded.
Call log:
waiting for get_by_role("button", name="Hello Python")
```

Ideally we hide the internal stack traces like we do in Node.js - maybe as a follow-up?

Fixes https://github.com/microsoft/playwright-python/issues/2369