### PR TITLE
_connect.py: Don't request context when inspecting stack

### DIFF
--- a/local-requirements.txt
+++ b/local-requirements.txt
@@ -1,7 +1,7 @@
 autobahn==23.1.2
 black==25.1.0
 build==1.2.2.post1
-flake8==7.1.2
+flake8==7.2.0
 mypy==1.15.0
 objgraph==3.6.2
 Pillow==11.1.0

--- a/playwright/_impl/_connection.py
+++ b/playwright/_impl/_connection.py
@@ -533,7 +533,9 @@ class Connection(EventEmitter):
         if self._api_zone.get():
             return cb()
         task = asyncio.current_task(self._loop)
-        st: List[inspect.FrameInfo] = getattr(task, "__pw_stack__", inspect.stack())
+        st: List[inspect.FrameInfo] = getattr(
+            task, "__pw_stack__", None
+        ) or inspect.stack(0)
         parsed_st = _extract_stack_trace_information_from_stack(st, is_internal)
         self._api_zone.set(parsed_st)
         try:

--- a/playwright/_impl/_connection.py
+++ b/playwright/_impl/_connection.py
@@ -362,11 +362,7 @@ class Connection(EventEmitter):
             "params": self._replace_channels_with_guids(params),
             "metadata": metadata,
         }
-        if (
-            self._tracing_count > 0
-            and frames
-            and object._guid != "localUtils"
-        ):
+        if self._tracing_count > 0 and frames and object._guid != "localUtils":
             self.local_utils.add_stack_to_tracing_no_reply(id, frames)
 
         self._transport.send(message)
@@ -518,10 +514,9 @@ class Connection(EventEmitter):
         if self._api_zone.get():
             return await cb()
         task = asyncio.current_task(self._loop)
-        st: List[inspect.FrameInfo] = getattr(task, "__pw_stack__", None)
-
-        if st == None:
-            st = inspect.stack(0)
+        st: List[inspect.FrameInfo] = getattr(
+            task, "__pw_stack__", None
+        ) or inspect.stack(0)
 
         parsed_st = _extract_stack_trace_information_from_stack(st, is_internal)
         self._api_zone.set(parsed_st)

--- a/playwright/_impl/_connection.py
+++ b/playwright/_impl/_connection.py
@@ -365,7 +365,6 @@ class Connection(EventEmitter):
         if (
             self._tracing_count > 0
             and frames
-            and frames
             and object._guid != "localUtils"
         ):
             self.local_utils.add_stack_to_tracing_no_reply(id, frames)
@@ -519,7 +518,11 @@ class Connection(EventEmitter):
         if self._api_zone.get():
             return await cb()
         task = asyncio.current_task(self._loop)
-        st: List[inspect.FrameInfo] = getattr(task, "__pw_stack__", inspect.stack())
+        st: List[inspect.FrameInfo] = getattr(task, "__pw_stack__", None)
+
+        if st == None:
+            st = inspect.stack(0)
+
         parsed_st = _extract_stack_trace_information_from_stack(st, is_internal)
         self._api_zone.set(parsed_st)
         try:

--- a/tests/async/test_asyncio.py
+++ b/tests/async/test_asyncio.py
@@ -97,11 +97,5 @@ async def test_should_return_proper_api_name_on_error(page: Page) -> None:
             False
         ), "Accessing undefined JavaScript variable should have thrown exception"
     except Exception as error:
-        assert (
-            str(error)
-            == """Page.evaluate: ReferenceError: does_not_exist is not defined
-    at eval (eval at evaluate (:234:30), <anonymous>:1:1)
-    at eval (<anonymous>)
-    at UtilityScript.evaluate (<anonymous>:234:30)
-    at UtilityScript.<anonymous> (<anonymous>:1:44)"""
-        )
+        # Each browser returns slightly different error messages, but they should all start with "Page.evaluate:", because that was the Playwright method where the error originated
+        assert str(error).startswith("Page.evaluate:")

--- a/tests/async/test_asyncio.py
+++ b/tests/async/test_asyncio.py
@@ -88,15 +88,21 @@ async def test_should_not_throw_with_taskgroup(page: Page) -> None:
     assert isinstance(exc_info.value.exceptions[0], ValueError)
     assert await page.evaluate("() => 11 * 11") == 121
 
+
 async def test_should_return_proper_api_name_on_error(page: Page) -> None:
     try:
         await page.evaluate("does_not_exist")
 
-        assert False, "Accessing undefined JavaScript variable should have thrown exception"
+        assert (
+            False
+        ), "Accessing undefined JavaScript variable should have thrown exception"
     except Exception as error:
