### PR TITLE
chore: fix double call log formatting

### DIFF
--- a/playwright/_impl/_connection.py
+++ b/playwright/_impl/_connection.py
@@ -619,4 +619,4 @@ def format_call_log(log: Optional[List[str]]) -> str:
         return ""
     if len(list(filter(lambda x: x.strip(), log))) == 0:
         return ""
-    return "\nCall log:\n" + "\n  - ".join(log) + "\n"
+    return "\nCall log:\n" + "\n".join(log) + "\n"


### PR DESCRIPTION
Looks like this was changed [here](https://github.com/microsoft/playwright/commit/2a3d67195dff6ece12bd36aab970a1fc95776998#diff-b6f15e1e595e78791af29171502861070168d93fac02cdd83fd8d99d535e9540L137). Relates https://github.com/microsoft/playwright-dotnet/issues/3132

Before:

```
Traceback (most recent call last):
  File "/Users/maxschmitt/Developer/playwright-python/test.py", line 30, in <module>
    asyncio.run(main())
  File "/Users/maxschmitt/.pyenv/versions/3.12.0/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/Users/maxschmitt/.pyenv/versions/3.12.0/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/maxschmitt/.pyenv/versions/3.12.0/lib/python3.12/asyncio/base_events.py", line 664, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/maxschmitt/Developer/playwright-python/test.py", line 25, in main
    await page.locator("textarea").fill("foo", timeout=123)
  File "/Users/maxschmitt/Developer/playwright-python/playwright/async_api/_generated.py", line 15782, in fill
    await self._impl_obj.fill(
  File "/Users/maxschmitt/Developer/playwright-python/playwright/_impl/_locator.py", line 212, in fill
    return await self._frame.fill(self._selector, strict=True, **params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/maxschmitt/Developer/playwright-python/playwright/_impl/_frame.py", line 527, in fill
    await self._channel.send("fill", locals_to_params(locals()))
  File "/Users/maxschmitt/Developer/playwright-python/playwright/_impl/_connection.py", line 61, in send
    return await self._connection.wrap_api_call(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/maxschmitt/Developer/playwright-python/playwright/_impl/_connection.py", line 528, in wrap_api_call
    raise rewrite_error(error, f"{parsed_st['apiName']}: {error}") from None
playwright._impl._errors.TimeoutError: Locator.fill: Timeout 123ms exceeded.
Call log:
  - waiting for locator("textarea")
  -     - locator resolved to <textarea disabled></textarea>
  -     - fill("foo")
  -   - attempting fill action
  -     2 × waiting for element to be visible, enabled and editable
  -       - element is not enabled
  -     - retrying fill action
  -     - waiting 20ms
  -     - waiting for element to be visible, enabled and editable
  -     - element is not enabled
  -   - retrying fill action
  -     - waiting 100ms

(env) ➜  playwright-python git:(main) ✗ 
```

After:

```
(env) ➜  playwright-python git:(win-arm64) ✗ python test.py
Traceback (most recent call last):
  File "/Users/maxschmitt/Developer/playwright-python/test.py", line 30, in <module>
    asyncio.run(main())
  File "/Users/maxschmitt/.pyenv/versions/3.12.0/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/Users/maxschmitt/.pyenv/versions/3.12.0/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/maxschmitt/.pyenv/versions/3.12.0/lib/python3.12/asyncio/base_events.py", line 664, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/maxschmitt/Developer/playwright-python/test.py", line 25, in main
    await page.locator("textarea").fill("foo", timeout=123)
  File "/Users/maxschmitt/Developer/playwright-python/playwright/async_api/_generated.py", line 15782, in fill
    await self._impl_obj.fill(
  File "/Users/maxschmitt/Developer/playwright-python/playwright/_impl/_locator.py", line 212, in fill
    return await self._frame.fill(self._selector, strict=True, **params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/maxschmitt/Developer/playwright-python/playwright/_impl/_frame.py", line 527, in fill
    await self._channel.send("fill", locals_to_params(locals()))
  File "/Users/maxschmitt/Developer/playwright-python/playwright/_impl/_connection.py", line 61, in send
    return await self._connection.wrap_api_call(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/maxschmitt/Developer/playwright-python/playwright/_impl/_connection.py", line 528, in wrap_api_call
    raise rewrite_error(error, f"{parsed_st['apiName']}: {error}") from None
playwright._impl._errors.TimeoutError: Locator.fill: Timeout 123ms exceeded.
Call log:
  - waiting for locator("textarea")
    - locator resolved to <textarea disabled></textarea>
    - fill("foo")
  - attempting fill action
    2 × waiting for element to be visible, enabled and editable
      - element is not enabled
    - retrying fill action
    - waiting 20ms
    - waiting for element to be visible, enabled and editable
    - element is not enabled
  - retrying fill action
    - waiting 100ms

```