### PR TITLE
prepare support for Nuitka

### DIFF
--- a/playwright/_impl/_driver.py
+++ b/playwright/_impl/_driver.py
@@ -22,31 +22,6 @@ import playwright
 from playwright._repo_version import version
 import pathlib
 
-def get_registry_directory() -> str:
-    env_defined = os.environ.get('PLAYWRIGHT_BROWSERS_PATH')
-    path_home = Path.home()
-    if env_defined == '0':
-        result = pathlib.Path(__file__).parent.parent.parent.joinpath('.local-browsers')
-    elif env_defined:
-        result = pathlib.Path(env_defined)
-    else:
-        cache_directory: Union[str, Path] = ''
-        if os.name == 'posix':
-            cache_directory = os.environ.get('XDG_CACHE_HOME', path_home / '.cache')
-        elif os.name == 'darwin':
-            cache_directory = path_home / 'Library' / 'Caches'
-        elif os.name == 'nt':
-            cache_directory = os.environ.get('LOCALAPPDATA', path_home / 'AppData' / 'Local')
-        else:
-            raise RuntimeError('Unsupported platform: ' + os.name)
-        result = pathlib.Path(cache_directory, 'ms-playwright')
-
-    if not result.is_absolute():
-        init_cwd = os.environ.get('INIT_CWD') or os.getcwd()
-        result = pathlib.Path(init_cwd).resolve().joinpath(result)
-
-    return str(result)
-
 
 def compute_driver_executable() -> Tuple[str, str]:
     driver_path = Path(inspect.getfile(playwright)).parent / "driver"

--- a/playwright/_impl/_driver.py
+++ b/playwright/_impl/_driver.py
@@ -16,11 +16,10 @@ import inspect
 import os
 import sys
 from pathlib import Path
-from typing import Tuple, Union
+from typing import Tuple
 
 import playwright
 from playwright._repo_version import version
-import pathlib
 
 
 def compute_driver_executable() -> Tuple[str, str]:

--- a/playwright/_impl/_driver.py
+++ b/playwright/_impl/_driver.py
@@ -16,10 +16,36 @@ import inspect
 import os
 import sys
 from pathlib import Path
-from typing import Tuple
+from typing import Tuple, Union
 
 import playwright
 from playwright._repo_version import version
+import pathlib
+
+def get_registry_directory() -> str:
+    env_defined = os.environ.get('PLAYWRIGHT_BROWSERS_PATH')
+    path_home = Path.home()
+    if env_defined == '0':
+        result = pathlib.Path(__file__).parent.parent.parent.joinpath('.local-browsers')
+    elif env_defined:
+        result = pathlib.Path(env_defined)
+    else:
+        cache_directory: Union[str, Path] = ''
+        if os.name == 'posix':
+            cache_directory = os.environ.get('XDG_CACHE_HOME', path_home / '.cache')
+        elif os.name == 'darwin':
+            cache_directory = path_home / 'Library' / 'Caches'
+        elif os.name == 'nt':
+            cache_directory = os.environ.get('LOCALAPPDATA', path_home / 'AppData' / 'Local')
+        else:
+            raise RuntimeError('Unsupported platform: ' + os.name)
+        result = pathlib.Path(cache_directory, 'ms-playwright')
+
+    if not result.is_absolute():
+        init_cwd = os.environ.get('INIT_CWD') or os.getcwd()
+        result = pathlib.Path(init_cwd).resolve().joinpath(result)
+
+    return str(result)
 
 
 def compute_driver_executable() -> Tuple[str, str]:

--- a/playwright/_impl/_transport.py
+++ b/playwright/_impl/_transport.py
@@ -105,9 +105,9 @@ class PipeTransport(Transport):
         self._stopped_future: asyncio.Future = asyncio.Future()
 
         try:
-            # For pyinstaller
+            # For pyinstaller and Nuitka
             env = get_driver_env()
-            if getattr(sys, "frozen", False):
+            if getattr(sys, "frozen", False) or globals().get("_compiled__"):
                 env.setdefault("PLAYWRIGHT_BROWSERS_PATH", "0")
 
             startupinfo = None


### PR DESCRIPTION
this PR will prepare playwright to make it easier to be compiled into standalone / onefile programs for ease of distribution
the following changes have been made:

1) added the python version of 
 ```js
const registryDirectory = exports.registryDirectory
```

in `playwright._impl._driver`, Nuitka will use this to resolve the path to the browsers .

2) check if `_compiled__` is in the globals dict, if it is, set `PLAYWRIGHT_BROWSERS_PATH` to 0 just like for pyinstaller