### PR TITLE
test: unflake test_context_add_cookies_should_work

### DIFF
--- a/tests/async/test_defaultbrowsercontext.py
+++ b/tests/async/test_defaultbrowsercontext.py
@@ -111,7 +111,7 @@ async def test_context_add_cookies_should_work(
         ]
     )
     assert await page.evaluate("() => document.cookie") == "username=John Doe"
-    assert await page.context.cookies() == [
+    assert _filter_cookies(await page.context.cookies()) == [
         {
             "name": "username",
             "value": "John Doe",
@@ -127,7 +127,7 @@ async def test_context_add_cookies_should_work(
 
 def _filter_cookies(cookies: Sequence[Cookie]) -> List[Cookie]:
     return list(
-        filter(lambda cookie: cookie["domain"] != "copilot.microsoft.com", cookies)
+        filter(lambda cookie: not cookie["domain"].endswith("microsoft.com"), cookies)
     )
 
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-python/actions/runs/16744062888/job/47398320653?pr=2934#step:8:1601

Similar like we do upstream. We forgot to add the filter call in another test.

Drive-by: Align how we filter to how we do it upstream.