### PR TITLE
fix(cdpSession): allow optional params in events

### DIFF
--- a/playwright/_impl/_cdp_session.py
+++ b/playwright/_impl/_cdp_session.py
@@ -26,7 +26,7 @@ class CDPSession(ChannelOwner):
         self._channel.on("event", lambda params: self._on_event(params))
 
     def _on_event(self, params: Any) -> None:
-        self.emit(params["method"], params["params"])
+        self.emit(params["method"], params.get("params"))
 
     async def send(self, method: str, params: Dict = None) -> Dict:
         return await self._channel.send("send", locals_to_params(locals()))


### PR DESCRIPTION
Following our protocol spec: https://github.com/microsoft/playwright/blob/82aefd24db1ba9977c3f6953347ee266845790ea/packages/protocol/src/protocol.yml#L3110