### PR TITLE
fix: "" userDataDir on Windows with Python 3.9

### DIFF
--- a/playwright/_impl/_browser_type.py
+++ b/playwright/_impl/_browser_type.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import pathlib
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional, Pattern, Sequence, Union, cast
 
@@ -167,6 +168,10 @@ class BrowserType(ChannelOwner):
         if not userDataDir:
             return ""
         if not Path(userDataDir).is_absolute():
+            # Can be dropped once we drop Python 3.9 support (10/2025):
+            # https://github.com/python/cpython/issues/82852
+            if sys.platform == "win32" and sys.version_info[:2] < (3, 10):
+                return pathlib.Path.cwd() / userDataDir
             return str(Path(userDataDir).resolve())
         return str(Path(userDataDir))
 


### PR DESCRIPTION
There is a bug in Python 3.9 on Windows that when you try to resolve `'foobar'` it stays `'foobar'`. Python 3.9+ has it fixed. Since we consider `''` in `userDataDir` as our public API lets workaround the bug for now.