### PR TITLE
devops: do not pin pytest-playwright for examples

### DIFF
--- a/examples/todomvc/requirements.txt
+++ b/examples/todomvc/requirements.txt
@@ -1,1 +1,1 @@
-pytest-playwright==0.3.0
+pytest-playwright


### PR DESCRIPTION
It should use ToT instead of an old pinned version.