### PR TITLE
chore: Fix broke CI configuration link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ pre-commit install
 pre-commit run --all-files
 ```
 
-For more details look at the [CI configuration](./blob/main/.github/workflows/ci.yml).
+For more details look at the [CI configuration](./.github/workflows/ci.yml).
 
 Collect coverage
 


### PR DESCRIPTION
The link in the below line

For more details look at the [CI configuration](https://github.com/microsoft/playwright-python/blob/main/blob/main/.github/workflows/ci.yml).

is incorrect since it has repeated /blob/main/ in its url. 

I have removed the repeated '/blob/main' so that the link has the right URL.

For more details look at the [CI configuration](https://github.com/microsoft/playwright-python/blob/main/.github/workflows/ci.yml).