### PR TITLE
chore: drop Python 3.8

### DIFF
--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -33,7 +33,7 @@ extends:
         steps:
         - task: UsePythonVersion@0
           inputs:
-            versionSpec: '3.8'
+            versionSpec: '3.9'
           displayName: 'Use Python'
         - script: |
             python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,18 +47,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9']
+        python-version: ['3.9', '3.10']
         browser: [chromium, firefox, webkit]
         include:
-        - os: ubuntu-latest
-          python-version: '3.10'
-          browser: chromium
-        - os: windows-latest
-          python-version: '3.10'
-          browser: chromium
-        - os: macos-latest
-          python-version: '3.10'
-          browser: chromium
         - os: windows-latest
           python-version: '3.11'
           browser: chromium

--- a/meta.yaml
+++ b/meta.yaml
@@ -15,17 +15,17 @@ build:
 
 requirements:
   build:
-    - python >=3.8                        # [build_platform != target_platform]
+    - python >=3.9                        # [build_platform != target_platform]
     - pip                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}  # [build_platform != target_platform]
   host:
-    - python >=3.8
+    - python >=3.9
     - wheel
     - pip
     - curl
     - setuptools_scm
   run:
-    - python >=3.8
+    - python >=3.9
     - greenlet ==3.1.1
     - pyee ==12.0.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ asyncio_mode = "auto"
 
 [tool.mypy]
 ignore_missing_imports = true
-python_version = "3.8"
+python_version = "3.9"
 warn_unused_ignores = false
 warn_redundant_casts = true
 warn_unused_configs = true
@@ -36,7 +36,7 @@ profile = "black"
 [tool.pyright]
 include = ["playwright", "tests", "scripts"]
 exclude = ["**/node_modules", "**/__pycache__", "**/.*", "./build"]
-pythonVersion = "3.8"
+pythonVersion = "3.9"
 reportMissingImports = false
 reportTypedDictNotRequiredAccess = false
 reportCallInDefaultInitializer = true

--- a/setup.py
+++ b/setup.py
@@ -228,7 +228,6 @@ setup(
         "Topic :: Internet :: WWW/HTTP :: Browsers",
         "Intended Audience :: Developers",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
@@ -237,7 +236,7 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     cmdclass={"bdist_wheel": PlaywrightBDistWheelCommand},
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Python 3.8 is EOL since this month and a bunch of our dependencies dropped support for it as well, so we can't stay on their recent versions.