### PR TITLE
Implement soft assertions

### DIFF
--- a/playwright/_impl/_assertions.py
+++ b/playwright/_impl/_assertions.py
@@ -1111,14 +1111,13 @@ class SoftAssertionContextManager(Generic[E]):
         __tracebackhide__ = True
 
         if self._context.has_failures():
-            if exc_type is not None:
+            if exc_type is not None and exc_val is not None:
                 failure_message = (
                     f"{str(exc_val)}"
                     f"\n\nThe above exception occurred within soft assertion block."
                     f"\n\nSoft assertion failures:\n{self._context.get_failure_messages()}"
                 )
-                if exc_val is not None:
-                    exc_val.args = (failure_message,) + exc_val.args[1:]
+                exc_val.args = (failure_message,) + exc_val.args[1:]
                 return
 
             raise AssertionError(

--- a/playwright/_impl/_assertions.py
+++ b/playwright/_impl/_assertions.py
@@ -13,7 +13,19 @@
 # limitations under the License.
 
 import collections.abc
-from typing import Any, List, Optional, Pattern, Sequence, Union
+from types import TracebackType
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Generic,
+    List,
+    Optional,
+    Pattern,
+    Sequence,
+    Type,
+    TypeVar,
+    Union,
+)
 from urllib.parse import urljoin
 
 from playwright._impl._api_structures import (
@@ -30,6 +42,10 @@ from playwright._impl._locator import Locator
 from playwright._impl._page import Page
 from playwright._impl._str_utils import escape_regex_flags
 
+if TYPE_CHECKING:
+    from ..async_api import Expect as AsyncExpect
+    from ..sync_api import Expect as SyncExpect
+
 
 class AssertionsBase:
     def __init__(
@@ -38,6 +54,7 @@ class AssertionsBase:
         timeout: float = None,
         is_not: bool = False,
         message: Optional[str] = None,
+        soft_context: Optional["SoftAssertionContext"] = None,
     ) -> None:
         self._actual_locator = locator
         self._loop = locator._loop
@@ -45,6 +62,7 @@ class AssertionsBase:
         self._timeout = timeout
         self._is_not = is_not
         self._custom_message = message
+        self._soft_context = soft_context
 
     async def _call_expect(
         self, expression: str, expect_options: FrameExpectOptions, title: Optional[str]
@@ -80,9 +98,13 @@ class AssertionsBase:
                 out_message = (
                     f"{message} '{expected}'" if expected is not None else f"{message}"
                 )
-            raise AssertionError(
+            error = AssertionError(
                 f"{out_message}\nActual value: {actual} {format_call_log(result.get('log'))}"
             )
+            if self._soft_context is not None:
+                self._soft_context.add_failure(error)
+            else:
+                raise error
 
 
 class PageAssertions(AssertionsBase):
@@ -92,8 +114,9 @@ class PageAssertions(AssertionsBase):
         timeout: float = None,
         is_not: bool = False,
         message: Optional[str] = None,
+        soft_context: Optional["SoftAssertionContext"] = None,
     ) -> None:
-        super().__init__(page.locator(":root"), timeout, is_not, message)
+        super().__init__(page.locator(":root"), timeout, is_not, message, soft_context)
         self._actual_page = page
 
     async def _call_expect(
@@ -107,7 +130,11 @@ class PageAssertions(AssertionsBase):
     @property
     def _not(self) -> "PageAssertions":
         return PageAssertions(
-            self._actual_page, self._timeout, not self._is_not, self._custom_message
+            self._actual_page,
+            self._timeout,
+            not self._is_not,
+            self._custom_message,
+            self._soft_context,
         )
 
     async def to_have_title(
@@ -167,8 +194,9 @@ class LocatorAssertions(AssertionsBase):
         timeout: float = None,
         is_not: bool = False,
         message: Optional[str] = None,
+        soft_context: Optional["SoftAssertionContext"] = None,
     ) -> None:
-        super().__init__(locator, timeout, is_not, message)
+        super().__init__(locator, timeout, is_not, message, soft_context)
         self._actual_locator = locator
 
     async def _call_expect(
@@ -180,7 +208,11 @@ class LocatorAssertions(AssertionsBase):
     @property
     def _not(self) -> "LocatorAssertions":
         return LocatorAssertions(
-            self._actual_locator, self._timeout, not self._is_not, self._custom_message
+            self._actual_locator,
+            self._timeout,
+            not self._is_not,
+            self._custom_message,
+            self._soft_context,
         )
 
     async def to_contain_text(
@@ -942,6 +974,7 @@ class APIResponseAssertions:
         timeout: float = None,
         is_not: bool = False,
         message: Optional[str] = None,
+        soft_context: Optional["SoftAssertionContext"] = None,
     ) -> None:
         self._loop = response._loop
         self._dispatcher_fiber = response._dispatcher_fiber
@@ -949,11 +982,16 @@ class APIResponseAssertions:
         self._is_not = is_not
         self._actual = response
         self._custom_message = message
+        self._soft_context = soft_context
 
     @property
     def _not(self) -> "APIResponseAssertions":
         return APIResponseAssertions(
-            self._actual, self._timeout, not self._is_not, self._custom_message
+            self._actual,
+            self._timeout,
+            not self._is_not,
+            self._custom_message,
+            self._soft_context,
         )
 
     async def to_be_ok(
@@ -974,7 +1012,11 @@ class APIResponseAssertions:
         if text is not None:
             out_message += f"\n Response Text:\n{text[:1000]}"
 
-        raise AssertionError(out_message)
+        error = AssertionError(out_message)
+        if self._soft_context is not None:
+            self._soft_context.add_failure(error)
+        else:
+            raise error
 
     async def not_to_be_ok(self) -> None:
         __tracebackhide__ = True
@@ -1027,3 +1069,58 @@ def to_expected_text_values(
         else:
             raise Error("value must be a string or regular expression")
     return out
+
+
+class SoftAssertionContext:
+    def __init__(self) -> None:
+        self._failures: List[Exception] = []
+
+    def __repr__(self) -> str:
+        return f"<SoftAssertionContext failures={self._failures!r}>"
+
+    def add_failure(self, error: Exception) -> None:
+        self._failures.append(error)
+
+    def has_failures(self) -> bool:
+        return bool(self._failures)
+
+    def get_failure_messages(self) -> str:
+        return "\n".join(
+            f"{i}. {str(error)}" for i, error in enumerate(self._failures, 1)
+        )
+
+
+E = TypeVar("E", "SyncExpect", "AsyncExpect")
+
+
+class SoftAssertionContextManager(Generic[E]):
+    def __init__(self, expect: E, context: SoftAssertionContext) -> None:
+        self._expect: E = expect
+        self._context = context
+
+    def __enter__(self) -> E:
+        self._expect._soft_context = self._context
+        return self._expect
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        __tracebackhide__ = True
+
+        if self._context.has_failures():
+            if exc_type is not None:
+                failure_message = (
+                    f"{str(exc_val)}"
+                    f"\n\nThe above exception occurred within soft assertion block."
+                    f"\n\nSoft assertion failures:\n{self._context.get_failure_messages()}"
+                )
+                if exc_val is not None:
+                    exc_val.args = (failure_message,) + exc_val.args[1:]
+                return
+
+            raise AssertionError(
+                f"Soft assertion failures\n{self._context.get_failure_messages()}"
+            )

--- a/playwright/async_api/__init__.py
+++ b/playwright/async_api/__init__.py
@@ -28,6 +28,10 @@ from playwright._impl._assertions import (
 )
 from playwright._impl._assertions import LocatorAssertions as LocatorAssertionsImpl
 from playwright._impl._assertions import PageAssertions as PageAssertionsImpl
+from playwright._impl._assertions import (
+    SoftAssertionContext,
+    SoftAssertionContextManager,
+)
 from playwright.async_api._context_manager import PlaywrightContextManager
 from playwright.async_api._generated import (
     Accessibility,
@@ -95,6 +99,7 @@ class Expect:
 
     def __init__(self) -> None:
         self._timeout: Optional[float] = None
+        self._soft_context: Optional[SoftAssertionContext] = None
 
     def set_options(self, timeout: Optional[float] = _unset) -> None:
         """
@@ -108,6 +113,11 @@ class Expect:
         """
         if timeout is not self._unset:
             self._timeout = timeout
+
+    def soft(self) -> SoftAssertionContextManager:
+        expect = Expect()
+        expect._timeout = self._timeout
+        return SoftAssertionContextManager(expect, SoftAssertionContext())
 
     @overload
     def __call__(
@@ -129,16 +139,29 @@ class Expect:
     ) -> Union[PageAssertions, LocatorAssertions, APIResponseAssertions]:
         if isinstance(actual, Page):
             return PageAssertions(
-                PageAssertionsImpl(actual._impl_obj, self._timeout, message=message)
+                PageAssertionsImpl(
+                    actual._impl_obj,
+                    self._timeout,
+                    message=message,
+                    soft_context=self._soft_context,
+                )
             )
         elif isinstance(actual, Locator):
             return LocatorAssertions(
-                LocatorAssertionsImpl(actual._impl_obj, self._timeout, message=message)
+                LocatorAssertionsImpl(
+                    actual._impl_obj,
+                    self._timeout,
+                    message=message,
+                    soft_context=self._soft_context,
+                )
             )
         elif isinstance(actual, APIResponse):
             return APIResponseAssertions(
                 APIResponseAssertionsImpl(
-                    actual._impl_obj, self._timeout, message=message
+                    actual._impl_obj,
+                    self._timeout,
+                    message=message,
+                    soft_context=self._soft_context,
                 )
             )
         raise ValueError(f"Unsupported type: {type(actual)}")

--- a/tests/async/test_assertions.py
+++ b/tests/async/test_assertions.py
@@ -1132,3 +1132,172 @@ async def test_to_have_role(page: Page) -> None:
     with pytest.raises(Error) as excinfo:
         await expect(page.locator("div")).to_have_role(re.compile(r"button|checkbox"))  # type: ignore
     assert '"role" argument in to_have_role must be a string' in str(excinfo.value)
+
+
+async def test_should_collect_soft_failures(page: Page) -> None:
+    await page.set_content(
+        """
+        <div id="div1">Text1</div>
+        <div id="div2">Text2</div>
+    """
+    )
+
+    with pytest.raises(AssertionError) as excinfo:
+        with expect.soft() as soft_expect:
+            await soft_expect(page.locator("#div1")).to_have_text("wrong", timeout=1000)
+            await soft_expect(page.locator("#div2")).to_have_text(
+                "wrong2", timeout=1000
+            )
+    assert "1. Locator expected to have text 'wrong'" in str(excinfo.value)
+    assert "2. Locator expected to have text 'wrong2'" in str(excinfo.value)
+
+
+async def test_should_support_custom_message_in_soft_assertions(page: Page) -> None:
+    await page.set_content('<div id="div1">Text1</div>')
+
+    with pytest.raises(AssertionError) as excinfo:
+        with expect.soft() as soft_expect:
+            await soft_expect(page.locator("#div1"), "Custom message 1").to_have_text(
+                "wrong", timeout=1000
+            )
+            await soft_expect(page.locator("#div1"), "Custom message 2").to_have_text(
+                "also wrong", timeout=1000
+            )
+    assert "1. Custom message 1" in str(excinfo.value)
+    assert "2. Custom message 2" in str(excinfo.value)
+
+
+async def test_should_work_with_different_assertion_types(
+    page: Page, server: Server
+) -> None:
+    await page.set_content(
+        """
+        <div id="div1">Text1</div>
+        <title>Page Title</title>
+    """
+    )
+
+    with pytest.raises(AssertionError) as excinfo:
+        with expect.soft() as soft_expect:
+            await soft_expect(page.locator("#div1")).to_have_text("wrong", timeout=1000)
+            await soft_expect(page).to_have_title("wrong title", timeout=1000)
+            response = await page.request.get(server.PREFIX + "/non-existent")
+            await soft_expect(response).to_be_ok()
+
+    error_text = str(excinfo.value)
+    assert "1. Locator expected to have text 'wrong'" in error_text
+    assert "2. Page title expected to be 'wrong title'" in error_text
+    assert "3. Response status expected to be within [200..299] range" in error_text
+
+
+async def test_should_report_soft_failures_in_order(page: Page) -> None:
+    await page.set_content(
+        """
+        <div id="first">First</div>
+        <div id="second">Second</div>
+        <div id="third">Third</div>
+    """
+    )
+
+    with pytest.raises(AssertionError) as excinfo:
+        with expect.soft() as soft_expect:
+            await soft_expect(page.locator("#third")).to_have_text(
+                "wrong3", timeout=1000
+            )
+            await soft_expect(page.locator("#first")).to_have_text(
+                "wrong1", timeout=1000
+            )
+            await soft_expect(page.locator("#second")).to_have_text(
+                "wrong2", timeout=1000
+            )
+
+    error_text = str(excinfo.value)
+    first_pos = error_text.find("wrong3")
+    second_pos = error_text.find("wrong1")
+    third_pos = error_text.find("wrong2")
+    assert (
+        first_pos < second_pos < third_pos
+    ), "Errors should be reported in order of occurrence"
+
+
+async def test_should_pass_successful_soft_assertions(page: Page) -> None:
+    await page.set_content("<div>Text</div>")
+
+    try:
+        with expect.soft() as soft_expect:
+            await soft_expect(page.locator("div")).to_have_text("Text")
+            await soft_expect(page.locator("div")).to_be_visible()
+    except Exception as e:
+        pytest.fail(f"Should not have raised an exception, but got: {e}")
+
+
+async def test_should_respect_timeout_in_soft_assertions(page: Page) -> None:
+    await page.set_content("<div>Text</div>")
+
+    original_timeout = expect._timeout
+    try:
+        expect.set_options(timeout=2000)
+        with pytest.raises(AssertionError) as excinfo:
+            with expect.soft() as soft_expect:
+                await soft_expect(page.locator("div")).to_have_text(
+                    "wrong", timeout=100
+                )
+                await soft_expect(page.locator("div")).to_have_text("also wrong")
+
+        error_text = str(excinfo.value)
+        assert "timeout 100ms" in error_text
+        assert "timeout 2000ms" in error_text
+    finally:
+        expect.set_options(timeout=original_timeout)
+
+
+async def test_should_include_soft_failures_in_error_message(page: Page) -> None:
+    await page.set_content("<div>Text</div>")
+
+    with pytest.raises(ValueError) as excinfo:
+        with expect.soft() as soft_expect:
+            await soft_expect(page.locator("div")).to_have_text("wrong", timeout=1000)
+            raise ValueError("Some error")
+
+    error_text = str(excinfo.value)
+    assert "Some error" in error_text
+    assert "expected to have text 'wrong'" in error_text
+
+
+async def test_should_collect_negated_soft_failures(page: Page) -> None:
+    await page.set_content(
+        """
+        <div id="div1">Text1</div>
+        <div id="div2">Text2</div>
+        <div id="div3">Text3</div>
+    """
+    )
+
+    with pytest.raises(AssertionError) as excinfo:
+        with expect.soft() as soft_expect:
+            await soft_expect(page.locator("#div1")).not_to_have_text(
+                "Text1", timeout=1000
+            )
+            await soft_expect(page.locator("#div2")).not_to_be_visible(timeout=1000)
+            await soft_expect(page.locator("#div3")).not_to_be_attached(timeout=1000)
+
+    error_text = str(excinfo.value)
+    assert "1. Locator expected not to have text 'Text1'" in error_text
+    assert "2. Locator expected not to be visible" in error_text
+    assert "3. Locator expected not to be attached" in error_text
+
+
+async def test_should_pass_negated_soft_assertions(page: Page) -> None:
+    await page.set_content(
+        """
+        <div id="div1">Text1</div>
+    """
+    )
+
+    try:
+        with expect.soft() as soft_expect:
+            await soft_expect(page.locator("#div1")).not_to_have_text("wrong")
+            await soft_expect(page.locator("#not-exists")).not_to_be_visible()
+            await soft_expect(page.locator("#not-exists")).not_to_be_attached()
+    except Exception as e:
+        pytest.fail(f"Should not have raised an exception, but got: {e}")


### PR DESCRIPTION
Related to #1272

This PR adds support for soft assertions, allowing multiple assertion failures to be collected before raising them together. I implemented this using a context manager pattern since it feels more natural and Pythonic:

```python
with expect.soft() as soft_expect:
    await soft_expect(page).to_have_title("wrong title")
    await soft_expect(page.locator("#div1")).to_have_text("wrong")
    response = await page.request.get("...")
    await soft_expect(response).to_be_ok()
```

Example error report:

```
>       with expect.soft() as soft_expect:
E       AssertionError: Soft assertion failures
E       1. Page title expected to be 'wrong title'
E       Actual value: Page Title
E       Call log:
E         - PageAssertions.to_have_title with timeout 5000ms
E         -   - waiting for locator(":root")
E         -     9 × locator resolved to <html>…</html>
E         -       - unexpected value "Page Title"
E
E       2. Locator expected to have text 'wrong'
E       Actual value: Text1
E       Call log:
E         - LocatorAssertions.to_have_text with timeout 5000ms
E         -   - waiting for locator("#div1")
E         -     9 × locator resolved to <div id="div1">Text1</div>
E         -       - unexpected value "Text1"
E
E       3. Response status expected to be within [200..299] range, was '404'
E       Call log:
E       → GET http://localhost:2137/non-existent
E         -   user-agent: (...)
E         -   accept: */*
E         -   accept-encoding: gzip,deflate,br
E         - ← 404 Not Found
E         -   content-type: text/plain
E         -   transfer-encoding: chunked
```

## Implementation Details

- The implementation maintains backward compatibility with all existing assertion methods
- Both sync and async APIs are fully supported with identical behavior
- Error messages preserve the order of failures and include clear numbering (1., 2., etc.)
- Custom error messages are properly handled and included in the final error report
- The implementation handles nested errors correctly (when other exceptions occur within the soft assertion block)
- Timeout settings are respected both at the global and individual assertion level

Initially, I used `contextlib.contextmanager` for `expect.soft()` as it was a simpler implementation. However, this approach included some unrelevant information in the traceback when assertions failed. To address this, I created a custom `SoftAssertionContextManager` class that gives us more control over the error handling and traceback presentation.

This is just one way to add soft assertions in Python Playwright. I think the context manager pattern works well with Python, but I’m totally open to other ideas if they fit the project better.