### PR TITLE
Fix build process producing wheels with incorrect RECORD

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -165,13 +165,12 @@ class PlaywrightBDistWheelCommand(BDistWheelCommand):
         for whlfile in glob.glob(os.path.join(self.dist_dir, "*.whl")):
             os.makedirs("wheelhouse", exist_ok=True)
             if InWheel:
-                with InWheel(
-                    in_wheel=whlfile,
-                    out_wheel=os.path.join("wheelhouse", os.path.basename(whlfile)),
-                ):
+                wheelhouse_whl = os.path.join("wheelhouse", os.path.basename(whlfile))
+                shutil.move(whlfile, wheelhouse_whl)
+                with InWheel(in_wheel=wheelhouse_whl, out_wheel=whlfile):
                     print(f"Updating RECORD file of {whlfile}")
         print("Copying new wheels")
-        shutil.move("wheelhouse", self.dist_dir)
+        shutil.rmtree("wheelhouse")
 
     def _download_and_extract_local_driver(
         self,


### PR DESCRIPTION
## Problem
`shutil.move("wheelhouse", self.dist_dir)` nests `wheelhouse` directory itself inside of `dist/.tmp-XXX` instead of moving its contents there.
That results in wheel with incorrect `RECORD` contents to end up in `dist` folder, which is then published.

## Solution
Move wheel with drivers and incorrect `RECORD` to `wheelhouse` and make `auditwheel` to put corrected wheel to `dist/.tmp-XXX`.
Then remove `wheelhouse` folder.

## Build process snapshots
Below are snapshots of dist and wheelhouse folder contents for comparison.

Note: hashes were shrunk and some output removed for readability sake

### Old setup.py
```
@@@ before-auditwheel
d79a094  ./dist/.tmp-bz7ar00j/playwright-1.49.1.dev2+g3f04396.d20241126-py3-none-manylinux1_x86_64.whl

@@@ after-auditwheel
ee22f99  ./wheelhouse/playwright-1.49.1.dev2+g3f04396.d20241126-py3-none-manylinux1_x86_64.whl
d79a094  ./dist/.tmp-bz7ar00j/playwright-1.49.1.dev2+g3f04396.d20241126-py3-none-manylinux1_x86_64.whl

@@@ before-end
ee22f99  ./dist/.tmp-bz7ar00j/wheelhouse/playwright-1.49.1.dev2+g3f04396.d20241126-py3-none-manylinux1_x86_64.whl
d79a094  ./dist/.tmp-bz7ar00j/playwright-1.49.1.dev2+g3f04396.d20241126-py3-none-manylinux1_x86_64.whl
```

When python -mbuild --wheel finished:

```
$ find ./dist -type f -exec sha256sum {} \;
d79a094  ./dist/playwright-1.49.1.dev2+g3f04396.d20241126-py3-none-manylinux1_x86_64.whl
```

### New setup.py
```
@@@ before-auditwheel
e593879  ./dist/.tmp-7np0n0up/playwright-1.49.1.dev2+g3f04396.d20241127-py3-none-manylinux1_x86_64.whl

@@@ after-auditwheel
72899a7  ./dist/.tmp-7np0n0up/playwright-1.49.1.dev2+g3f04396.d20241127-py3-none-manylinux1_x86_64.whl
e593879  ./wheelhouse/playwright-1.49.1.dev2+g3f04396.d20241127-py3-none-manylinux1_x86_64.whl

@@@ before-end
72899a7  ./dist/.tmp-7np0n0up/playwright-1.49.1.dev2+g3f04396.d20241127-py3-none-manylinux1_x86_64.whl
```

When python -mbuild --wheel finished:
```
$ find ./dist -type f -exec sha256sum {} \;
72899a7  ./dist/playwright-1.49.1.dev2+g3f04396.d20241127-py3-none-manylinux1_x86_64.whl
```

### Instrumented code
```py
        def snapshot_fs(label, *dirs):
            print('@@@', label)
            lines = subprocess.check_output(['find', *dirs, '-type', 'f', '-exec', 'sha256sum', '{}', ';'], encoding='utf-8')
            print(*sorted(lines.splitlines(False)), sep='\n')
            print()
        
        snapshot_fs('before-auditwheel', './dist')
        for whlfile in glob.glob(os.path.join(self.dist_dir, "*.whl")):
            os.makedirs("wheelhouse", exist_ok=True)
            if InWheel:
                wheel_house_whl = os.path.join("wheelhouse", os.path.basename(whlfile))
                shutil.move(whlfile, wheel_house_whl)
                with InWheel(in_wheel=wheel_house_whl, out_wheel=whlfile):
                # with InWheel(
                #     in_wheel=whlfile,
                #     out_wheel=os.path.join("wheelhouse", os.path.basename(whlfile)),
                # ):
                    print(f"Updating RECORD file of {whlfile}")
        print("Copying new wheels")
        snapshot_fs('after-auditwheel', './dist', './wheelhouse')
        # shutil.move("wheelhouse", self.dist_dir)
        shutil.rmtree("wheelhouse")
        snapshot_fs('before-end', './dist')
```