-        print(':-:' + error.message + ':-:')
-        assert error.message == """Page.evaluate: ReferenceError: does_not_exist is not defined
+        print(":-:" + error.message + ":-:")
+        assert (
+            error.message
+            == """Page.evaluate: ReferenceError: does_not_exist is not defined
     at eval (eval at evaluate (:234:30), <anonymous>:1:1)
     at eval (<anonymous>)
     at UtilityScript.evaluate (<anonymous>:234:30)
     at UtilityScript.<anonymous> (<anonymous>:1:44)"""
+        )

--- a/tests/async/test_asyncio.py
+++ b/tests/async/test_asyncio.py
@@ -87,3 +87,16 @@ async def test_should_not_throw_with_taskgroup(page: Page) -> None:
     assert "Something went wrong" in str(exc_info.value.exceptions[0])
     assert isinstance(exc_info.value.exceptions[0], ValueError)
     assert await page.evaluate("() => 11 * 11") == 121
+
+async def test_should_return_proper_api_name_on_error(page: Page) -> None:
+    try:
+        await page.evaluate("does_not_exist")
+
+        assert False, "Accessing undefined JavaScript variable should have thrown exception"
+    except Exception as error:
+        print(':-:' + error.message + ':-:')
+        assert error.message == """Page.evaluate: ReferenceError: does_not_exist is not defined
+    at eval (eval at evaluate (:234:30), <anonymous>:1:1)
+    at eval (<anonymous>)
+    at UtilityScript.evaluate (<anonymous>:234:30)
+    at UtilityScript.<anonymous> (<anonymous>:1:44)"""

--- a/tests/sync/test_sync.py
+++ b/tests/sync/test_sync.py
@@ -356,11 +356,5 @@ def test_should_return_proper_api_name_on_error(page: Page) -> None:
             False
         ), "Accessing undefined JavaScript variable should have thrown exception"
     except Exception as error:
-        assert (
-            str(error)
-            == """Page.evaluate: ReferenceError: does_not_exist is not defined
-    at eval (eval at evaluate (:234:30), <anonymous>:1:1)
-    at eval (<anonymous>)
-    at UtilityScript.evaluate (<anonymous>:234:30)
-    at UtilityScript.<anonymous> (<anonymous>:1:44)"""
-        )
+        # Each browser returns slightly different error messages, but they should all start with "Page.evaluate:", because that was the Playwright method where the error originated
+        assert str(error).startswith("Page.evaluate:")

--- a/tests/sync/test_sync.py
+++ b/tests/sync/test_sync.py
@@ -346,3 +346,16 @@ def test_call_sync_method_after_playwright_close_with_own_loop(
     p.start()
     p.join()
     assert p.exitcode == 0
+
+def test_should_return_proper_api_name_on_error(page: Page) -> None:
+    try:
+        page.evaluate("does_not_exist")
+
+        assert False, "Accessing undefined JavaScript variable should have thrown exception"
+    except Exception as error:
+        print(':-:' + error.message + ':-:')
+        assert error.message == """Page.evaluate: ReferenceError: does_not_exist is not defined
+    at eval (eval at evaluate (:234:30), <anonymous>:1:1)
+    at eval (<anonymous>)
+    at UtilityScript.evaluate (<anonymous>:234:30)
+    at UtilityScript.<anonymous> (<anonymous>:1:44)"""

--- a/tests/sync/test_sync.py
+++ b/tests/sync/test_sync.py
@@ -347,15 +347,21 @@ def test_call_sync_method_after_playwright_close_with_own_loop(
     p.join()
     assert p.exitcode == 0
 
+
 def test_should_return_proper_api_name_on_error(page: Page) -> None:
     try:
         page.evaluate("does_not_exist")
 
-        assert False, "Accessing undefined JavaScript variable should have thrown exception"
+        assert (
+            False
+        ), "Accessing undefined JavaScript variable should have thrown exception"
     except Exception as error:
-        print(':-:' + error.message + ':-:')
-        assert error.message == """Page.evaluate: ReferenceError: does_not_exist is not defined
+        print(":-:" + error.message + ":-:")
+        assert (
+            error.message
+            == """Page.evaluate: ReferenceError: does_not_exist is not defined
     at eval (eval at evaluate (:234:30), <anonymous>:1:1)
     at eval (<anonymous>)
     at UtilityScript.evaluate (<anonymous>:234:30)
     at UtilityScript.<anonymous> (<anonymous>:1:44)"""
+        )


### PR DESCRIPTION
This PR partially fixes https://github.com/microsoft/playwright-python/issues/2744

This PR makes two changes:
1. Call `inspect.stack(0)` instead of `inspect.stack()`
2. Only call `inspect.stack()` when `getattr(task, "__pw_stack__")` doesn't find a stack in the task

`inspect.stack()` by default requests context for the first frame of the callstack, which is a [very expensive operation](https://stackoverflow.com/a/17407257/132540). We don't use the returned context information, so we can safely use `inspect.stack(context=0)`.

In my testing, this improved the speed of `evaluate()` by about 2.5x:

**Test:**
```py
async def test_speed_test(page: Page) -> None:
    start_time = time.time()

    for i in range(0, 1000):
        await page.evaluate('() => 1 + 1')

    print(time.time() - start_time)
```

Before this PR: 10s
After this PR: 4s

The second change is that we originally were calling `getattr(task, "__pw_stack__", inspect.stack())`, which retrieved the entire callstack and then threw it away if `getattr(task, "__pw_stack__")` succeeded. I wasn't able to figure out how to get `getattr(task, "__pw_stack__")` to return a value, so I'm not sure how much this change sped things up, but it seems like a sensible change to make.

I've added async and sync tests.

I have a more detailed fix, but I figured I'd first try to get this PR landed, since it involves small changes for a pretty large speedup :)