### PR TITLE
fix(cli): don't show a stack trace when command + c of the CLI

### DIFF
--- a/playwright/__main__.py
+++ b/playwright/__main__.py
@@ -19,11 +19,14 @@ from playwright._impl._driver import compute_driver_executable, get_driver_env
 
 
 def main() -> None:
-    driver_executable, driver_cli = compute_driver_executable()
-    completed_process = subprocess.run(
-        [driver_executable, driver_cli, *sys.argv[1:]], env=get_driver_env()
-    )
-    sys.exit(completed_process.returncode)
+    try:
+        driver_executable, driver_cli = compute_driver_executable()
+        completed_process = subprocess.run(
+            [driver_executable, driver_cli, *sys.argv[1:]], env=get_driver_env()
+        )
+        sys.exit(completed_process.returncode)
+    except KeyboardInterrupt:
+        sys.exit(130)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
130 means Command terminated by user, this matches it what happens with `npx playwright ...`.