### PR TITLE
devops: do not pin conda-build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,8 +33,7 @@ jobs:
           channels: conda-forge
           miniconda-version: latest
       - name: Prepare
-        # Pinned because of https://github.com/conda/conda-build/issues/5267
-        run: conda install anaconda-client conda-build=24.1.2 conda-verify py-lief=0.12.3
+        run: conda install anaconda-client conda-build conda-verify
       - name: Build and Upload
         env:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}


### PR DESCRIPTION
Removing since https://github.com/conda/conda-build/issues/5267 is fixed.

Lets see what else is needed to fix https://github.com/microsoft/playwright-python/actions/runs/11441512009/workflow.