### PR TITLE
devops: add noarch support to meta.yaml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,8 +169,9 @@ jobs:
       - name: Get conda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: 3.9
+          python-version: 3.12
           channels: conda-forge
+          miniconda-version: latest
       - name: Prepare
         run: conda install conda-build conda-verify
       - name: Build

--- a/meta.yaml
+++ b/meta.yaml
@@ -6,6 +6,7 @@ source:
   path: .
 
 build:
+  noarch: python
   number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
   binary_relocation: False


### PR DESCRIPTION
This PR modifies our conda package configuration to use `noarch: python` in our meta.yaml. This change will help us distribute a single package that works across all Python versions (>=3.9 as specified in our requirements) instead of creating separate packages for each Python version.

Key changes:
- Added `noarch: python` to meta.yaml build configuration 
- Updated CI workflow to use Python 3.12 for building (the build Python version becomes less relevant with noarch. Align it tho between out test and publish workflows)
- Added explicit miniconda-version: latest to ensure consistent builds (align between test/publish workflows)

Background:
Previously, our conda packages were being built specifically for each Python version (e.g., py39, py312, py313), which made distribution and maintenance more complex. By switching to `noarch: python`, we rely on the Python version requirements specified in meta.yaml (python >=3.9) to handle compatibility, while producing a single package that works across all supported Python versions.

Fixes https://github.com/microsoft/playwright-python/issues/2740