### PR TITLE
Add support for string arrays in multipart fields

### DIFF
--- a/playwright/_impl/_fetch.py
+++ b/playwright/_impl/_fetch.py
@@ -40,6 +40,7 @@ from playwright._impl._helper import (
     async_readfile,
     async_writefile,
     is_file_payload,
+    is_file_array_payload,
     locals_to_params,
     object_to_array,
     to_impl,
@@ -394,6 +395,14 @@ class APIRequestContext(ChannelOwner):
                     multipart_data.append(
                         FormField(name=name, file=file_payload_to_json(payload))
                     )
+                elif is_file_array_payload(value):
+                    for item in value:
+                        payload = cast(FilePayload, item)
+                        assert isinstance(payload["buffer"], bytes)
+                        multipart_data.append(FormField(name=name, file=file_payload_to_json(payload)))
+                elif isinstance(value, list):
+                    for item in value:
+                        multipart_data.append(FormField(name=name, value=str(item)))
                 elif isinstance(value, str):
                     multipart_data.append(FormField(name=name, value=value))
         if (

--- a/playwright/_impl/_helper.py
+++ b/playwright/_impl/_helper.py
@@ -561,6 +561,9 @@ def is_file_payload(value: Optional[Any]) -> bool:
         and "buffer" in value
     )
 
+def is_file_array_payload(value: Optional[Any]) -> bool:
+    return isinstance(value, list) and all(is_file_payload(x) for x in value)
+
 
 TEXTUAL_MIME_TYPE = re.compile(
     r"^(text\/.*?|application\/(json|(x-)?javascript|xml.*?|ecmascript|graphql|x-www-form-urlencoded)|image\/svg(\+xml)?|application\/.*?(\+json|\+xml))(;\s*charset=.*)?$"

--- a/playwright/async_api/_generated.py
+++ b/playwright/async_api/_generated.py
@@ -18229,9 +18229,7 @@ class APIRequestContext(AsyncBase):
         headers: typing.Optional[typing.Dict[str, str]] = None,
         data: typing.Optional[typing.Union[typing.Any, str, bytes]] = None,
         form: typing.Optional[typing.Dict[str, typing.Union[str, float, bool]]] = None,
-        multipart: typing.Optional[
-            typing.Dict[str, typing.Union[bytes, bool, float, str, FilePayload]]
-        ] = None,
+        multipart: typing.Dict[str,typing.Union[bytes,bool,float,str,FilePayload,typing.List[typing.Union[str, FilePayload]]]] = None,
         timeout: typing.Optional[float] = None,
         fail_on_status_code: typing.Optional[bool] = None,
         ignore_https_errors: typing.Optional[bool] = None,


### PR DESCRIPTION
Version
1.57

Steps to reproduce
An extension to the issue
https://github.com/microsoft/playwright-python/issues/2784

Adds support for string arrays in `multipart` fields, allowing usage like:

```python
multipart = {
    "codes[]": ["C34376202", "C481866"],
    "files"= [ 
        { "name"="Document1.txt", "mimeType":"text/plain", buffer: b"Text file 1 content" },
        { "name"="Document2.txt", "mimeType":"text/plain", buffer: b"Text file 2 content" }
    ]
}


Previously, only single values (str/file) were supported due to type and logic limitations.
Changes made
✅ Updated multipart type hint to include List[Union[str, FilePayload]]
✅ Enhanced handling of list values in form field processing
✅ Improved is_file_array_payload to correctly identify file arrays
✅ Added support for multiple same-named fields (e.g. codes[]) via list expansion
Why this is useful
Enables sending arrays of strings (e.g. batch codes, IDs) in multipart requests — a common use case when interacting with web forms or APIs expecting repeated keys.
This aligns with real-world HTTP behavior where field[] syntax is widely used for array submission.