### PR TITLE
fix(driver): consider PLAYWRIGHT_NODEJS_PATH from host env win32

### DIFF
--- a/playwright/_impl/_driver.py
+++ b/playwright/_impl/_driver.py
@@ -26,7 +26,10 @@ def compute_driver_executable() -> Tuple[str, str]:
     driver_path = Path(inspect.getfile(playwright)).parent / "driver"
     cli_path = str(driver_path / "package" / "cli.js")
     if sys.platform == "win32":
-        return (str(driver_path / "node.exe"), cli_path)
+        return (
+            os.getenv("PLAYWRIGHT_NODEJS_PATH", str(driver_path / "node.exe")),
+            cli_path,
+        )
     return (os.getenv("PLAYWRIGHT_NODEJS_PATH", str(driver_path / "node")), cli_path)
 
 


### PR DESCRIPTION
Adds the ability to use the env variable on win32 PLAYWRIGHT_NODEJS_PATH to use local nodejs