### PR TITLE
More stack-related performance improvements

### DIFF
--- a/playwright/_impl/_connection.py
+++ b/playwright/_impl/_connection.py
@@ -387,9 +387,7 @@ class Connection(EventEmitter):
                 parsed_error = parse_error(
                     error["error"], format_call_log(msg.get("log"))  # type: ignore
                 )
-                parsed_error._stack = "".join(
-                    traceback.format_list(callback.stack_trace)
-                )
+                parsed_error._stack = "".join(callback.stack_trace.format())
                 callback.future.set_exception(parsed_error)
             else:
                 result = self._replace_guids_with_channels(msg.get("result"))

--- a/playwright/_impl/_connection.py
+++ b/playwright/_impl/_connection.py
@@ -333,7 +333,7 @@ class Connection(EventEmitter):
         task = asyncio.current_task(self._loop)
         callback.stack_trace = cast(
             traceback.StackSummary,
-            getattr(task, "__pw_stack_trace__", traceback.extract_stack()),
+            getattr(task, "__pw_stack_trace__", traceback.extract_stack(limit=10)),
         )
         callback.no_reply = no_reply
         self._callbacks[id] = callback
@@ -388,7 +388,7 @@ class Connection(EventEmitter):
                     error["error"], format_call_log(msg.get("log"))  # type: ignore
                 )
                 parsed_error._stack = "".join(
-                    traceback.format_list(callback.stack_trace)[-10:]
+                    traceback.format_list(callback.stack_trace)
                 )
                 callback.future.set_exception(parsed_error)
             else:

--- a/playwright/_impl/_network.py
+++ b/playwright/_impl/_network.py
@@ -530,7 +530,7 @@ class Route(ChannelOwner):
         setattr(
             fut,
             "__pw_stack__",
-            getattr(asyncio.current_task(self._loop), "__pw_stack__", inspect.stack()),
+            getattr(asyncio.current_task(self._loop), "__pw_stack__", inspect.stack(0)),
         )
         target_closed_future = self.request._target_closed_future()
         await asyncio.wait(

--- a/playwright/_impl/_path_utils.py
+++ b/playwright/_impl/_path_utils.py
@@ -14,12 +14,14 @@
 
 import inspect
 from pathlib import Path
+from types import FrameType
+from typing import cast
 
 
 def get_file_dirname() -> Path:
     """Returns the callee (`__file__`) directory name"""
-    frame = inspect.stack()[1]
-    module = inspect.getmodule(frame[0])
+    frame = cast(FrameType, inspect.currentframe()).f_back
+    module = inspect.getmodule(frame)
     assert module
     assert module.__file__
     return Path(module.__file__).parent.absolute()

--- a/playwright/_impl/_sync_base.py
+++ b/playwright/_impl/_sync_base.py
@@ -105,7 +105,7 @@ class SyncBase(ImplWrapper):
 
         g_self = greenlet.getcurrent()
         task: asyncio.tasks.Task[Any] = self._loop.create_task(coro)
-        setattr(task, "__pw_stack__", inspect.stack())
+        setattr(task, "__pw_stack__", inspect.stack(0))
         setattr(task, "__pw_stack_trace__", traceback.extract_stack())
 
         task.add_done_callback(lambda _: g_self.switch())

--- a/playwright/_impl/_sync_base.py
+++ b/playwright/_impl/_sync_base.py
@@ -106,7 +106,7 @@ class SyncBase(ImplWrapper):
         g_self = greenlet.getcurrent()
         task: asyncio.tasks.Task[Any] = self._loop.create_task(coro)
         setattr(task, "__pw_stack__", inspect.stack(0))
-        setattr(task, "__pw_stack_trace__", traceback.extract_stack())
+        setattr(task, "__pw_stack_trace__", traceback.extract_stack(limit=10))
 
         task.add_done_callback(lambda _: g_self.switch())
         while not task.done():


### PR DESCRIPTION
Building off of https://github.com/microsoft/playwright-python/pull/2835, this PR replaces the remaining instances of `stack()` with `stack(0)`, so that we avoid getting context information for the first frame of the stack, which is expensive.

I also discovered that we were calling `traceback.format_list(traceback.extract_stack()[-10:])`, which does the following:
1. Extract the entire stack
2. Format the entire stack into strings
3. Throw away everything except for the last 10 formatted frames of the stack

To fix this, I've made `extract_stack()` use the `limit=10` parameter.

Finally, I optimized `_path_utils.py` to only retrieve two frames from the stack, instead of retrieving the entire stack and then discarding everything but the second frame :)