### PR TITLE
chore: publish win32-arm64 wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,12 @@ base_wheel_bundles = [
         "platform": "win32",
         "zip_name": "win32_x64",
     },
+    {
+        "wheel": "win_arm64.whl",
+        "machine": "arm64",
+        "platform": "win32",
+        "zip_name": "win32_arm64",
+    },
 ]
 
 if len(sys.argv) == 2 and sys.argv[1] == "--list-wheels":


### PR DESCRIPTION
What is it solving? Before this change Playwright for Python was not able to run on `win32-arm64` since we don't publish a wheel on that platform. The install via PIP was failing. In Node.js its already working since Windows emulates all the arm64 instructions. This patch adds a new wheel using a dedicated `win32-arm64` driver (contains also win32-arm64 Node.js) in order to make Playwright work there.

Relates https://github.com/microsoft/playwright/pull/35185

This requires a new roll to make the Docker tests pass.
