### PR TITLE
fix: screenshot type inferred from path file extension

### DIFF
--- a/playwright/_impl/_element_handle.py
+++ b/playwright/_impl/_element_handle.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import base64
+import mimetypes
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -323,6 +324,8 @@ class ElementHandle(JSHandle):
     ) -> bytes:
         params = locals_to_params(locals())
         if "path" in params:
+            if "type" not in params:
+                params["type"] = determine_screenshot_type(params["path"])
             del params["path"]
         if "mask" in params:
             params["mask"] = list(
@@ -450,3 +453,12 @@ def convert_select_option_values(
         elements = list(map(lambda e: e._channel, element))
 
     return dict(options=options, elements=elements)
+
+
+def determine_screenshot_type(path: Union[str, Path]) -> Literal["jpeg", "png"]:
+    mime_type, _ = mimetypes.guess_type(path)
+    if mime_type == "image/png":
+        return "png"
+    if mime_type == "image/jpeg":
+        return "jpeg"
+    raise Error(f'Unsupported screenshot mime type for path "{path}": {mime_type}')

--- a/playwright/_impl/_page.py
+++ b/playwright/_impl/_page.py
@@ -51,7 +51,7 @@ from playwright._impl._connection import (
 )
 from playwright._impl._console_message import ConsoleMessage
 from playwright._impl._download import Download
-from playwright._impl._element_handle import ElementHandle
+from playwright._impl._element_handle import ElementHandle, determine_screenshot_type
 from playwright._impl._errors import Error, TargetClosedError, is_target_closed_error
 from playwright._impl._event_context_manager import EventContextManagerImpl
 from playwright._impl._file_chooser import FileChooser
@@ -800,6 +800,8 @@ class Page(ChannelOwner):
     ) -> bytes:
         params = locals_to_params(locals())
         if "path" in params:
+            if "type" not in params:
+                params["type"] = determine_screenshot_type(params["path"])
             del params["path"]
         if "mask" in params:
             params["mask"] = list(


### PR DESCRIPTION
The screenshot methods for both element and page do not really infer file type from path file extension if `type` is not provided. I tried some name like 'xxx.jpeg' without `type` in arguments, the generated file format was actually png.
This pull request is trying to fix this.