### PR TITLE
chore(roll): roll to Playwright v1.45.0-beta-1719505820000

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Playwright is a Python library to automate [Chromium](https://www.chromium.org/H
 
 |          | Linux | macOS | Windows |
 |   :---   | :---: | :---: | :---:   |
-| Chromium <!-- GEN:chromium-version -->127.0.6533.5<!-- GEN:stop --> | ✅ | ✅ | ✅ |
+| Chromium <!-- GEN:chromium-version -->127.0.6533.17<!-- GEN:stop --> | ✅ | ✅ | ✅ |
 | WebKit <!-- GEN:webkit-version -->17.4<!-- GEN:stop --> | ✅ | ✅ | ✅ |
 | Firefox <!-- GEN:firefox-version -->127.0<!-- GEN:stop --> | ✅ | ✅ | ✅ |
 

--- a/playwright/_impl/_clock.py
+++ b/playwright/_impl/_clock.py
@@ -32,7 +32,7 @@ class Clock:
 
     async def fast_forward(
         self,
-        ticks: Union[float, str],
+        ticks: Union[int, str],
     ) -> None:
         await self._browser_context._channel.send(
             "clockFastForward", parse_ticks(ticks)
@@ -51,7 +51,7 @@ class Clock:
 
     async def run_for(
         self,
-        ticks: Union[float, str],
+        ticks: Union[int, str],
     ) -> None:
         await self._browser_context._channel.send("clockRunFor", parse_ticks(ticks))
 
@@ -71,16 +71,16 @@ class Clock:
 
 
 def parse_time(
-    time: Union[float, str, datetime.datetime]
+    time: Union[float, int, str, datetime.datetime]
 ) -> Dict[str, Union[int, str]]:
-    if isinstance(time, (int, float)):
+    if isinstance(time, (float, int)):
         return {"timeNumber": int(time)}
     if isinstance(time, str):
         return {"timeString": time}
-    return {"timeNumber": int(time.timestamp())}
+    return {"timeNumber": int(time.timestamp() * 1_000)}
 
 
-def parse_ticks(ticks: Union[float, str]) -> Dict[str, Union[int, str]]:
-    if isinstance(ticks, (float, int)):
-        return {"ticksNumber": int(ticks)}
+def parse_ticks(ticks: Union[int, str]) -> Dict[str, Union[int, str]]:
+    if isinstance(ticks, int):
+        return {"ticksNumber": ticks}
     return {"ticksString": ticks}

--- a/playwright/_impl/_clock.py
+++ b/playwright/_impl/_clock.py
@@ -71,10 +71,10 @@ class Clock:
 
 
 def parse_time(
-    time: Union[float, int, str, datetime.datetime]
+    time: Union[float, str, datetime.datetime]
 ) -> Dict[str, Union[int, str]]:
     if isinstance(time, (float, int)):
-        return {"timeNumber": int(time)}
+        return {"timeNumber": int(time * 1_000)}
     if isinstance(time, str):
         return {"timeString": time}
     return {"timeNumber": int(time.timestamp() * 1_000)}

--- a/playwright/_impl/_clock.py
+++ b/playwright/_impl/_clock.py
@@ -25,14 +25,14 @@ class Clock:
         self._loop = browser_context._loop
         self._dispatcher_fiber = browser_context._dispatcher_fiber
 
-    async def install(self, time: Union[int, str, datetime.datetime] = None) -> None:
+    async def install(self, time: Union[float, str, datetime.datetime] = None) -> None:
         await self._browser_context._channel.send(
             "clockInstall", parse_time(time) if time is not None else {}
         )
 
     async def fast_forward(
         self,
-        ticks: Union[int, str],
+        ticks: Union[float, str],
     ) -> None:
         await self._browser_context._channel.send(
             "clockFastForward", parse_ticks(ticks)
@@ -40,7 +40,7 @@ class Clock:
 
     async def pause_at(
         self,
-        time: Union[int, str, datetime.datetime],
+        time: Union[float, str, datetime.datetime],
     ) -> None:
         await self._browser_context._channel.send("clockPauseAt", parse_time(time))
 
@@ -51,34 +51,36 @@ class Clock:
 
     async def run_for(
         self,
-        ticks: Union[int, str],
+        ticks: Union[float, str],
     ) -> None:
         await self._browser_context._channel.send("clockRunFor", parse_ticks(ticks))
 
     async def set_fixed_time(
         self,
-        time: Union[int, str, datetime.datetime],
+        time: Union[float, str, datetime.datetime],
     ) -> None:
         await self._browser_context._channel.send("clockSetFixedTime", parse_time(time))
 
     async def set_system_time(
         self,
-        time: Union[int, str, datetime.datetime],
+        time: Union[float, str, datetime.datetime],
     ) -> None:
         await self._browser_context._channel.send(
             "clockSetSystemTime", parse_time(time)
         )
 
 
-def parse_time(time: Union[int, str, datetime.datetime]) -> Dict[str, Union[int, str]]:
-    if isinstance(time, int):
-        return {"timeNumber": time}
+def parse_time(
+    time: Union[float, str, datetime.datetime]
+) -> Dict[str, Union[int, str]]:
+    if isinstance(time, (int, float)):
+        return {"timeNumber": int(time)}
     if isinstance(time, str):
         return {"timeString": time}
     return {"timeNumber": int(time.timestamp())}
 
 
-def parse_ticks(ticks: Union[int, str]) -> Dict[str, Union[int, str]]:
-    if isinstance(ticks, int):
-        return {"ticksNumber": ticks}
+def parse_ticks(ticks: Union[float, str]) -> Dict[str, Union[int, str]]:
+    if isinstance(ticks, (float, int)):
+        return {"ticksNumber": int(ticks)}
     return {"ticksString": ticks}

--- a/playwright/async_api/_generated.py
+++ b/playwright/async_api/_generated.py
@@ -6710,6 +6710,8 @@ class Clock(AsyncBase):
         Parameters
         ----------
         ticks : Union[int, str]
+            Time may be the number of milliseconds to advance the clock by or a human-readable string. Valid string formats are
+            "08" for eight seconds, "01:00" for one minute and "02:34:10" for two hours, 34 minutes and ten seconds.
         """
 
         return mapping.from_maybe_impl(await self._impl_obj.fast_forward(ticks=ticks))
@@ -6734,6 +6736,7 @@ class Clock(AsyncBase):
         Parameters
         ----------
         time : Union[datetime.datetime, float, str]
+            Time to pause at.
         """
 
         return mapping.from_maybe_impl(await self._impl_obj.pause_at(time=time))
@@ -6761,6 +6764,8 @@ class Clock(AsyncBase):
         Parameters
         ----------
         ticks : Union[int, str]
+            Time may be the number of milliseconds to advance the clock by or a human-readable string. Valid string formats are
+            "08" for eight seconds, "01:00" for one minute and "02:34:10" for two hours, 34 minutes and ten seconds.
         """
 
         return mapping.from_maybe_impl(await self._impl_obj.run_for(ticks=ticks))
@@ -6806,6 +6811,7 @@ class Clock(AsyncBase):
         Parameters
         ----------
         time : Union[datetime.datetime, float, str]
+            Time to be set.
         """
 
         return mapping.from_maybe_impl(await self._impl_obj.set_system_time(time=time))

--- a/playwright/async_api/_generated.py
+++ b/playwright/async_api/_generated.py
@@ -6694,7 +6694,7 @@ class Clock(AsyncBase):
 
         return mapping.from_maybe_impl(await self._impl_obj.install(time=time))
 
-    async def fast_forward(self, ticks: typing.Union[float, str]) -> None:
+    async def fast_forward(self, ticks: typing.Union[int, str]) -> None:
         """Clock.fast_forward
 
         Advance the clock by jumping forward in time. Only fires due timers at most once. This is equivalent to user
@@ -6709,9 +6709,7 @@ class Clock(AsyncBase):
 
         Parameters
         ----------
-        ticks : Union[float, str]
-            Time may be the number of milliseconds to advance the clock by or a human-readable string. Valid string formats are
-            "08" for eight seconds, "01:00" for one minute and "02:34:10" for two hours, 34 minutes and ten seconds.
+        ticks : Union[int, str]
         """
 
         return mapping.from_maybe_impl(await self._impl_obj.fast_forward(ticks=ticks))
@@ -6748,7 +6746,7 @@ class Clock(AsyncBase):
 
         return mapping.from_maybe_impl(await self._impl_obj.resume())
 
-    async def run_for(self, ticks: typing.Union[float, str]) -> None:
+    async def run_for(self, ticks: typing.Union[int, str]) -> None:
         """Clock.run_for
 
         Advance the clock, firing all the time-related callbacks.
@@ -6762,9 +6760,7 @@ class Clock(AsyncBase):
 
         Parameters
         ----------
-        ticks : Union[float, str]
-            Time may be the number of milliseconds to advance the clock by or a human-readable string. Valid string formats are
-            "08" for eight seconds, "01:00" for one minute and "02:34:10" for two hours, 34 minutes and ten seconds.
+        ticks : Union[int, str]
         """
 
         return mapping.from_maybe_impl(await self._impl_obj.run_for(ticks=ticks))

--- a/playwright/async_api/_generated.py
+++ b/playwright/async_api/_generated.py
@@ -6664,7 +6664,9 @@ mapping.register(SelectorsImpl, Selectors)
 
 class Clock(AsyncBase):
     async def install(
-        self, *, time: typing.Optional[typing.Union[int, str, datetime.datetime]] = None
+        self,
+        *,
+        time: typing.Optional[typing.Union[float, str, datetime.datetime]] = None
     ) -> None:
         """Clock.install
 
@@ -6686,13 +6688,13 @@ class Clock(AsyncBase):
 
         Parameters
         ----------
-        time : Union[datetime.datetime, int, str, None]
+        time : Union[datetime.datetime, float, str, None]
             Time to initialize with, current system time by default.
         """
 
         return mapping.from_maybe_impl(await self._impl_obj.install(time=time))
 
-    async def fast_forward(self, ticks: typing.Union[int, str]) -> None:
+    async def fast_forward(self, ticks: typing.Union[float, str]) -> None:
         """Clock.fast_forward
 
         Advance the clock by jumping forward in time. Only fires due timers at most once. This is equivalent to user
@@ -6707,14 +6709,14 @@ class Clock(AsyncBase):
 
         Parameters
         ----------
-        ticks : Union[int, str]
+        ticks : Union[float, str]
             Time may be the number of milliseconds to advance the clock by or a human-readable string. Valid string formats are
             "08" for eight seconds, "01:00" for one minute and "02:34:10" for two hours, 34 minutes and ten seconds.
         """
 
         return mapping.from_maybe_impl(await self._impl_obj.fast_forward(ticks=ticks))
 
-    async def pause_at(self, time: typing.Union[int, str, datetime.datetime]) -> None:
+    async def pause_at(self, time: typing.Union[float, str, datetime.datetime]) -> None:
         """Clock.pause_at
 
         Advance the clock by jumping forward in time and pause the time. Once this method is called, no timers are fired
@@ -6733,7 +6735,7 @@ class Clock(AsyncBase):
 
         Parameters
         ----------
-        time : Union[datetime.datetime, int, str]
+        time : Union[datetime.datetime, float, str]
         """
 
         return mapping.from_maybe_impl(await self._impl_obj.pause_at(time=time))
@@ -6746,7 +6748,7 @@ class Clock(AsyncBase):
 
         return mapping.from_maybe_impl(await self._impl_obj.resume())
 
-    async def run_for(self, ticks: typing.Union[int, str]) -> None:
+    async def run_for(self, ticks: typing.Union[float, str]) -> None:
         """Clock.run_for
 
         Advance the clock, firing all the time-related callbacks.
@@ -6760,7 +6762,7 @@ class Clock(AsyncBase):
 
         Parameters
         ----------
-        ticks : Union[int, str]
+        ticks : Union[float, str]
             Time may be the number of milliseconds to advance the clock by or a human-readable string. Valid string formats are
             "08" for eight seconds, "01:00" for one minute and "02:34:10" for two hours, 34 minutes and ten seconds.
         """
@@ -6768,7 +6770,7 @@ class Clock(AsyncBase):
         return mapping.from_maybe_impl(await self._impl_obj.run_for(ticks=ticks))
 
     async def set_fixed_time(
-        self, time: typing.Union[int, str, datetime.datetime]
+        self, time: typing.Union[float, str, datetime.datetime]
     ) -> None:
         """Clock.set_fixed_time
 
@@ -6784,14 +6786,14 @@ class Clock(AsyncBase):
 
         Parameters
         ----------
-        time : Union[datetime.datetime, int, str]
+        time : Union[datetime.datetime, float, str]
             Time to be set.
         """
 
         return mapping.from_maybe_impl(await self._impl_obj.set_fixed_time(time=time))
 
     async def set_system_time(
-        self, time: typing.Union[int, str, datetime.datetime]
+        self, time: typing.Union[float, str, datetime.datetime]
     ) -> None:
         """Clock.set_system_time
 
@@ -6807,7 +6809,7 @@ class Clock(AsyncBase):
 
         Parameters
         ----------
-        time : Union[datetime.datetime, int, str]
+        time : Union[datetime.datetime, float, str]
         """
 
         return mapping.from_maybe_impl(await self._impl_obj.set_system_time(time=time))
@@ -8662,22 +8664,6 @@ class Page(AsyncContextManager):
         asyncio.run(main())
         ```
 
-        An example of passing an element handle:
-
-        ```py
-        async def print(source, element):
-            print(await element.text_content())
-
-        await page.expose_binding(\"clicked\", print, handle=true)
-        await page.set_content(\"\"\"
-          <script>
-            document.addEventListener('click', event => window.clicked(event.target));
-          </script>
-          <div>Click me</div>
-          <div>Or click me</div>
-        \"\"\")
-        ```
-
         Parameters
         ----------
         name : str
@@ -8687,6 +8673,7 @@ class Page(AsyncContextManager):
         handle : Union[bool, None]
             Whether to pass the argument as a handle, instead of passing by value. When passing a handle, only one argument is
             supported. When passing by value, multiple arguments are supported.
+            Deprecated: This option will be removed in the future.
         """
 
         return mapping.from_maybe_impl(
@@ -12849,22 +12836,6 @@ class BrowserContext(AsyncContextManager):
         asyncio.run(main())
         ```
 
-        An example of passing an element handle:
-
-        ```py
-        async def print(source, element):
-            print(await element.text_content())
-
-        await context.expose_binding(\"clicked\", print, handle=true)
-        await page.set_content(\"\"\"
-          <script>
-            document.addEventListener('click', event => window.clicked(event.target));
-          </script>
-          <div>Click me</div>
-          <div>Or click me</div>
-        \"\"\")
-        ```
-
         Parameters
         ----------
         name : str
@@ -12874,6 +12845,7 @@ class BrowserContext(AsyncContextManager):
         handle : Union[bool, None]
             Whether to pass the argument as a handle, instead of passing by value. When passing a handle, only one argument is
             supported. When passing by value, multiple arguments are supported.
+            Deprecated: This option will be removed in the future.
         """
 
         return mapping.from_maybe_impl(

--- a/playwright/sync_api/_generated.py
+++ b/playwright/sync_api/_generated.py
@@ -6804,7 +6804,7 @@ class Clock(SyncBase):
 
         return mapping.from_maybe_impl(self._sync(self._impl_obj.install(time=time)))
 
-    def fast_forward(self, ticks: typing.Union[float, str]) -> None:
+    def fast_forward(self, ticks: typing.Union[int, str]) -> None:
         """Clock.fast_forward
 
         Advance the clock by jumping forward in time. Only fires due timers at most once. This is equivalent to user
@@ -6819,9 +6819,7 @@ class Clock(SyncBase):
 
         Parameters
         ----------
-        ticks : Union[float, str]
-            Time may be the number of milliseconds to advance the clock by or a human-readable string. Valid string formats are
-            "08" for eight seconds, "01:00" for one minute and "02:34:10" for two hours, 34 minutes and ten seconds.
+        ticks : Union[int, str]
         """
 
         return mapping.from_maybe_impl(
@@ -6860,7 +6858,7 @@ class Clock(SyncBase):
 
         return mapping.from_maybe_impl(self._sync(self._impl_obj.resume()))
 
-    def run_for(self, ticks: typing.Union[float, str]) -> None:
+    def run_for(self, ticks: typing.Union[int, str]) -> None:
         """Clock.run_for
 
         Advance the clock, firing all the time-related callbacks.
@@ -6874,9 +6872,7 @@ class Clock(SyncBase):
 
         Parameters
         ----------
-        ticks : Union[float, str]
-            Time may be the number of milliseconds to advance the clock by or a human-readable string. Valid string formats are
-            "08" for eight seconds, "01:00" for one minute and "02:34:10" for two hours, 34 minutes and ten seconds.
+        ticks : Union[int, str]
         """
 
         return mapping.from_maybe_impl(self._sync(self._impl_obj.run_for(ticks=ticks)))

--- a/playwright/sync_api/_generated.py
+++ b/playwright/sync_api/_generated.py
@@ -6774,7 +6774,9 @@ mapping.register(SelectorsImpl, Selectors)
 
 class Clock(SyncBase):
     def install(
-        self, *, time: typing.Optional[typing.Union[int, str, datetime.datetime]] = None
+        self,
+        *,
+        time: typing.Optional[typing.Union[float, str, datetime.datetime]] = None
     ) -> None:
         """Clock.install
 
@@ -6796,13 +6798,13 @@ class Clock(SyncBase):
 
         Parameters
         ----------
-        time : Union[datetime.datetime, int, str, None]
+        time : Union[datetime.datetime, float, str, None]
             Time to initialize with, current system time by default.
         """
 
         return mapping.from_maybe_impl(self._sync(self._impl_obj.install(time=time)))
 
-    def fast_forward(self, ticks: typing.Union[int, str]) -> None:
+    def fast_forward(self, ticks: typing.Union[float, str]) -> None:
         """Clock.fast_forward
 
         Advance the clock by jumping forward in time. Only fires due timers at most once. This is equivalent to user
@@ -6817,7 +6819,7 @@ class Clock(SyncBase):
 
         Parameters
         ----------
-        ticks : Union[int, str]
+        ticks : Union[float, str]
             Time may be the number of milliseconds to advance the clock by or a human-readable string. Valid string formats are
             "08" for eight seconds, "01:00" for one minute and "02:34:10" for two hours, 34 minutes and ten seconds.
         """
@@ -6826,7 +6828,7 @@ class Clock(SyncBase):
             self._sync(self._impl_obj.fast_forward(ticks=ticks))
         )
 
-    def pause_at(self, time: typing.Union[int, str, datetime.datetime]) -> None:
+    def pause_at(self, time: typing.Union[float, str, datetime.datetime]) -> None:
         """Clock.pause_at
 
         Advance the clock by jumping forward in time and pause the time. Once this method is called, no timers are fired
@@ -6845,7 +6847,7 @@ class Clock(SyncBase):
 
         Parameters
         ----------
-        time : Union[datetime.datetime, int, str]
+        time : Union[datetime.datetime, float, str]
         """
 
         return mapping.from_maybe_impl(self._sync(self._impl_obj.pause_at(time=time)))
@@ -6858,7 +6860,7 @@ class Clock(SyncBase):
 
         return mapping.from_maybe_impl(self._sync(self._impl_obj.resume()))
 
-    def run_for(self, ticks: typing.Union[int, str]) -> None:
+    def run_for(self, ticks: typing.Union[float, str]) -> None:
         """Clock.run_for
 
         Advance the clock, firing all the time-related callbacks.
@@ -6872,14 +6874,14 @@ class Clock(SyncBase):
 
         Parameters
         ----------
-        ticks : Union[int, str]
+        ticks : Union[float, str]
             Time may be the number of milliseconds to advance the clock by or a human-readable string. Valid string formats are
             "08" for eight seconds, "01:00" for one minute and "02:34:10" for two hours, 34 minutes and ten seconds.
         """
 
         return mapping.from_maybe_impl(self._sync(self._impl_obj.run_for(ticks=ticks)))
 
-    def set_fixed_time(self, time: typing.Union[int, str, datetime.datetime]) -> None:
+    def set_fixed_time(self, time: typing.Union[float, str, datetime.datetime]) -> None:
         """Clock.set_fixed_time
 
         Makes `Date.now` and `new Date()` return fixed fake time at all times, keeps all the timers running.
@@ -6894,7 +6896,7 @@ class Clock(SyncBase):
 
         Parameters
         ----------
-        time : Union[datetime.datetime, int, str]
+        time : Union[datetime.datetime, float, str]
             Time to be set.
         """
 
@@ -6902,7 +6904,9 @@ class Clock(SyncBase):
             self._sync(self._impl_obj.set_fixed_time(time=time))
         )
 
-    def set_system_time(self, time: typing.Union[int, str, datetime.datetime]) -> None:
+    def set_system_time(
+        self, time: typing.Union[float, str, datetime.datetime]
+    ) -> None:
         """Clock.set_system_time
 
         Sets current system time but does not trigger any timers.
@@ -6917,7 +6921,7 @@ class Clock(SyncBase):
 
         Parameters
         ----------
-        time : Union[datetime.datetime, int, str]
+        time : Union[datetime.datetime, float, str]
         """
 
         return mapping.from_maybe_impl(
@@ -8689,22 +8693,6 @@ class Page(SyncContextManager):
             run(playwright)
         ```
 
-        An example of passing an element handle:
-
-        ```py
-        def print(source, element):
-            print(element.text_content())
-
-        page.expose_binding(\"clicked\", print, handle=true)
-        page.set_content(\"\"\"
-          <script>
-            document.addEventListener('click', event => window.clicked(event.target));
-          </script>
-          <div>Click me</div>
-          <div>Or click me</div>
-        \"\"\")
-        ```
-
         Parameters
         ----------
         name : str
@@ -8714,6 +8702,7 @@ class Page(SyncContextManager):
         handle : Union[bool, None]
             Whether to pass the argument as a handle, instead of passing by value. When passing a handle, only one argument is
             supported. When passing by value, multiple arguments are supported.
+            Deprecated: This option will be removed in the future.
         """
 
         return mapping.from_maybe_impl(
@@ -12871,22 +12860,6 @@ class BrowserContext(SyncContextManager):
             run(playwright)
         ```
 
-        An example of passing an element handle:
-
-        ```py
-        def print(source, element):
-            print(element.text_content())
-
-        context.expose_binding(\"clicked\", print, handle=true)
-        page.set_content(\"\"\"
-          <script>
-            document.addEventListener('click', event => window.clicked(event.target));
-          </script>
-          <div>Click me</div>
-          <div>Or click me</div>
-        \"\"\")
-        ```
-
         Parameters
         ----------
         name : str
@@ -12896,6 +12869,7 @@ class BrowserContext(SyncContextManager):
         handle : Union[bool, None]
             Whether to pass the argument as a handle, instead of passing by value. When passing a handle, only one argument is
             supported. When passing by value, multiple arguments are supported.
+            Deprecated: This option will be removed in the future.
         """
 
         return mapping.from_maybe_impl(

--- a/playwright/sync_api/_generated.py
+++ b/playwright/sync_api/_generated.py
@@ -6820,6 +6820,8 @@ class Clock(SyncBase):
         Parameters
         ----------
         ticks : Union[int, str]
+            Time may be the number of milliseconds to advance the clock by or a human-readable string. Valid string formats are
+            "08" for eight seconds, "01:00" for one minute and "02:34:10" for two hours, 34 minutes and ten seconds.
         """
 
         return mapping.from_maybe_impl(
@@ -6846,6 +6848,7 @@ class Clock(SyncBase):
         Parameters
         ----------
         time : Union[datetime.datetime, float, str]
+            Time to pause at.
         """
 
         return mapping.from_maybe_impl(self._sync(self._impl_obj.pause_at(time=time)))
@@ -6873,6 +6876,8 @@ class Clock(SyncBase):
         Parameters
         ----------
         ticks : Union[int, str]
+            Time may be the number of milliseconds to advance the clock by or a human-readable string. Valid string formats are
+            "08" for eight seconds, "01:00" for one minute and "02:34:10" for two hours, 34 minutes and ten seconds.
         """
 
         return mapping.from_maybe_impl(self._sync(self._impl_obj.run_for(ticks=ticks)))
@@ -6918,6 +6923,7 @@ class Clock(SyncBase):
         Parameters
         ----------
         time : Union[datetime.datetime, float, str]
+            Time to be set.
         """
 
         return mapping.from_maybe_impl(

--- a/scripts/documentation_provider.py
+++ b/scripts/documentation_provider.py
@@ -481,6 +481,8 @@ class DocumentationProvider:
             return f"{{{', '.join(items)}}}"
         if type_name == "boolean":
             return "bool"
+        if type_name == "long":
+            return "int"
         if type_name.lower() == "string":
             return "str"
         if type_name == "any" or type_name == "Serializable":

--- a/scripts/documentation_provider.py
+++ b/scripts/documentation_provider.py
@@ -483,8 +483,6 @@ class DocumentationProvider:
             return "bool"
         if type_name.lower() == "string":
             return "str"
-        if type_name.lower() == "long":
-            return "float"
         if type_name == "any" or type_name == "Serializable":
             return "Any"
         if type_name == "Object":

--- a/scripts/documentation_provider.py
+++ b/scripts/documentation_provider.py
@@ -483,6 +483,8 @@ class DocumentationProvider:
             return "bool"
         if type_name.lower() == "string":
             return "str"
+        if type_name.lower() == "long":
+            return "float"
         if type_name == "any" or type_name == "Serializable":
             return "Any"
         if type_name == "Object":

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ except ImportError:
     InWheel = None
 from wheel.bdist_wheel import bdist_wheel as BDistWheelCommand
 
-driver_version = "1.45.0-alpha-2024-06-14"
+driver_version = "1.45.0-beta-1719505820000"
 
 
 def extractall(zip: zipfile.ZipFile, path: str) -> None:

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ except ImportError:
     InWheel = None
 from wheel.bdist_wheel import bdist_wheel as BDistWheelCommand
 
-driver_version = "1.45.0-beta-1719505820000"
+driver_version = "1.45.1-beta-1719996498000"
 
 
 def extractall(zip: zipfile.ZipFile, path: str) -> None:

--- a/tests/async/test_page_clock.py
+++ b/tests/async/test_page_clock.py
@@ -282,10 +282,10 @@ class TestPopup:
             page.wait_for_event("popup"), page.evaluate("window.open('about:blank')")
         )
         popup_time = await popup.evaluate("Date.now()")
-        assert popup_time == now.timestamp()
+        assert popup_time == now.timestamp() * 1000
         await page.clock.run_for(1000)
         popup_time_after = await popup.evaluate("Date.now()")
-        assert popup_time_after == now.timestamp() + 1000
+        assert popup_time_after == now.timestamp() * 1000 + 1000
 
     async def test_should_tick_before_popup(self, page: Page) -> None:
         await page.clock.install(time=0)
@@ -296,7 +296,8 @@ class TestPopup:
             page.wait_for_event("popup"), page.evaluate("window.open('about:blank')")
         )
         popup_time = await popup.evaluate("Date.now()")
-        assert popup_time == int(now.timestamp() + 1000)
+        assert popup_time == int(now.timestamp() * 1000 + 1000)
+        assert datetime.datetime.fromtimestamp(popup_time / 1_000).year == 2015
 
     async def test_should_run_time_before_popup(
         self, page: Page, server: Server

--- a/tests/async/test_page_clock.py
+++ b/tests/async/test_page_clock.py
@@ -151,7 +151,7 @@ class TestFastForward:
     @pytest.fixture(autouse=True)
     async def before_each(self, page: Page) -> AsyncGenerator[None, None]:
         await page.clock.install(time=0)
-        await page.clock.pause_at(1000)
+        await page.clock.pause_at(1)
         yield
 
     async def test_ignores_timers_which_wouldnt_be_run(
@@ -184,11 +184,11 @@ class TestStubTimers:
     @pytest.fixture(autouse=True)
     async def before_each(self, page: Page) -> AsyncGenerator[None, None]:
         await page.clock.install(time=0)
-        await page.clock.pause_at(1000)
+        await page.clock.pause_at(1)
         yield
 
     async def test_sets_initial_timestamp(self, page: Page) -> None:
-        await page.clock.set_system_time(1400)
+        await page.clock.set_system_time(1.4)
         assert await page.evaluate("Date.now()") == 1400
 
     async def test_replaces_global_setTimeout(
@@ -255,8 +255,8 @@ class TestStubTimers:
 
 class TestStubTimersPerformance:
     async def test_replaces_global_performance_time_origin(self, page: Page) -> None:
-        await page.clock.install(time=1000)
-        await page.clock.pause_at(2000)
+        await page.clock.install(time=1)
+        await page.clock.pause_at(2)
         promise = asyncio.create_task(
             page.evaluate(
                 """async () => {
@@ -332,7 +332,7 @@ class TestPopup:
             ),
         )
         await page.clock.install(time=0)
-        await page.clock.pause_at(1000)
+        await page.clock.pause_at(1)
         await page.goto(server.EMPTY_PAGE)
         # Wait for 2 second in real life to check that it is past in popup.
         await page.wait_for_timeout(2000)
@@ -351,15 +351,15 @@ class TestSetFixedTime:
         await page.evaluate("new Promise(f => setTimeout(f, 1))")
 
     async def test_allows_setting_time_multiple_times(self, page: Page) -> None:
-        await page.clock.set_fixed_time(100)
+        await page.clock.set_fixed_time(0.1)
         assert await page.evaluate("Date.now()") == 100
-        await page.clock.set_fixed_time(200)
+        await page.clock.set_fixed_time(0.2)
         assert await page.evaluate("Date.now()") == 200
 
     async def test_fixed_time_is_not_affected_by_clock_manipulation(
         self, page: Page
     ) -> None:
-        await page.clock.set_fixed_time(100)
+        await page.clock.set_fixed_time(0.1)
         assert await page.evaluate("Date.now()") == 100
         await page.clock.fast_forward(20)
         assert await page.evaluate("Date.now()") == 100
@@ -367,9 +367,9 @@ class TestSetFixedTime:
     async def test_allows_installing_fake_timers_after_setting_time(
         self, page: Page, calls: List[Any]
     ) -> None:
-        await page.clock.set_fixed_time(100)
+        await page.clock.set_fixed_time(0.1)
         assert await page.evaluate("Date.now()") == 100
-        await page.clock.set_fixed_time(200)
+        await page.clock.set_fixed_time(0.2)
         await page.evaluate("setTimeout(() => window.stub(Date.now()))")
         await page.clock.run_for(0)
         assert calls == [[200]]
@@ -407,7 +407,7 @@ class TestWhileRunning:
     async def test_should_pause(self, page: Page) -> None:
         await page.clock.install(time=0)
         await page.goto("data:text/html,")
-        await page.clock.pause_at(1000)
+        await page.clock.pause_at(1)
         await page.wait_for_timeout(1000)
         await page.clock.resume()
         now = await page.evaluate("Date.now()")
@@ -416,7 +416,7 @@ class TestWhileRunning:
     async def test_should_pause_and_fast_forward(self, page: Page) -> None:
         await page.clock.install(time=0)
         await page.goto("data:text/html,")
-        await page.clock.pause_at(1000)
+        await page.clock.pause_at(1)
         await page.clock.fast_forward(1000)
         now = await page.evaluate("Date.now()")
         assert now == 2000
@@ -424,7 +424,7 @@ class TestWhileRunning:
     async def test_should_set_system_time_on_pause(self, page: Page) -> None:
         await page.clock.install(time=0)
         await page.goto("data:text/html,")
-        await page.clock.pause_at(1000)
+        await page.clock.pause_at(1)
         now = await page.evaluate("Date.now()")
         assert now == 1000
 

--- a/tests/sync/test_page_clock.py
+++ b/tests/sync/test_page_clock.py
@@ -146,7 +146,7 @@ class TestFastForward:
     @pytest.fixture(autouse=True)
     def before_each(self, page: Page) -> Generator[None, None, None]:
         page.clock.install(time=0)
-        page.clock.pause_at(1000)
+        page.clock.pause_at(1)
         yield
 
     def test_ignores_timers_which_wouldnt_be_run(
@@ -177,11 +177,11 @@ class TestStubTimers:
     @pytest.fixture(autouse=True)
     def before_each(self, page: Page) -> Generator[None, None, None]:
         page.clock.install(time=0)
-        page.clock.pause_at(1000)
+        page.clock.pause_at(1)
         yield
 
     def test_sets_initial_timestamp(self, page: Page) -> None:
-        page.clock.set_system_time(1400)
+        page.clock.set_system_time(1.4)
         assert page.evaluate("Date.now()") == 1400
 
     def test_replaces_global_setTimeout(self, page: Page, calls: List[Any]) -> None:
@@ -239,8 +239,8 @@ class TestStubTimers:
 
 class TestStubTimersPerformance:
     def test_replaces_global_performance_time_origin(self, page: Page) -> None:
-        page.clock.install(time=1000)
-        page.clock.pause_at(2000)
+        page.clock.install(time=1)
+        page.clock.pause_at(2)
         page.evaluate(
             """() => {
             window.waitForPromise = new Promise(async resolve => {
@@ -312,7 +312,7 @@ class TestPopup:
             ),
         )
         page.clock.install(time=0)
-        page.clock.pause_at(1000)
+        page.clock.pause_at(1)
         page.goto(server.EMPTY_PAGE)
         # Wait for 2 second in real life to check that it is past in popup.
         page.wait_for_timeout(2000)
@@ -325,10 +325,10 @@ class TestPopup:
 
 class TestSetFixedTime:
     def test_allows_passing_as_int(self, page: Page) -> None:
-        page.clock.set_fixed_time(100)
-        assert page.evaluate("Date.now()") == 100
-        page.clock.set_fixed_time(int(200))
-        assert page.evaluate("Date.now()") == 200
+        page.clock.set_fixed_time(1)
+        assert page.evaluate("Date.now()") == 1000
+        page.clock.set_fixed_time(int(2))
+        assert page.evaluate("Date.now()") == 2000
 
     def test_does_not_fake_methods(self, page: Page) -> None:
         page.clock.set_fixed_time(0)
@@ -336,13 +336,13 @@ class TestSetFixedTime:
         page.evaluate("new Promise(f => setTimeout(f, 1))")
 
     def test_allows_setting_time_multiple_times(self, page: Page) -> None:
-        page.clock.set_fixed_time(100)
+        page.clock.set_fixed_time(0.1)
         assert page.evaluate("Date.now()") == 100
-        page.clock.set_fixed_time(200)
+        page.clock.set_fixed_time(0.2)
         assert page.evaluate("Date.now()") == 200
 
     def test_fixed_time_is_not_affected_by_clock_manipulation(self, page: Page) -> None:
-        page.clock.set_fixed_time(100)
+        page.clock.set_fixed_time(0.1)
         assert page.evaluate("Date.now()") == 100
         page.clock.fast_forward(20)
         assert page.evaluate("Date.now()") == 100
@@ -350,9 +350,9 @@ class TestSetFixedTime:
     def test_allows_installing_fake_timers_after_setting_time(
         self, page: Page, calls: List[Any]
     ) -> None:
-        page.clock.set_fixed_time(100)
+        page.clock.set_fixed_time(0.1)
         assert page.evaluate("Date.now()") == 100
-        page.clock.set_fixed_time(200)
+        page.clock.set_fixed_time(0.2)
         page.evaluate("setTimeout(() => window.stub(Date.now()))")
         page.clock.run_for(0)
         assert calls == [[200]]
@@ -390,7 +390,7 @@ class TestWhileRunning:
     def test_should_pause(self, page: Page) -> None:
         page.clock.install(time=0)
         page.goto("data:text/html,")
-        page.clock.pause_at(1000)
+        page.clock.pause_at(1)
         page.wait_for_timeout(1000)
         page.clock.resume()
         now = page.evaluate("Date.now()")
@@ -399,7 +399,7 @@ class TestWhileRunning:
     def test_should_pause_and_fast_forward(self, page: Page) -> None:
         page.clock.install(time=0)
         page.goto("data:text/html,")
-        page.clock.pause_at(1000)
+        page.clock.pause_at(1)
         page.clock.fast_forward(1000)
         now = page.evaluate("Date.now()")
         assert now == 2000
@@ -407,7 +407,7 @@ class TestWhileRunning:
     def test_should_set_system_time_on_pause(self, page: Page) -> None:
         page.clock.install(time=0)
         page.goto("data:text/html,")
-        page.clock.pause_at(1000)
+        page.clock.pause_at(1)
         now = page.evaluate("Date.now()")
         assert now == 1000
 

--- a/tests/sync/test_page_clock.py
+++ b/tests/sync/test_page_clock.py
@@ -265,10 +265,10 @@ class TestPopup:
             page.evaluate("window.open('about:blank')")
         popup = popup_info.value
         popup_time = popup.evaluate("Date.now()")
-        assert popup_time == now.timestamp()
+        assert popup_time == now.timestamp() * 1000
         page.clock.run_for(1000)
         popup_time_after = popup.evaluate("Date.now()")
-        assert popup_time_after == now.timestamp() + 1000
+        assert popup_time_after == now.timestamp() * 1000 + 1000
 
     def test_should_tick_before_popup(self, page: Page) -> None:
         page.clock.install(time=0)
@@ -279,7 +279,8 @@ class TestPopup:
             page.evaluate("window.open('about:blank')")
         popup = popup_info.value
         popup_time = popup.evaluate("Date.now()")
-        assert popup_time == int(now.timestamp() + 1000)
+        assert popup_time == int(now.timestamp() * 1_000 + 1000)
+        assert datetime.datetime.fromtimestamp(popup_time / 1_000).year == 2015
 
     def test_should_run_time_before_popup(self, page: Page, server: Server) -> None:
         server.set_route(
@@ -323,6 +324,12 @@ class TestPopup:
 
 
 class TestSetFixedTime:
+    def test_allows_passing_as_int(self, page: Page) -> None:
+        page.clock.set_fixed_time(100)
+        assert page.evaluate("Date.now()") == 100
+        page.clock.set_fixed_time(int(200))
+        assert page.evaluate("Date.now()") == 200
+
     def test_does_not_fake_methods(self, page: Page) -> None:
         page.clock.set_fixed_time(0)
         # Should not stall.


### PR DESCRIPTION
`fromtimestamp` and `timestamp()` both return float's - so choosing a float seems more reasonable here.