### PR TITLE
test: use tmp_path instead of tmpdir fixture

### DIFF
--- a/tests/async/test_browsercontext_storage_state.py
+++ b/tests/async/test_browsercontext_storage_state.py
@@ -97,7 +97,7 @@ async def test_should_set_local_storage(browser: Browser) -> None:
 
 
 async def test_should_round_trip_through_the_file(
-    browser: Browser, context: BrowserContext, tmpdir: Path
+    browser: Browser, context: BrowserContext, tmp_path: Path
 ) -> None:
     page1 = await context.new_page()
     await page1.route(
@@ -113,7 +113,7 @@ async def test_should_round_trip_through_the_file(
         }"""
     )
 
-    path = tmpdir / "storage-state.json"
+    path = tmp_path / "storage-state.json"
     state = await context.storage_state(path=path)
     with open(path, "r") as f:
         written = json.load(f)

--- a/tests/async/test_browsertype_connect.py
+++ b/tests/async/test_browsertype_connect.py
@@ -208,12 +208,12 @@ async def test_should_not_allow_getting_the_path(
 async def test_prevent_getting_video_path(
     browser_type: BrowserType,
     launch_server: Callable[[], RemoteServer],
-    tmpdir: Path,
+    tmp_path: Path,
     server: Server,
 ) -> None:
     remote_server = launch_server()
     browser = await browser_type.connect(remote_server.ws_endpoint)
-    page = await browser.new_page(record_video_dir=tmpdir)
+    page = await browser.new_page(record_video_dir=tmp_path)
     await page.goto(server.PREFIX + "/grid.html")
     await browser.close()
     assert page.video

--- a/tests/async/test_chromium_tracing.py
+++ b/tests/async/test_chromium_tracing.py
@@ -24,9 +24,9 @@ from tests.server import Server
 
 @pytest.mark.only_browser("chromium")
 async def test_should_output_a_trace(
-    browser: Browser, page: Page, server: Server, tmpdir: Path
+    browser: Browser, page: Page, server: Server, tmp_path: Path
 ) -> None:
-    output_file = tmpdir / "trace.json"
+    output_file = tmp_path / "trace.json"
     await browser.start_tracing(page=page, screenshots=True, path=output_file)
     await page.goto(server.PREFIX + "/grid.html")
     await browser.stop_tracing()
@@ -35,9 +35,9 @@ async def test_should_output_a_trace(
 
 @pytest.mark.only_browser("chromium")
 async def test_should_create_directories_as_needed(
-    browser: Browser, page: Page, server: Server, tmpdir: Path
+    browser: Browser, page: Page, server: Server, tmp_path: Path
 ) -> None:
-    output_file = tmpdir / "these" / "are" / "directories" / "trace.json"
+    output_file = tmp_path / "these" / "are" / "directories" / "trace.json"
     await browser.start_tracing(page=page, screenshots=True, path=output_file)
     await page.goto(server.PREFIX + "/grid.html")
     await browser.stop_tracing()
@@ -46,9 +46,9 @@ async def test_should_create_directories_as_needed(
 
 @pytest.mark.only_browser("chromium")
 async def test_should_run_with_custom_categories_if_provided(
-    browser: Browser, page: Page, tmpdir: Path
+    browser: Browser, page: Page, tmp_path: Path
 ) -> None:
-    output_file = tmpdir / "trace.json"
+    output_file = tmp_path / "trace.json"
     await browser.start_tracing(
         page=page,
         screenshots=True,
@@ -66,11 +66,11 @@ async def test_should_run_with_custom_categories_if_provided(
 
 @pytest.mark.only_browser("chromium")
 async def test_should_throw_if_tracing_on_two_pages(
-    browser: Browser, page: Page, tmpdir: Path
+    browser: Browser, page: Page, tmp_path: Path
 ) -> None:
-    output_file_1 = tmpdir / "trace1.json"
+    output_file_1 = tmp_path / "trace1.json"
     await browser.start_tracing(page=page, screenshots=True, path=output_file_1)
-    output_file_2 = tmpdir / "trace2.json"
+    output_file_2 = tmp_path / "trace2.json"
     with pytest.raises(Exception):
         await browser.start_tracing(page=page, screenshots=True, path=output_file_2)
     await browser.stop_tracing()
@@ -78,9 +78,9 @@ async def test_should_throw_if_tracing_on_two_pages(
 
 @pytest.mark.only_browser("chromium")
 async def test_should_return_a_buffer(
-    browser: Browser, page: Page, server: Server, tmpdir: Path
+    browser: Browser, page: Page, server: Server, tmp_path: Path
 ) -> None:
-    output_file = tmpdir / "trace.json"
+    output_file = tmp_path / "trace.json"
     await browser.start_tracing(page=page, path=output_file, screenshots=True)
     await page.goto(server.PREFIX + "/grid.html")
     value = await browser.stop_tracing()

--- a/tests/async/test_defaultbrowsercontext.py
+++ b/tests/async/test_defaultbrowsercontext.py
@@ -45,7 +45,7 @@ from .utils import Utils
 
 @pytest.fixture()
 async def launch_persistent(
-    tmpdir: Path, launch_arguments: Dict, browser_type: BrowserType
+    tmp_path: Path, launch_arguments: Dict, browser_type: BrowserType
 ) -> AsyncGenerator[Callable[..., Awaitable[Tuple[Page, BrowserContext]]], None]:
     context: Optional[BrowserContext] = None
 
@@ -54,7 +54,7 @@ async def launch_persistent(
         if context:
             raise ValueError("can only launch one persistent context")
         context = await browser_type.launch_persistent_context(
-            str(tmpdir), **{**launch_arguments, **options}
+            str(tmp_path), **{**launch_arguments, **options}
         )
         assert context
         return (context.pages[0], context)
@@ -373,14 +373,14 @@ async def test_should_support_extra_http_headers_option(
 
 
 async def test_should_accept_user_data_dir(
-    tmpdir: Path,
+    tmp_path: Path,
     launch_persistent: "Callable[..., asyncio.Future[Tuple[Page, BrowserContext]]]",
 ) -> None:
     (page, context) = await launch_persistent()
     # Note: we need an open page to make sure its functional.
-    assert len(os.listdir(tmpdir)) > 0
+    assert len(os.listdir(tmp_path)) > 0
     await context.close()
-    assert len(os.listdir(tmpdir)) > 0
+    assert len(os.listdir(tmp_path)) > 0
 
 
 async def test_should_restore_state_from_userDataDir(
@@ -426,11 +426,11 @@ async def test_should_have_default_url_when_launching_browser(
 
 @pytest.mark.skip_browser("firefox")
 async def test_should_throw_if_page_argument_is_passed(
-    browser_type: BrowserType, server: Server, tmpdir: Path, launch_arguments: Dict
+    browser_type: BrowserType, server: Server, tmp_path: Path, launch_arguments: Dict
 ) -> None:
     options = {**launch_arguments, "args": [server.EMPTY_PAGE]}
     with pytest.raises(Error) as exc:
-        await browser_type.launch_persistent_context(tmpdir, **options)
+        await browser_type.launch_persistent_context(tmp_path, **options)
     assert "can not specify page" in exc.value.message
 
 

--- a/tests/async/test_download.py
+++ b/tests/async/test_download.py
@@ -83,14 +83,14 @@ async def test_should_report_downloads_with_accept_downloads_true(
 
 
 async def test_should_save_to_user_specified_path(
-    tmpdir: Path, browser: Browser, server: Server
+    tmp_path: Path, browser: Browser, server: Server
 ) -> None:
     page = await browser.new_page(accept_downloads=True)
     await page.set_content(f'<a href="{server.PREFIX}/download">download</a>')
     async with page.expect_download() as download_info:
         await page.click("a")
     download = await download_info.value
-    user_path = tmpdir / "download.txt"
+    user_path = tmp_path / "download.txt"
     await download.save_as(user_path)
     assert user_path.exists()
     assert user_path.read_text("utf-8") == "Hello world"
@@ -98,14 +98,14 @@ async def test_should_save_to_user_specified_path(
 
 
 async def test_should_save_to_user_specified_path_without_updating_original_path(
-    tmpdir: Path, browser: Browser, server: Server
+    tmp_path: Path, browser: Browser, server: Server
 ) -> None:
     page = await browser.new_page(accept_downloads=True)
     await page.set_content(f'<a href="{server.PREFIX}/download">download</a>')
     async with page.expect_download() as download_info:
         await page.click("a")
     download = await download_info.value
-    user_path = tmpdir / "download.txt"
+    user_path = tmp_path / "download.txt"
     await download.save_as(user_path)
     assert user_path.exists()
     assert user_path.read_text("utf-8") == "Hello world"
@@ -117,19 +117,19 @@ async def test_should_save_to_user_specified_path_without_updating_original_path
 
 
 async def test_should_save_to_two_different_paths_with_multiple_save_as_calls(
-    tmpdir: Path, browser: Browser, server: Server
+    tmp_path: Path, browser: Browser, server: Server
 ) -> None:
     page = await browser.new_page(accept_downloads=True)
     await page.set_content(f'<a href="{server.PREFIX}/download">download</a>')
     async with page.expect_download() as download_info:
         await page.click("a")
     download = await download_info.value
-    user_path = tmpdir / "download.txt"
+    user_path = tmp_path / "download.txt"
     await download.save_as(user_path)
     assert user_path.exists()
     assert user_path.read_text("utf-8") == "Hello world"
 
-    anotheruser_path = tmpdir / "download (2).txt"
+    anotheruser_path = tmp_path / "download (2).txt"
     await download.save_as(anotheruser_path)
     assert anotheruser_path.exists()
     assert anotheruser_path.read_text("utf-8") == "Hello world"
@@ -137,32 +137,32 @@ async def test_should_save_to_two_different_paths_with_multiple_save_as_calls(
 
 
 async def test_should_save_to_overwritten_filepath(
-    tmpdir: Path, browser: Browser, server: Server
+    tmp_path: Path, browser: Browser, server: Server
 ) -> None:
     page = await browser.new_page(accept_downloads=True)
     await page.set_content(f'<a href="{server.PREFIX}/download">download</a>')
     async with page.expect_download() as download_info:
         await page.click("a")
     download = await download_info.value
-    user_path = tmpdir / "download.txt"
+    user_path = tmp_path / "download.txt"
     await download.save_as(user_path)
-    assert len(list(Path(tmpdir).glob("*.*"))) == 1
+    assert len(list(tmp_path.glob("*.*"))) == 1
     await download.save_as(user_path)
-    assert len(list(Path(tmpdir).glob("*.*"))) == 1
+    assert len(list(tmp_path.glob("*.*"))) == 1
     assert user_path.exists()
     assert user_path.read_text("utf-8") == "Hello world"
     await page.close()
 
 
 async def test_should_create_subdirectories_when_saving_to_non_existent_user_specified_path(
-    tmpdir: Path, browser: Browser, server: Server
+    tmp_path: Path, browser: Browser, server: Server
 ) -> None:
     page = await browser.new_page(accept_downloads=True)
     await page.set_content(f'<a href="{server.PREFIX}/download">download</a>')
     async with page.expect_download() as download_info:
         await page.click("a")
     download = await download_info.value
-    nested_path = tmpdir / "these" / "are" / "directories" / "download.txt"
+    nested_path = tmp_path / "these" / "are" / "directories" / "download.txt"
     await download.save_as(nested_path)
     assert nested_path.exists()
     assert nested_path.read_text("utf-8") == "Hello world"
@@ -170,14 +170,14 @@ async def test_should_create_subdirectories_when_saving_to_non_existent_user_spe
 
 
 async def test_should_error_when_saving_with_downloads_disabled(
-    tmpdir: Path, browser: Browser, server: Server
+    tmp_path: Path, browser: Browser, server: Server
 ) -> None:
     page = await browser.new_page(accept_downloads=False)
     await page.set_content(f'<a href="{server.PREFIX}/download">download</a>')
     async with page.expect_download() as download_info:
         await page.click("a")
     download = await download_info.value
-    user_path = tmpdir / "download.txt"
+    user_path = tmp_path / "download.txt"
     with pytest.raises(Error) as exc:
         await download.save_as(user_path)
     assert (
@@ -192,14 +192,14 @@ async def test_should_error_when_saving_with_downloads_disabled(
 
 
 async def test_should_error_when_saving_after_deletion(
-    tmpdir: Path, browser: Browser, server: Server
+    tmp_path: Path, browser: Browser, server: Server
 ) -> None:
     page = await browser.new_page(accept_downloads=True)
     await page.set_content(f'<a href="{server.PREFIX}/download">download</a>')
     async with page.expect_download() as download_info:
         await page.click("a")
     download = await download_info.value
-    user_path = tmpdir / "download.txt"
+    user_path = tmp_path / "download.txt"
     await download.delete()
     with pytest.raises(Error) as exc:
         await download.save_as(user_path)

--- a/tests/async/test_fetch_global.py
+++ b/tests/async/test_fetch_global.py
@@ -289,7 +289,7 @@ async def test_should_return_empty_body(playwright: Playwright, server: Server) 
 
 
 async def test_storage_state_should_round_trip_through_file(
-    playwright: Playwright, tmpdir: Path
+    playwright: Playwright, tmp_path: Path
 ) -> None:
     expected: StorageState = {
         "cookies": [
@@ -307,7 +307,7 @@ async def test_storage_state_should_round_trip_through_file(
         "origins": [],
     }
     request = await playwright.request.new_context(storage_state=expected)
-    path = tmpdir / "storage-state.json"
+    path = tmp_path / "storage-state.json"
     actual = await request.storage_state(path=path)
     assert actual == expected
 

--- a/tests/async/test_har.py
+++ b/tests/async/test_har.py
@@ -27,8 +27,8 @@ from tests.server import Server, TestServerRequest
 from tests.utils import must
 
 
-async def test_should_work(browser: Browser, server: Server, tmpdir: Path) -> None:
-    path = os.path.join(tmpdir, "log.har")
+async def test_should_work(browser: Browser, server: Server, tmp_path: Path) -> None:
+    path = os.path.join(tmp_path, "log.har")
     context = await browser.new_context(record_har_path=path)
     page = await context.new_page()
     await page.goto(server.EMPTY_PAGE)
@@ -39,9 +39,9 @@ async def test_should_work(browser: Browser, server: Server, tmpdir: Path) -> No
 
 
 async def test_should_omit_content(
-    browser: Browser, server: Server, tmpdir: Path
+    browser: Browser, server: Server, tmp_path: Path
 ) -> None:
-    path = os.path.join(tmpdir, "log.har")
+    path = os.path.join(tmp_path, "log.har")
     context = await browser.new_context(
         record_har_path=path,
         record_har_content="omit",
@@ -59,9 +59,9 @@ async def test_should_omit_content(
 
 
 async def test_should_omit_content_legacy(
-    browser: Browser, server: Server, tmpdir: Path
+    browser: Browser, server: Server, tmp_path: Path
 ) -> None:
-    path = os.path.join(tmpdir, "log.har")
+    path = os.path.join(tmp_path, "log.har")
     context = await browser.new_context(
         record_har_path=path, record_har_omit_content=True
     )
@@ -78,9 +78,9 @@ async def test_should_omit_content_legacy(
 
 
 async def test_should_attach_content(
-    browser: Browser, server: Server, tmpdir: Path
+    browser: Browser, server: Server, tmp_path: Path
 ) -> None:
-    path = os.path.join(tmpdir, "log.har.zip")
+    path = os.path.join(tmp_path, "log.har.zip")
     context = await browser.new_context(
         record_har_path=path,
         record_har_content="attach",
@@ -137,9 +137,9 @@ async def test_should_attach_content(
 
 
 async def test_should_not_omit_content(
-    browser: Browser, server: Server, tmpdir: Path
+    browser: Browser, server: Server, tmp_path: Path
 ) -> None:
-    path = os.path.join(tmpdir, "log.har")
+    path = os.path.join(tmp_path, "log.har")
     context = await browser.new_context(
         record_har_path=path, record_har_omit_content=False
     )
@@ -153,9 +153,9 @@ async def test_should_not_omit_content(
 
 
 async def test_should_include_content(
-    browser: Browser, server: Server, tmpdir: Path
+    browser: Browser, server: Server, tmp_path: Path
 ) -> None:
-    path = os.path.join(tmpdir, "log.har")
+    path = os.path.join(tmp_path, "log.har")
     context = await browser.new_context(record_har_path=path)
     page = await context.new_page()
     await page.goto(server.PREFIX + "/har.html")
@@ -171,9 +171,9 @@ async def test_should_include_content(
 
 
 async def test_should_default_to_full_mode(
-    browser: Browser, server: Server, tmpdir: Path
+    browser: Browser, server: Server, tmp_path: Path
 ) -> None:
-    path = os.path.join(tmpdir, "log.har")
+    path = os.path.join(tmp_path, "log.har")
     context = await browser.new_context(
         record_har_path=path,
     )
@@ -188,9 +188,9 @@ async def test_should_default_to_full_mode(
 
 
 async def test_should_support_minimal_mode(
-    browser: Browser, server: Server, tmpdir: Path
+    browser: Browser, server: Server, tmp_path: Path
 ) -> None:
-    path = os.path.join(tmpdir, "log.har")
+    path = os.path.join(tmp_path, "log.har")
     context = await browser.new_context(
         record_har_path=path,
         record_har_mode="minimal",
@@ -206,9 +206,9 @@ async def test_should_support_minimal_mode(
 
 
 async def test_should_filter_by_glob(
-    browser: Browser, server: Server, tmpdir: str
+    browser: Browser, server: Server, tmp_path: str
 ) -> None:
-    path = os.path.join(tmpdir, "log.har")
+    path = os.path.join(tmp_path, "log.har")
     context = await browser.new_context(
         base_url=server.PREFIX,
         record_har_path=path,
@@ -227,9 +227,9 @@ async def test_should_filter_by_glob(
 
 
 async def test_should_filter_by_regexp(
-    browser: Browser, server: Server, tmpdir: str
+    browser: Browser, server: Server, tmp_path: str
 ) -> None:
-    path = os.path.join(tmpdir, "log.har")
+    path = os.path.join(tmp_path, "log.har")
     context = await browser.new_context(
         base_url=server.PREFIX,
         record_har_path=path,
@@ -303,9 +303,9 @@ async def test_by_default_should_abort_requests_not_found_in_har(
 
 
 async def test_fallback_continue_should_continue_requests_on_bad_har(
-    context: BrowserContext, server: Server, tmpdir: Path
+    context: BrowserContext, server: Server, tmp_path: Path
 ) -> None:
-    path_to_invalid_har = tmpdir / "invalid.har"
+    path_to_invalid_har = tmp_path / "invalid.har"
     with path_to_invalid_har.open("w") as f:
         json.dump({"log": {}}, f)
     await context.route_from_har(har=path_to_invalid_har, not_found="fallback")
@@ -500,9 +500,9 @@ async def test_should_fulfill_from_har_with_content_in_a_file(
 
 
 async def test_should_round_trip_har_zip(
-    browser: Browser, server: Server, assetdir: Path, tmpdir: Path
+    browser: Browser, server: Server, assetdir: Path, tmp_path: Path
 ) -> None:
-    har_path = tmpdir / "har.zip"
+    har_path = tmp_path / "har.zip"
     context_1 = await browser.new_context(
         record_har_mode="minimal", record_har_path=har_path
     )
@@ -521,7 +521,7 @@ async def test_should_round_trip_har_zip(
 
 
 async def test_should_round_trip_har_with_post_data(
-    browser: Browser, server: Server, assetdir: Path, tmpdir: Path
+    browser: Browser, server: Server, assetdir: Path, tmp_path: Path
 ) -> None:
     server.set_route("/echo", lambda req: (req.write(req.post_body), req.finish()))
     fetch_function = """
@@ -530,7 +530,7 @@ async def test_should_round_trip_har_with_post_data(
             return await response.text();
         };
     """
-    har_path = tmpdir / "har.zip"
+    har_path = tmp_path / "har.zip"
     context_1 = await browser.new_context(
         record_har_mode="minimal", record_har_path=har_path
     )
@@ -554,7 +554,7 @@ async def test_should_round_trip_har_with_post_data(
 
 
 async def test_should_disambiguate_by_header(
-    browser: Browser, server: Server, tmpdir: Path
+    browser: Browser, server: Server, tmp_path: Path
 ) -> None:
     server.set_route(
         "/echo",
@@ -574,7 +574,7 @@ async def test_should_disambiguate_by_header(
             return await response.text();
         };
     """
-    har_path = tmpdir / "har.zip"
+    har_path = tmp_path / "har.zip"
     context_1 = await browser.new_context(
         record_har_mode="minimal", record_har_path=har_path
     )
@@ -597,9 +597,9 @@ async def test_should_disambiguate_by_header(
 
 
 async def test_should_produce_extracted_zip(
-    browser: Browser, server: Server, tmpdir: Path
+    browser: Browser, server: Server, tmp_path: Path
 ) -> None:
-    har_path = tmpdir / "har.har"
+    har_path = tmp_path / "har.har"
     context = await browser.new_context(
         record_har_mode="minimal", record_har_path=har_path, record_har_content="attach"
     )
@@ -624,9 +624,9 @@ async def test_should_produce_extracted_zip(
 
 
 async def test_should_update_har_zip_for_context(
-    browser: Browser, server: Server, tmpdir: Path
+    browser: Browser, server: Server, tmp_path: Path
 ) -> None:
-    har_path = tmpdir / "har.zip"
+    har_path = tmp_path / "har.zip"
     context = await browser.new_context()
     await context.route_from_har(har_path, update=True)
     page_1 = await context.new_page()
@@ -684,9 +684,9 @@ async def test_context_unroute_call_should_stop_context_route_from_har(
 
 
 async def test_should_update_har_zip_for_page(
-    browser: Browser, server: Server, tmpdir: Path
+    browser: Browser, server: Server, tmp_path: Path
 ) -> None:
-    har_path = tmpdir / "har.zip"
+    har_path = tmp_path / "har.zip"
     context = await browser.new_context()
     page_1 = await context.new_page()
     await page_1.route_from_har(har_path, update=True)
@@ -706,9 +706,9 @@ async def test_should_update_har_zip_for_page(
 
 
 async def test_should_update_har_zip_for_page_with_different_options(
-    browser: Browser, server: Server, tmpdir: Path
+    browser: Browser, server: Server, tmp_path: Path
 ) -> None:
-    har_path = tmpdir / "har.zip"
+    har_path = tmp_path / "har.zip"
     context1 = await browser.new_context()
     page1 = await context1.new_page()
     await page1.route_from_har(
@@ -729,9 +729,9 @@ async def test_should_update_har_zip_for_page_with_different_options(
 
 
 async def test_should_update_extracted_har_zip_for_page(
-    browser: Browser, server: Server, tmpdir: Path
+    browser: Browser, server: Server, tmp_path: Path
 ) -> None:
-    har_path = tmpdir / "har.har"
+    har_path = tmp_path / "har.har"
     context = await browser.new_context()
     page_1 = await context.new_page()
     await page_1.route_from_har(har_path, update=True)
@@ -757,9 +757,9 @@ async def test_should_update_extracted_har_zip_for_page(
 async def test_should_ignore_aborted_requests(
     context_factory: Callable[[], Awaitable[BrowserContext]],
     server: Server,
-    tmpdir: Path,
+    tmp_path: Path,
 ) -> None:
-    path = tmpdir / "test.har"
+    path = tmp_path / "test.har"
     server.set_route("/x", lambda request: request.loseConnection())
     context1 = await context_factory()
     await context1.route_from_har(har=path, update=True)

--- a/tests/async/test_headful.py
+++ b/tests/async/test_headful.py
@@ -23,10 +23,10 @@ from tests.server import Server
 
 
 async def test_should_have_default_url_when_launching_browser(
-    browser_type: BrowserType, launch_arguments: Dict, tmpdir: Path
+    browser_type: BrowserType, launch_arguments: Dict, tmp_path: Path
 ) -> None:
     browser_context = await browser_type.launch_persistent_context(
-        tmpdir, **{**launch_arguments, "headless": False}
+        tmp_path, **{**launch_arguments, "headless": False}
     )
     urls = [page.url for page in browser_context.pages]
     assert urls == ["about:blank"]
@@ -34,10 +34,10 @@ async def test_should_have_default_url_when_launching_browser(
 
 
 async def test_should_close_browser_with_beforeunload_page(
-    browser_type: BrowserType, launch_arguments: Dict, server: Server, tmpdir: Path
+    browser_type: BrowserType, launch_arguments: Dict, server: Server, tmp_path: Path
 ) -> None:
     browser_context = await browser_type.launch_persistent_context(
-        tmpdir, **{**launch_arguments, "headless": False}
+        tmp_path, **{**launch_arguments, "headless": False}
     )
     page = await browser_context.new_page()
     await page.goto(server.PREFIX + "/beforeunload.html")

--- a/tests/async/test_launcher.py
+++ b/tests/async/test_launcher.py
@@ -112,7 +112,7 @@ async def test_browser_close_should_be_callable_twice(
 @pytest.mark.only_browser("chromium")
 async def test_browser_launch_should_return_background_pages(
     browser_type: BrowserType,
-    tmpdir: Path,
+    tmp_path: Path,
     browser_channel: Optional[str],
     assetdir: Path,
     launch_arguments: Dict,
@@ -122,7 +122,7 @@ async def test_browser_launch_should_return_background_pages(
 
     extension_path = str(assetdir / "simple-extension")
     context = await browser_type.launch_persistent_context(
-        str(tmpdir),
+        str(tmp_path),
         **{
             **launch_arguments,
             "headless": False,

--- a/tests/async/test_page_base_url.py
+++ b/tests/async/test_page_base_url.py
@@ -38,10 +38,10 @@ async def test_should_construct_a_new_url_when_a_base_url_in_browser_new_page_is
 
 
 async def test_should_construct_a_new_url_when_a_base_url_in_browser_new_persistent_context_is_passed(
-    browser_type: BrowserType, tmpdir: Path, server: Server, launch_arguments: Dict
+    browser_type: BrowserType, tmp_path: Path, server: Server, launch_arguments: Dict
 ) -> None:
     context = await browser_type.launch_persistent_context(
-        tmpdir, **launch_arguments, base_url=server.PREFIX
+        tmp_path, **launch_arguments, base_url=server.PREFIX
     )
     page = await context.new_page()
     assert (must(await page.goto("/empty.html"))).url == server.EMPTY_PAGE

--- a/tests/async/test_pdf.py
+++ b/tests/async/test_pdf.py
@@ -23,8 +23,8 @@ from tests.server import Server
 pytestmark = pytest.mark.only_browser("chromium")
 
 
-async def test_should_be_able_to_save_pdf_file(page: Page, tmpdir: Path) -> None:
-    output_file = tmpdir / "foo.png"
+async def test_should_be_able_to_save_pdf_file(page: Page, tmp_path: Path) -> None:
+    output_file = tmp_path / "foo.png"
     await page.pdf(path=str(output_file))
     assert os.path.getsize(output_file) > 0
 
@@ -35,11 +35,11 @@ async def test_should_be_able_capture_pdf_without_path(page: Page) -> None:
 
 
 async def test_should_be_able_to_generate_outline(
-    page: Page, server: Server, tmpdir: Path
+    page: Page, server: Server, tmp_path: Path
 ) -> None:
     await page.goto(server.PREFIX + "/headings.html")
-    output_file_no_outline = tmpdir / "outputNoOutline.pdf"
-    output_file_outline = tmpdir / "outputOutline.pdf"
+    output_file_no_outline = tmp_path / "outputNoOutline.pdf"
+    output_file_outline = tmp_path / "outputOutline.pdf"
     await page.pdf(path=output_file_no_outline)
     await page.pdf(path=output_file_outline, tagged=True, outline=True)
     assert os.path.getsize(output_file_outline) > os.path.getsize(

--- a/tests/async/test_tracing.py
+++ b/tests/async/test_tracing.py
@@ -87,7 +87,7 @@ async def test_should_collect_sources(
 
 
 async def test_should_collect_trace_with_resources_but_no_js(
-    context: BrowserContext, page: Page, server: Server, tmpdir: Path
+    context: BrowserContext, page: Page, server: Server, tmp_path: Path
 ) -> None:
     await context.tracing.start(screenshots=True, snapshots=True)
     await page.goto(server.PREFIX + "/frames/frame.html")
@@ -105,7 +105,7 @@ async def test_should_collect_trace_with_resources_but_no_js(
         server.PREFIX + "/one-style.html"
     )  # should not produce a route.continue_ entry since we continue all routes if no match.
     await page.close()
-    trace_file_path = tmpdir / "trace.zip"
+    trace_file_path = tmp_path / "trace.zip"
     await context.tracing.stop(path=trace_file_path)
 
     (_, events) = parse_trace(trace_file_path)
@@ -147,7 +147,7 @@ async def test_should_collect_trace_with_resources_but_no_js(
 
 
 async def test_should_correctly_determine_sync_apiname(
-    context: BrowserContext, page: Page, server: Server, tmpdir: Path
+    context: BrowserContext, page: Page, server: Server, tmp_path: Path
 ) -> None:
     await context.tracing.start(screenshots=True, snapshots=True)
 
@@ -162,7 +162,7 @@ async def test_should_correctly_determine_sync_apiname(
     await page.goto(server.PREFIX + "/grid.html")
     await received_response
     await page.close()
-    trace_file_path = tmpdir / "trace.zip"
+    trace_file_path = tmp_path / "trace.zip"
     await context.tracing.stop(path=trace_file_path)
 
     (_, events) = parse_trace(trace_file_path)
@@ -174,19 +174,19 @@ async def test_should_correctly_determine_sync_apiname(
 
 
 async def test_should_collect_two_traces(
-    context: BrowserContext, page: Page, server: Server, tmpdir: Path
+    context: BrowserContext, page: Page, server: Server, tmp_path: Path
 ) -> None:
     await context.tracing.start(screenshots=True, snapshots=True)
     await page.goto(server.EMPTY_PAGE)
     await page.set_content("<button>Click</button>")
     await page.click('"Click"')
-    tracing1_path = tmpdir / "trace1.zip"
+    tracing1_path = tmp_path / "trace1.zip"
     await context.tracing.stop(path=tracing1_path)
 
     await context.tracing.start(screenshots=True, snapshots=True)
     await page.dblclick('"Click"')
     await page.close()
-    tracing2_path = tmpdir / "trace2.zip"
+    tracing2_path = tmp_path / "trace2.zip"
     await context.tracing.stop(path=tracing2_path)
 
     (_, events) = parse_trace(tracing1_path)
@@ -209,7 +209,7 @@ async def test_should_not_throw_when_stopping_without_start_but_not_exporting(
 
 
 async def test_should_work_with_playwright_context_managers(
-    context: BrowserContext, page: Page, server: Server, tmpdir: Path
+    context: BrowserContext, page: Page, server: Server, tmp_path: Path
 ) -> None:
     await context.tracing.start(screenshots=True, snapshots=True)
     await page.goto(server.EMPTY_PAGE)
@@ -221,7 +221,7 @@ async def test_should_work_with_playwright_context_managers(
 
     async with page.expect_popup():
         await page.evaluate("window._popup = window.open(document.location.href)")
-    trace_file_path = tmpdir / "trace.zip"
+    trace_file_path = tmp_path / "trace.zip"
     await context.tracing.stop(path=trace_file_path)
 
     (_, events) = parse_trace(trace_file_path)
@@ -238,7 +238,7 @@ async def test_should_work_with_playwright_context_managers(
 
 
 async def test_should_display_wait_for_load_state_even_if_did_not_wait_for_it(
-    context: BrowserContext, page: Page, server: Server, tmpdir: Path
+    context: BrowserContext, page: Page, server: Server, tmp_path: Path
 ) -> None:
     await context.tracing.start(screenshots=True, snapshots=True)
 
@@ -246,7 +246,7 @@ async def test_should_display_wait_for_load_state_even_if_did_not_wait_for_it(
     await page.wait_for_load_state("load")
     await page.wait_for_load_state("load")
 
-    trace_file_path = tmpdir / "trace.zip"
+    trace_file_path = tmp_path / "trace.zip"
     await context.tracing.stop(path=trace_file_path)
 
     (_, events) = parse_trace(trace_file_path)
@@ -260,23 +260,23 @@ async def test_should_display_wait_for_load_state_even_if_did_not_wait_for_it(
 async def test_should_respect_traces_dir_and_name(
     browser_type: BrowserType,
     server: Server,
-    tmpdir: Path,
+    tmp_path: Path,
     launch_arguments: Dict,
 ) -> None:
-    traces_dir = tmpdir / "traces"
+    traces_dir = tmp_path / "traces"
     browser = await browser_type.launch(traces_dir=traces_dir, **launch_arguments)
     context = await browser.new_context()
     page = await context.new_page()
 
     await context.tracing.start(name="name1", snapshots=True)
     await page.goto(server.PREFIX + "/one-style.html")
-    await context.tracing.stop_chunk(path=tmpdir / "trace1.zip")
+    await context.tracing.stop_chunk(path=tmp_path / "trace1.zip")
     assert (traces_dir / "name1.trace").exists()
     assert (traces_dir / "name1.network").exists()
 
     await context.tracing.start_chunk(name="name2")
     await page.goto(server.PREFIX + "/har.html")
-    await context.tracing.stop(path=tmpdir / "trace2.zip")
+    await context.tracing.stop(path=tmp_path / "trace2.zip")
     assert (traces_dir / "name2.trace").exists()
     assert (traces_dir / "name2.network").exists()
 
@@ -290,7 +290,7 @@ async def test_should_respect_traces_dir_and_name(
             ]
         )
 
-    (resources, events) = parse_trace(tmpdir / "trace1.zip")
+    (resources, events) = parse_trace(tmp_path / "trace1.zip")
     assert get_trace_actions(events) == ["Page.goto"]
     assert resource_names(resources) == [
         "resources/XXX.css",
@@ -300,7 +300,7 @@ async def test_should_respect_traces_dir_and_name(
         "trace.trace",
     ]
 
-    (resources, events) = parse_trace(tmpdir / "trace2.zip")
+    (resources, events) = parse_trace(tmp_path / "trace2.zip")
     assert get_trace_actions(events) == ["Page.goto"]
     assert resource_names(resources) == [
         "resources/XXX.css",

--- a/tests/async/test_video.py
+++ b/tests/async/test_video.py
@@ -21,37 +21,37 @@ from tests.server import Server
 
 
 async def test_should_expose_video_path(
-    browser: Browser, tmpdir: Path, server: Server
+    browser: Browser, tmp_path: Path, server: Server
 ) -> None:
-    page = await browser.new_page(record_video_dir=tmpdir)
+    page = await browser.new_page(record_video_dir=tmp_path)
     await page.goto(server.PREFIX + "/grid.html")
     assert page.video
     path = await page.video.path()
-    assert str(tmpdir) in str(path)
+    assert str(tmp_path) in str(path)
     await page.context.close()
 
 
 async def test_short_video_should_throw(
-    browser: Browser, tmpdir: Path, server: Server
+    browser: Browser, tmp_path: Path, server: Server
 ) -> None:
-    page = await browser.new_page(record_video_dir=tmpdir)
+    page = await browser.new_page(record_video_dir=tmp_path)
     await page.goto(server.PREFIX + "/grid.html")
     assert page.video
     path = await page.video.path()
-    assert str(tmpdir) in str(path)
+    assert str(tmp_path) in str(path)
     await page.wait_for_timeout(1000)
     await page.context.close()
     assert os.path.exists(path)
 
 
 async def test_short_video_should_throw_persistent_context(
-    browser_type: BrowserType, tmpdir: Path, launch_arguments: Dict, server: Server
+    browser_type: BrowserType, tmp_path: Path, launch_arguments: Dict, server: Server
 ) -> None:
     context = await browser_type.launch_persistent_context(
-        str(tmpdir),
+        str(tmp_path),
         **launch_arguments,
         viewport={"width": 320, "height": 240},
-        record_video_dir=str(tmpdir) + "1",
+        record_video_dir=str(tmp_path) + "1",
     )
     page = context.pages[0]
     await page.goto(server.PREFIX + "/grid.html")
@@ -60,16 +60,16 @@ async def test_short_video_should_throw_persistent_context(
 
     assert page.video
     path = await page.video.path()
-    assert str(tmpdir) in str(path)
+    assert str(tmp_path) in str(path)
 
 
 async def test_should_not_error_if_page_not_closed_before_save_as(
-    browser: Browser, tmpdir: Path, server: Server
+    browser: Browser, tmp_path: Path, server: Server
 ) -> None:
-    page = await browser.new_page(record_video_dir=tmpdir)
+    page = await browser.new_page(record_video_dir=tmp_path)
     await page.goto(server.PREFIX + "/grid.html")
     await page.wait_for_timeout(1000)  # make sure video has some data
-    out_path = tmpdir / "some-video.webm"
+    out_path = tmp_path / "some-video.webm"
     assert page.video
     saved = page.video.save_as(out_path)
     await page.close()
@@ -79,7 +79,7 @@ async def test_should_not_error_if_page_not_closed_before_save_as(
 
 
 async def test_should_be_None_if_not_recording(
-    browser: Browser, tmpdir: Path, server: Server
+    browser: Browser, tmp_path: Path, server: Server
 ) -> None:
     page = await browser.new_page()
     assert page.video is None

--- a/tests/sync/test_browsercontext_storage_state.py
+++ b/tests/sync/test_browsercontext_storage_state.py
@@ -93,7 +93,7 @@ def test_should_set_local_storage(browser: Browser) -> None:
 
 
 def test_should_round_trip_through_the_file(
-    browser: Browser, context: BrowserContext, tmpdir: Path
+    browser: Browser, context: BrowserContext, tmp_path: Path
 ) -> None:
     page1 = context.new_page()
     page1.route(
@@ -109,7 +109,7 @@ def test_should_round_trip_through_the_file(
         }"""
     )
 
-    path = tmpdir / "storage-state.json"
+    path = tmp_path / "storage-state.json"
     state = context.storage_state(path=path)
     with open(path, "r") as f:
         written = json.load(f)

--- a/tests/sync/test_fetch_global.py
+++ b/tests/sync/test_fetch_global.py
@@ -236,7 +236,7 @@ def test_should_return_empty_body(playwright: Playwright, server: Server) -> Non
 
 
 def test_storage_state_should_round_trip_through_file(
-    playwright: Playwright, tmpdir: Path
+    playwright: Playwright, tmp_path: Path
 ) -> None:
     expected: StorageState = {
         "cookies": [
@@ -254,7 +254,7 @@ def test_storage_state_should_round_trip_through_file(
         "origins": [],
     }
     request = playwright.request.new_context(storage_state=expected)
-    path = tmpdir / "storage-state.json"
+    path = tmp_path / "storage-state.json"
     actual = request.storage_state(path=path)
     assert actual == expected
 

--- a/tests/sync/test_har.py
+++ b/tests/sync/test_har.py
@@ -25,8 +25,8 @@ from playwright.sync_api import Browser, BrowserContext, Error, Page, Route, exp
 from tests.server import Server
 
 
-def test_should_work(browser: Browser, server: Server, tmpdir: Path) -> None:
-    path = os.path.join(tmpdir, "log.har")
+def test_should_work(browser: Browser, server: Server, tmp_path: Path) -> None:
+    path = os.path.join(tmp_path, "log.har")
     context = browser.new_context(record_har_path=path)
     page = context.new_page()
     page.goto(server.EMPTY_PAGE)
@@ -36,8 +36,8 @@ def test_should_work(browser: Browser, server: Server, tmpdir: Path) -> None:
         assert "log" in data
 
 
-def test_should_omit_content(browser: Browser, server: Server, tmpdir: Path) -> None:
-    path = os.path.join(tmpdir, "log.har")
+def test_should_omit_content(browser: Browser, server: Server, tmp_path: Path) -> None:
+    path = os.path.join(tmp_path, "log.har")
     context = browser.new_context(record_har_path=path, record_har_content="omit")
     page = context.new_page()
     page.goto(server.PREFIX + "/har.html")
@@ -53,9 +53,9 @@ def test_should_omit_content(browser: Browser, server: Server, tmpdir: Path) -> 
 
 
 def test_should_omit_content_legacy(
-    browser: Browser, server: Server, tmpdir: Path
+    browser: Browser, server: Server, tmp_path: Path
 ) -> None:
-    path = os.path.join(tmpdir, "log.har")
+    path = os.path.join(tmp_path, "log.har")
     context = browser.new_context(record_har_path=path, record_har_omit_content=True)
     page = context.new_page()
     page.goto(server.PREFIX + "/har.html")
@@ -70,8 +70,10 @@ def test_should_omit_content_legacy(
         assert "encoding" not in content1
 
 
-def test_should_attach_content(browser: Browser, server: Server, tmpdir: Path) -> None:
-    path = os.path.join(tmpdir, "log.har.zip")
+def test_should_attach_content(
+    browser: Browser, server: Server, tmp_path: Path
+) -> None:
+    path = os.path.join(tmp_path, "log.har.zip")
     context = browser.new_context(
         record_har_path=path,
         record_har_content="attach",
@@ -127,8 +129,10 @@ def test_should_attach_content(browser: Browser, server: Server, tmpdir: Path) -
                 assert len(f.read()) == entries[2]["response"]["content"]["size"]
 
 
-def test_should_include_content(browser: Browser, server: Server, tmpdir: Path) -> None:
-    path = os.path.join(tmpdir, "log.har")
+def test_should_include_content(
+    browser: Browser, server: Server, tmp_path: Path
+) -> None:
+    path = os.path.join(tmp_path, "log.har")
     context = browser.new_context(record_har_path=path)
     page = context.new_page()
     page.goto(server.PREFIX + "/har.html")
@@ -144,9 +148,9 @@ def test_should_include_content(browser: Browser, server: Server, tmpdir: Path) 
 
 
 def test_should_default_to_full_mode(
-    browser: Browser, server: Server, tmpdir: Path
+    browser: Browser, server: Server, tmp_path: Path
 ) -> None:
-    path = os.path.join(tmpdir, "log.har")
+    path = os.path.join(tmp_path, "log.har")
     context = browser.new_context(
         record_har_path=path,
     )
@@ -161,9 +165,9 @@ def test_should_default_to_full_mode(
 
 
 def test_should_support_minimal_mode(
-    browser: Browser, server: Server, tmpdir: Path
+    browser: Browser, server: Server, tmp_path: Path
 ) -> None:
-    path = os.path.join(tmpdir, "log.har")
+    path = os.path.join(tmp_path, "log.har")
     context = browser.new_context(
         record_har_path=path,
         record_har_mode="minimal",
@@ -178,8 +182,8 @@ def test_should_support_minimal_mode(
         assert log["entries"][0]["request"]["bodySize"] == -1
 
 
-def test_should_filter_by_glob(browser: Browser, server: Server, tmpdir: str) -> None:
-    path = os.path.join(tmpdir, "log.har")
+def test_should_filter_by_glob(browser: Browser, server: Server, tmp_path: str) -> None:
+    path = os.path.join(tmp_path, "log.har")
     context = browser.new_context(
         base_url=server.PREFIX,
         record_har_path=path,
@@ -197,8 +201,10 @@ def test_should_filter_by_glob(browser: Browser, server: Server, tmpdir: str) ->
         assert log["entries"][0]["request"]["url"].endswith("one-style.css")
 
 
-def test_should_filter_by_regexp(browser: Browser, server: Server, tmpdir: str) -> None:
-    path = os.path.join(tmpdir, "log.har")
+def test_should_filter_by_regexp(
+    browser: Browser, server: Server, tmp_path: str
+) -> None:
+    path = os.path.join(tmp_path, "log.har")
     context = browser.new_context(
         base_url=server.PREFIX,
         record_har_path=path,
@@ -270,9 +276,9 @@ def test_by_default_should_abort_requests_not_found_in_har(
 
 
 def test_fallback_continue_should_continue_requests_on_bad_har(
-    context: BrowserContext, server: Server, tmpdir: Path
+    context: BrowserContext, server: Server, tmp_path: Path
 ) -> None:
-    path_to_invalid_har = tmpdir / "invalid.har"
+    path_to_invalid_har = tmp_path / "invalid.har"
     with path_to_invalid_har.open("w") as f:
         json.dump({"log": {}}, f)
     context.route_from_har(har=path_to_invalid_har, not_found="fallback")
@@ -423,9 +429,9 @@ def test_should_fulfill_from_har_with_content_in_a_file(
 
 
 def test_should_round_trip_har_zip(
-    browser: Browser, server: Server, tmpdir: Path
+    browser: Browser, server: Server, tmp_path: Path
 ) -> None:
-    har_path = tmpdir / "har.zip"
+    har_path = tmp_path / "har.zip"
     context_1 = browser.new_context(record_har_mode="minimal", record_har_path=har_path)
     page_1 = context_1.new_page()
     page_1.goto(server.PREFIX + "/one-style.html")
@@ -440,7 +446,7 @@ def test_should_round_trip_har_zip(
 
 
 def test_should_round_trip_har_with_post_data(
-    browser: Browser, server: Server, tmpdir: Path
+    browser: Browser, server: Server, tmp_path: Path
 ) -> None:
     server.set_route(
         "/echo", lambda req: (req.write(cast(Any, req).post_body), req.finish())
@@ -451,7 +457,7 @@ def test_should_round_trip_har_with_post_data(
             return response.text();
         };
     """
-    har_path = tmpdir / "har.zip"
+    har_path = tmp_path / "har.zip"
     context_1 = browser.new_context(record_har_mode="minimal", record_har_path=har_path)
     page_1 = context_1.new_page()
     page_1.goto(server.EMPTY_PAGE)
@@ -473,7 +479,7 @@ def test_should_round_trip_har_with_post_data(
 
 
 def test_should_disambiguate_by_header(
-    browser: Browser, server: Server, tmpdir: Path
+    browser: Browser, server: Server, tmp_path: Path
 ) -> None:
     server.set_route(
         "/echo",
@@ -493,7 +499,7 @@ def test_should_disambiguate_by_header(
             return response.text();
         };
     """
-    har_path = tmpdir / "har.zip"
+    har_path = tmp_path / "har.zip"
     context_1 = browser.new_context(record_har_mode="minimal", record_har_path=har_path)
     page_1 = context_1.new_page()
     page_1.goto(server.EMPTY_PAGE)
@@ -514,9 +520,9 @@ def test_should_disambiguate_by_header(
 
 
 def test_should_produce_extracted_zip(
-    browser: Browser, server: Server, tmpdir: Path
+    browser: Browser, server: Server, tmp_path: Path
 ) -> None:
-    har_path = tmpdir / "har.har"
+    har_path = tmp_path / "har.har"
     context = browser.new_context(
         record_har_mode="minimal", record_har_path=har_path, record_har_content="attach"
     )
@@ -539,9 +545,9 @@ def test_should_produce_extracted_zip(
 
 
 def test_should_update_har_zip_for_context(
-    browser: Browser, server: Server, tmpdir: Path
+    browser: Browser, server: Server, tmp_path: Path
 ) -> None:
-    har_path = tmpdir / "har.zip"
+    har_path = tmp_path / "har.zip"
     context = browser.new_context()
     context.route_from_har(har_path, update=True)
     page_1 = context.new_page()
@@ -559,9 +565,9 @@ def test_should_update_har_zip_for_context(
 
 
 def test_should_update_har_zip_for_page(
-    browser: Browser, server: Server, tmpdir: Path
+    browser: Browser, server: Server, tmp_path: Path
 ) -> None:
-    har_path = tmpdir / "har.zip"
+    har_path = tmp_path / "har.zip"
     context = browser.new_context()
     page_1 = context.new_page()
     page_1.route_from_har(har_path, update=True)
@@ -579,9 +585,9 @@ def test_should_update_har_zip_for_page(
 
 
 def test_should_update_har_zip_for_page_with_different_options(
-    browser: Browser, server: Server, tmpdir: Path
+    browser: Browser, server: Server, tmp_path: Path
 ) -> None:
-    har_path = tmpdir / "har.zip"
+    har_path = tmp_path / "har.zip"
     context1 = browser.new_context()
     page1 = context1.new_page()
     page1.route_from_har(
@@ -600,9 +606,9 @@ def test_should_update_har_zip_for_page_with_different_options(
 
 
 def test_should_update_extracted_har_zip_for_page(
-    browser: Browser, server: Server, tmpdir: Path
+    browser: Browser, server: Server, tmp_path: Path
 ) -> None:
-    har_path = tmpdir / "har.har"
+    har_path = tmp_path / "har.har"
     context = browser.new_context()
     page_1 = context.new_page()
     page_1.route_from_har(har_path, update=True)

--- a/tests/sync/test_launcher.py
+++ b/tests/sync/test_launcher.py
@@ -93,7 +93,7 @@ def test_browser_close_should_be_callable_twice(
 @pytest.mark.only_browser("chromium")
 def test_browser_launch_should_return_background_pages(
     browser_type: BrowserType,
-    tmpdir: Path,
+    tmp_path: Path,
     browser_channel: Optional[str],
     assetdir: Path,
     launch_arguments: Dict,
@@ -103,7 +103,7 @@ def test_browser_launch_should_return_background_pages(
 
     extension_path = str(assetdir / "simple-extension")
     context = browser_type.launch_persistent_context(
-        str(tmpdir),
+        str(tmp_path),
         **{
             **launch_arguments,
             "headless": False,

--- a/tests/sync/test_pdf.py
+++ b/tests/sync/test_pdf.py
@@ -21,8 +21,8 @@ from playwright.sync_api import Page
 
 
 @pytest.mark.only_browser("chromium")
-def test_should_be_able_to_save_pdf_file(page: Page, tmpdir: Path) -> None:
-    output_file = tmpdir / "foo.png"
+def test_should_be_able_to_save_pdf_file(page: Page, tmp_path: Path) -> None:
+    output_file = tmp_path / "foo.png"
     page.pdf(path=str(output_file))
     assert os.path.getsize(output_file) > 0
 

--- a/tests/sync/test_tracing.py
+++ b/tests/sync/test_tracing.py
@@ -80,7 +80,7 @@ def test_should_collect_sources(
 
 
 def test_should_collect_trace_with_resources_but_no_js(
-    context: BrowserContext, page: Page, server: Server, tmpdir: Path
+    context: BrowserContext, page: Page, server: Server, tmp_path: Path
 ) -> None:
     context.tracing.start(screenshots=True, snapshots=True)
     page.goto(server.PREFIX + "/frames/frame.html")
@@ -98,7 +98,7 @@ def test_should_collect_trace_with_resources_but_no_js(
         server.PREFIX + "/one-style.html"
     )  # should not produce a route.continue_ entry since we continue all routes if no match.
     page.close()
-    trace_file_path = tmpdir / "trace.zip"
+    trace_file_path = tmp_path / "trace.zip"
     context.tracing.stop(path=trace_file_path)
 
     (_, events) = parse_trace(trace_file_path)
@@ -140,7 +140,7 @@ def test_should_collect_trace_with_resources_but_no_js(
 
 
 def test_should_correctly_determine_sync_apiname(
-    context: BrowserContext, page: Page, server: Server, tmpdir: Path
+    context: BrowserContext, page: Page, server: Server, tmp_path: Path
 ) -> None:
     context.tracing.start(screenshots=True, snapshots=True)
     received_response = threading.Event()
@@ -155,7 +155,7 @@ def test_should_correctly_determine_sync_apiname(
     received_response.wait()
 
     page.close()
-    trace_file_path = tmpdir / "trace.zip"
+    trace_file_path = tmp_path / "trace.zip"
     context.tracing.stop(path=trace_file_path)
 
     (_, events) = parse_trace(trace_file_path)
@@ -167,19 +167,19 @@ def test_should_correctly_determine_sync_apiname(
 
 
 def test_should_collect_two_traces(
-    context: BrowserContext, page: Page, server: Server, tmpdir: Path
+    context: BrowserContext, page: Page, server: Server, tmp_path: Path
 ) -> None:
     context.tracing.start(screenshots=True, snapshots=True)
     page.goto(server.EMPTY_PAGE)
     page.set_content("<button>Click</button>")
     page.click('"Click"')
-    tracing1_path = tmpdir / "trace1.zip"
+    tracing1_path = tmp_path / "trace1.zip"
     context.tracing.stop(path=tracing1_path)
 
     context.tracing.start(screenshots=True, snapshots=True)
     page.dblclick('"Click"')
     page.close()
-    tracing2_path = tmpdir / "trace2.zip"
+    tracing2_path = tmp_path / "trace2.zip"
     context.tracing.stop(path=tracing2_path)
 
     (_, events) = parse_trace(tracing1_path)
@@ -202,7 +202,7 @@ def test_should_not_throw_when_stopping_without_start_but_not_exporting(
 
 
 def test_should_work_with_playwright_context_managers(
-    context: BrowserContext, page: Page, server: Server, tmpdir: Path
+    context: BrowserContext, page: Page, server: Server, tmp_path: Path
 ) -> None:
     context.tracing.start(screenshots=True, snapshots=True)
     page.goto(server.EMPTY_PAGE)
@@ -214,7 +214,7 @@ def test_should_work_with_playwright_context_managers(
 
     with page.expect_popup():
         page.evaluate("window._popup = window.open(document.location.href)")
-    trace_file_path = tmpdir / "trace.zip"
+    trace_file_path = tmp_path / "trace.zip"
     context.tracing.stop(path=trace_file_path)
 
     (_, events) = parse_trace(trace_file_path)
@@ -231,7 +231,7 @@ def test_should_work_with_playwright_context_managers(
 
 
 def test_should_display_wait_for_load_state_even_if_did_not_wait_for_it(
-    context: BrowserContext, page: Page, server: Server, tmpdir: Path
+    context: BrowserContext, page: Page, server: Server, tmp_path: Path
 ) -> None:
     context.tracing.start(screenshots=True, snapshots=True)
 
@@ -239,7 +239,7 @@ def test_should_display_wait_for_load_state_even_if_did_not_wait_for_it(
     page.wait_for_load_state("load")
     page.wait_for_load_state("load")
 
-    trace_file_path = tmpdir / "trace.zip"
+    trace_file_path = tmp_path / "trace.zip"
     context.tracing.stop(path=trace_file_path)
 
     (_, events) = parse_trace(trace_file_path)
@@ -253,23 +253,23 @@ def test_should_display_wait_for_load_state_even_if_did_not_wait_for_it(
 def test_should_respect_traces_dir_and_name(
     browser_type: BrowserType,
     server: Server,
-    tmpdir: Path,
+    tmp_path: Path,
     launch_arguments: Any,
 ) -> None:
-    traces_dir = tmpdir / "traces"
+    traces_dir = tmp_path / "traces"
     browser = browser_type.launch(traces_dir=traces_dir, **launch_arguments)
     context = browser.new_context()
     page = context.new_page()
 
     context.tracing.start(name="name1", snapshots=True)
     page.goto(server.PREFIX + "/one-style.html")
-    context.tracing.stop_chunk(path=tmpdir / "trace1.zip")
+    context.tracing.stop_chunk(path=tmp_path / "trace1.zip")
     assert (traces_dir / "name1.trace").exists()
     assert (traces_dir / "name1.network").exists()
 
     context.tracing.start_chunk(name="name2")
     page.goto(server.PREFIX + "/har.html")
-    context.tracing.stop(path=tmpdir / "trace2.zip")
+    context.tracing.stop(path=tmp_path / "trace2.zip")
     assert (traces_dir / "name2.trace").exists()
     assert (traces_dir / "name2.network").exists()
 
@@ -283,7 +283,7 @@ def test_should_respect_traces_dir_and_name(
             ]
         )
 
-    (resources, events) = parse_trace(tmpdir / "trace1.zip")
+    (resources, events) = parse_trace(tmp_path / "trace1.zip")
     assert get_trace_actions(events) == ["Page.goto"]
     assert resource_names(resources) == [
         "resources/XXX.css",
@@ -293,7 +293,7 @@ def test_should_respect_traces_dir_and_name(
         "trace.trace",
     ]
 
-    (resources, events) = parse_trace(tmpdir / "trace2.zip")
+    (resources, events) = parse_trace(tmp_path / "trace2.zip")
     assert get_trace_actions(events) == ["Page.goto"]
     assert resource_names(resources) == [
         "resources/XXX.css",

--- a/tests/sync/test_video.py
+++ b/tests/sync/test_video.py
@@ -23,85 +23,85 @@ from tests.server import Server
 
 
 def test_should_expose_video_path(
-    browser: Browser, tmpdir: Path, server: Server
+    browser: Browser, tmp_path: Path, server: Server
 ) -> None:
     page = browser.new_page(
-        record_video_dir=tmpdir, record_video_size={"width": 100, "height": 200}
+        record_video_dir=tmp_path, record_video_size={"width": 100, "height": 200}
     )
     page.goto(server.PREFIX + "/grid.html")
     video = page.video
     assert video
     path = video.path()
     assert repr(page.video) == f"<Video page={page}>"
-    assert str(tmpdir) in str(path)
+    assert str(tmp_path) in str(path)
     page.wait_for_timeout(1000)
     page.context.close()
 
 
-def test_video_should_exist(browser: Browser, tmpdir: Path, server: Server) -> None:
-    page = browser.new_page(record_video_dir=tmpdir)
+def test_video_should_exist(browser: Browser, tmp_path: Path, server: Server) -> None:
+    page = browser.new_page(record_video_dir=tmp_path)
     page.goto(server.PREFIX + "/grid.html")
     video = page.video
     assert video
     path = video.path()
-    assert str(tmpdir) in str(path)
+    assert str(tmp_path) in str(path)
     page.wait_for_timeout(1000)
     page.context.close()
     assert os.path.exists(path)
 
 
-def test_record_video_to_path(browser: Browser, tmpdir: Path, server: Server) -> None:
-    page = browser.new_page(record_video_dir=tmpdir)
+def test_record_video_to_path(browser: Browser, tmp_path: Path, server: Server) -> None:
+    page = browser.new_page(record_video_dir=tmp_path)
     page.goto(server.PREFIX + "/grid.html")
     video = page.video
     assert video
     path = video.path()
-    assert str(tmpdir) in str(path)
+    assert str(tmp_path) in str(path)
     page.wait_for_timeout(1000)
     page.context.close()
     assert os.path.exists(path)
 
 
 def test_record_video_to_path_persistent(
-    browser_type: BrowserType, tmpdir: Path, server: Server, launch_arguments: Dict
+    browser_type: BrowserType, tmp_path: Path, server: Server, launch_arguments: Dict
 ) -> None:
     context = browser_type.launch_persistent_context(
-        tmpdir, **launch_arguments, record_video_dir=tmpdir
+        tmp_path, **launch_arguments, record_video_dir=tmp_path
     )
     page = context.pages[0]
     page.goto(server.PREFIX + "/grid.html")
     video = page.video
     assert video
     path = video.path()
-    assert str(tmpdir) in str(path)
+    assert str(tmp_path) in str(path)
     page.wait_for_timeout(1000)
     context.close()
     assert os.path.exists(path)
 
 
 def test_record_video_can_get_video_path_immediately(
-    browser_type: BrowserType, tmpdir: Path, launch_arguments: Dict
+    browser_type: BrowserType, tmp_path: Path, launch_arguments: Dict
 ) -> None:
     context = browser_type.launch_persistent_context(
-        tmpdir, **launch_arguments, record_video_dir=tmpdir
+        tmp_path, **launch_arguments, record_video_dir=tmp_path
     )
     page = context.pages[0]
     video = page.video
     assert video
     path = video.path()
-    assert str(tmpdir) in str(path)
+    assert str(tmp_path) in str(path)
     page.wait_for_timeout(1000)
     context.close()
     assert os.path.exists(path)
 
 
 def test_should_error_if_page_not_closed_before_save_as(
-    browser: Browser, tmpdir: Path, server: Server
+    browser: Browser, tmp_path: Path, server: Server
 ) -> None:
-    page = browser.new_page(record_video_dir=tmpdir)
+    page = browser.new_page(record_video_dir=tmp_path)
     page.goto(server.PREFIX + "/grid.html")
     page.wait_for_timeout(1000)  # Give it some time to record.
-    out_path = tmpdir / "some-video.webm"
+    out_path = tmp_path / "some-video.webm"
     with pytest.raises(Error) as err:
         video = page.video
         assert video


### PR DESCRIPTION
Before we were using this:

https://github.com/pytest-dev/pytest/blob/9e9633de9da7a9fab03b4bba3a326bf85b412050/src/_pytest/legacypath.py#L306-L320

We should use this instead:

https://github.com/pytest-dev/pytest/blob/9e9633de9da7a9fab03b4bba3a326bf85b412050/src/_pytest/tmpdir.py#L258-L263

The old one didn't use 'Path' instances which makes trouble sometimes.