### PR TITLE
fix(conda build): revert noarch and add playwright install test

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -40,6 +40,7 @@ test: # [build_platform == target_platform]
     - playwright.async_api
   commands:
     - playwright --help
+    - playwright install
 
 about:
   home: https://github.com/microsoft/playwright-python


### PR DESCRIPTION
closes #2791

Starting by just adding the failing test case proposed by @mxschmitt in https://github.com/microsoft/playwright-python/issues/2791#issuecomment-2734669610, to prove to ourselves that ci _will_ fail with this additional test.