### PR TITLE
devops: make wheels smaller (use deflate zip compression)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,9 @@ class PlaywrightBDistWheelCommand(BDistWheelCommand):
             extractall(zip, f"driver/{wheel_bundle['zip_name']}")
         wheel_location = without_platform + wheel_bundle["wheel"]
         shutil.copy(base_wheel_location, wheel_location)
-        with zipfile.ZipFile(wheel_location, "a") as zip:
+        with zipfile.ZipFile(
+            wheel_location, mode="a", compression=zipfile.ZIP_DEFLATED
+        ) as zip:
             driver_root = os.path.abspath(f"driver/{wheel_bundle['zip_name']}")
             for dir_path, _, files in os.walk(driver_root):
                 for file in files:


### PR DESCRIPTION
Since https://github.com/microsoft/playwright-python/commit/4fd5de05438f31990d4612c1dd9252da86e34155 the produced wheels contained the source as `deflate` and the driver as `store` compressed files. This resulted in a very large wheel file which wasn't accepted by Pypi.

This uses deflated everywhere.