### PR TITLE
chore: update pytest-asyncio

### DIFF
--- a/local-requirements.txt
+++ b/local-requirements.txt
@@ -9,7 +9,7 @@ pixelmatch==0.3.0
 pre-commit==3.5.0
 pyOpenSSL==25.0.0
 pytest==8.3.5
-pytest-asyncio==0.25.3
+pytest-asyncio==0.26.0
 pytest-cov==6.0.0
 pytest-repeat==0.9.3
 pytest-rerunfailures==15.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ markers = [
 junit_family = "xunit2"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
+asyncio_default_test_loop_scope = "session"
 
 [tool.mypy]
 ignore_missing_imports = true

--- a/tests/async/conftest.py
+++ b/tests/async/conftest.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 import asyncio
-from typing import Any, AsyncGenerator, Awaitable, Callable, Dict, Generator, List
+from typing import Any, AsyncGenerator, Awaitable, Callable, Dict, Generator
 
 import pytest
-from pytest_asyncio import is_async_test
 
 from playwright.async_api import (
     Browser,
@@ -35,14 +34,6 @@ from .utils import utils as utils_object
 @pytest.fixture
 def utils() -> Generator[Utils, None, None]:
     yield utils_object
-
-
-# Will mark all the tests as async
-def pytest_collection_modifyitems(items: List[pytest.Item]) -> None:
-    pytest_asyncio_tests = (item for item in items if is_async_test(item))
-    session_scope_marker = pytest.mark.asyncio(loop_scope="session")
-    for async_test in pytest_asyncio_tests:
-        async_test.add_marker(session_scope_marker, append=False)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
This PR does not include any user-facing changes - its only about our tests. There it updates the `pytest-asyncio` plugin and leverages the new config option which simplifies it.

Relates https://github.com/microsoft/playwright-python/issues/2742.