### PR TITLE
fix(assertions): allow tuple as valid input type for expected text values

### DIFF
--- a/playwright/_impl/_assertions.py
+++ b/playwright/_impl/_assertions.py
@@ -874,7 +874,7 @@ def to_expected_text_values(
     ignoreCase: Optional[bool] = None,
 ) -> Sequence[ExpectedTextValue]:
     out: List[ExpectedTextValue] = []
-    assert isinstance(items, list)
+    assert isinstance(items, (list, tuple))
     for item in items:
         if isinstance(item, str):
             o = ExpectedTextValue(

--- a/tests/async/test_assertions.py
+++ b/tests/async/test_assertions.py
@@ -274,6 +274,10 @@ async def test_assertions_locator_to_have_text(page: Page, server: Server) -> No
     await expect(page.locator("div")).to_have_text(
         ["Text  1", re.compile(r"Text   \d+a")]
     )
+    # Should work with a tuple
+    await expect(page.locator("div")).to_have_text(
+        ("Text  1", re.compile(r"Text   \d+a"))
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-python/issues/2722