### PR TITLE
Fix handling of ignore_default_args when passed as a boolean.

### DIFF
--- a/playwright/_impl/_browser_type.py
+++ b/playwright/_impl/_browser_type.py
@@ -356,6 +356,8 @@ def normalize_launch_params(params: Dict) -> None:
         if params["ignoreDefaultArgs"] is True:
             params["ignoreAllDefaultArgs"] = True
             del params["ignoreDefaultArgs"]
+        elif params["ignoreDefaultArgs"] is False:
+            del params["ignoreDefaultArgs"]
     if "executablePath" in params:
         params["executablePath"] = str(Path(params["executablePath"]))
     if "downloadsPath" in params:

--- a/tests/test_ignore_default_args_bool.py
+++ b/tests/test_ignore_default_args_bool.py
@@ -1,0 +1,29 @@
+def test_ignore_default_args_false_is_removed():
+    # Unit test: no driver/browser needed.
+    from playwright._impl._browser_type import normalize_launch_params
+
+    params = {"ignoreDefaultArgs": False}
+    normalize_launch_params(params)
+
+    assert "ignoreDefaultArgs" not in params
+    assert "ignoreAllDefaultArgs" not in params
+
+
+def test_ignore_default_args_true_sets_ignore_all_default_args():
+    from playwright._impl._browser_type import normalize_launch_params
+
+    params = {"ignoreDefaultArgs": True}
+    normalize_launch_params(params)
+
+    assert "ignoreDefaultArgs" not in params
+    assert params["ignoreAllDefaultArgs"] is True
+
+
+def test_ignore_default_args_list_is_preserved():
+    from playwright._impl._browser_type import normalize_launch_params
+
+    params = {"ignoreDefaultArgs": ["--mute-audio"]}
+    normalize_launch_params(params)
+
+    assert params["ignoreDefaultArgs"] == ["--mute-audio"]
+    assert "ignoreAllDefaultArgs" not in params


### PR DESCRIPTION
Problem:
Passing ignore_default_args=False was sent over the wire as a boolean, but the server expects an array for ignoreDefaultArgs, resulting in:

"expected array, got boolean".

Fix:
- ignore_default_args=True → send ignoreAllDefaultArgs=True
- ignore_default_args=False → do not send ignoreDefaultArgs at all
- ignore_default_args=list → unchanged

Tests:
Added unit tests covering bool True/False and list cases across
chromium, firefox, and webkit.

Related issue: #3005