### PR TITLE
fix(api): ignore deprecated timeout arg provided to is_visible/hidden

### DIFF
--- a/playwright/_impl/_locator.py
+++ b/playwright/_impl/_locator.py
@@ -501,19 +501,17 @@ class Locator:
         )
 
     async def is_hidden(self, timeout: float = None) -> bool:
-        params = locals_to_params(locals())
+        # timeout is deprecated and does nothing
         return await self._frame.is_hidden(
             self._selector,
             strict=True,
-            **params,
         )
 
     async def is_visible(self, timeout: float = None) -> bool:
-        params = locals_to_params(locals())
+        # timeout is deprecated and does nothing
         return await self._frame.is_visible(
             self._selector,
             strict=True,
-            **params,
         )
 
     async def press(

--- a/playwright/_impl/_page.py
+++ b/playwright/_impl/_page.py
@@ -447,12 +447,14 @@ class Page(ChannelOwner):
     async def is_hidden(
         self, selector: str, strict: bool = None, timeout: float = None
     ) -> bool:
-        return await self._main_frame.is_hidden(**locals_to_params(locals()))
+        # timeout is deprecated and does nothing
+        return await self._main_frame.is_hidden(selector=selector, strict=strict)
 
     async def is_visible(
         self, selector: str, strict: bool = None, timeout: float = None
     ) -> bool:
-        return await self._main_frame.is_visible(**locals_to_params(locals()))
+        # timeout is deprecated and does nothing
+        return await self._main_frame.is_visible(selector=selector, strict=strict)
 
     async def dispatch_event(
         self,

--- a/tests/async/test_locators.py
+++ b/tests/async/test_locators.py
@@ -1143,3 +1143,12 @@ async def test_locator_click_timeout_error_should_contain_call_log(page: Page) -
         "During handling of the above exception, another exception occurred"
         not in formatted_exception
     )
+
+
+async def test_locator_should_ignore_deprecated_is_hidden_and_visible_timeout(
+    page: Page,
+) -> None:
+    await page.set_content("<div>foo</div>")
+    div = page.locator("div")
+    assert await div.is_hidden(timeout=10) is False
+    assert await div.is_visible(timeout=10) is True

--- a/tests/async/test_page.py
+++ b/tests/async/test_page.py
@@ -1451,3 +1451,11 @@ async def test_page_pause_should_reset_custom_timeouts(
     server.set_route("/empty.html", lambda route: None)
     with pytest.raises(Error, match="Timeout 456ms exceeded."):
         await page.goto(server.EMPTY_PAGE)
+
+
+async def test_page_should_ignore_deprecated_is_hidden_and_visible_timeout(
+    page: Page,
+) -> None:
+    await page.set_content("<div>foo</div>")
+    assert await page.is_hidden("div", timeout=10) is False
+    assert await page.is_visible("div", timeout=10) is True

--- a/tests/sync/test_locators.py
+++ b/tests/sync/test_locators.py
@@ -997,3 +997,12 @@ def test_locator_click_timeout_error_should_contain_call_log(page: Page) -> None
         "During handling of the above exception, another exception occurred"
         not in formatted_exception
     )
+
+
+def test_locator_should_ignore_deprecated_is_hidden_and_visible_timeout(
+    page: Page,
+) -> None:
+    page.set_content("<div>foo</div>")
+    div = page.locator("div")
+    assert div.is_hidden(timeout=10) is False
+    assert div.is_visible(timeout=10) is True

--- a/tests/sync/test_page.py
+++ b/tests/sync/test_page.py
@@ -114,3 +114,11 @@ def test_page_pause_should_reset_custom_timeouts(
     server.set_route("/empty.html", lambda route: None)
     with pytest.raises(Error, match="Timeout 456ms exceeded."):
         page.goto(server.EMPTY_PAGE)
+
+
+def test_page_should_ignore_deprecated_is_hidden_and_visible_timeout(
+    page: Page,
+) -> None:
+    page.set_content("<div>foo</div>")
+    assert page.is_hidden("div", timeout=10) is False
+    assert page.is_visible("div", timeout=10) is True


### PR DESCRIPTION
Fixes #2904 

Ignore `timeout` args passed to any `is_visible()`/`is_hidden()` call.