### PR TITLE
chore: throw FileNotFoundError for nonexistant files

### DIFF
--- a/playwright/_impl/_set_input_files_helpers.py
+++ b/playwright/_impl/_set_input_files_helpers.py
@@ -14,6 +14,7 @@
 import base64
 import collections.abc
 import os
+import stat
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -144,7 +145,8 @@ def resolve_paths_and_directory_for_input_files(
     local_paths: Optional[List[str]] = None
     local_directory: Optional[str] = None
     for item in items:
-        if os.path.isdir(item):
+        item_stat = os.stat(item)  # Raises FileNotFoundError if doesn't exist
+        if stat.S_ISDIR(item_stat.st_mode):
             if local_directory:
                 raise Error("Multiple directories are not supported")
             local_directory = str(Path(item).resolve())

--- a/tests/sync/test_locators.py
+++ b/tests/sync/test_locators.py
@@ -327,6 +327,12 @@ def test_locators_should_upload_a_file(page: Page, server: Server) -> None:
     )
 
 
+def test_locators_upload_nonexistant_file(page: Page, server: Server) -> None:
+    page.goto(server.PREFIX + "/input/fileupload.html")
+    with pytest.raises(FileNotFoundError):
+        page.locator("input[type=file]").set_input_files("nonexistant.html")
+
+
 def test_locators_should_press(page: Page) -> None:
     page.set_content("<input type='text' />")
     page.locator("input").press("h")


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/38450. We were only checking file existence on the server (https://github.com/microsoft/playwright/blob/f9e039408b70ab27b5107de3863343236d8835ae/packages/playwright-core/src/server/dom.ts#L655-L657), but didn't surface the error, so it showed up as a timeout. In Node.js, we check file existence on the client (https://github.com/microsoft/playwright/blob/f9e039408b70ab27b5107de3863343236d8835ae/packages/playwright-core/src/client/elementHandle.ts#L263), mirroring this behaviour to Python.