### PR TITLE
fix(connect): Future exception was never retrieved on close()

### DIFF
--- a/playwright/_impl/_connection.py
+++ b/playwright/_impl/_connection.py
@@ -293,6 +293,9 @@ class Connection(EventEmitter):
         for ws_connection in self._child_ws_connections:
             ws_connection._transport.dispose()
         for callback in self._callbacks.values():
+            # To prevent 'Future exception was never retrieved' we ignore all callbacks that are no_reply.
+            if callback.no_reply:
+                continue
             callback.future.set_exception(self._closed_error)
         self._callbacks.clear()
         self.emit("close")


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-python/issues/2426

Mirror of: https://github.com/microsoft/playwright-python/blob/5b6461884286172202f7f8ed875330f83c97abcf/playwright/_impl/_connection.py#L371-L374