### PR TITLE
fix: Make context manager __exit__/__aexit__ signatures compatible with typing protocols

### DIFF
--- a/playwright/_impl/_async_base.py
+++ b/playwright/_impl/_async_base.py
@@ -96,9 +96,9 @@ class AsyncContextManager(AsyncBase):
 
     async def __aexit__(
         self,
-        exc_type: Type[BaseException],
-        exc_val: BaseException,
-        traceback: TracebackType,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        traceback: Optional[TracebackType],
     ) -> None:
         await self.close()
 

--- a/playwright/_impl/_sync_base.py
+++ b/playwright/_impl/_sync_base.py
@@ -142,9 +142,9 @@ class SyncContextManager(SyncBase):
 
     def __exit__(
         self,
-        exc_type: Type[BaseException],
-        exc_val: BaseException,
-        _traceback: TracebackType,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        _traceback: Optional[TracebackType],
     ) -> None:
         self.close()
 


### PR DESCRIPTION
Updates `AsyncContextManager.__aexit__` and `SyncContextManager.__exit__` to use Optional types for exception parameters (exc_type, exc_val, traceback) to match the standard Python typing protocols.

This aligns with the official type definitions in typeshed where AbstractContextManager and AbstractAsyncContextManager define these parameters as Optional since they are None when no exception occurs.

Ref: https://github.com/python/typeshed/blob/9317dc62bd4fb46b8b48ce5353286cab80308d47/stdlib/contextlib.pyi#L52-L54

Fixes type checker compatibility issues when using BrowserContext with type checkers that enforce strict protocol compliance.

Fixes https://github.com/microsoft/playwright-python/issues/2856