### PR TITLE
fix: context.request timeout

### DIFF
--- a/playwright/_impl/_browser_context.py
+++ b/playwright/_impl/_browser_context.py
@@ -124,6 +124,7 @@ class BrowserContext(ChannelOwner):
         self._tracing = cast(Tracing, from_channel(initializer["tracing"]))
         self._har_recorders: Dict[str, HarRecordingMetadata] = {}
         self._request: APIRequestContext = from_channel(initializer["requestContext"])
+        self._request._timeout_settings = self._timeout_settings
         self._clock = Clock(self)
         self._channel.on(
             "bindingCall",

--- a/tests/sync/test_page_request_timeout.py
+++ b/tests/sync/test_page_request_timeout.py
@@ -1,0 +1,36 @@
+# Copyright (c) Microsoft Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from playwright.sync_api import BrowserContext, Error, Page
+from tests.server import Server
+
+
+def test_context_request_should_support_timeout_option(
+    page: Page, context: BrowserContext, server: Server
+) -> None:
+    # https://github.com/microsoft/playwright/issues/39220
+
+    server.set_route("/empty.html", lambda req: None)
+    with pytest.raises(Error, match="Timeout 123ms exceeded"):
+        page.request.get(server.EMPTY_PAGE, timeout=123)
+    with pytest.raises(Error, match="Timeout 123ms exceeded"):
+        context.request.get(server.EMPTY_PAGE, timeout=123)
+
+    context.set_default_timeout(123)
+    with pytest.raises(Error, match="Timeout 123ms exceeded"):
+        page.request.get(server.EMPTY_PAGE)
+    with pytest.raises(Error, match="Timeout 123ms exceeded"):
+        context.request.get(server.EMPTY_PAGE)

--- a/tests/sync/test_page_request_timeout.py
+++ b/tests/sync/test_page_request_timeout.py
@@ -23,14 +23,14 @@ def test_context_request_should_support_timeout_option(
 ) -> None:
     # https://github.com/microsoft/playwright/issues/39220
 
-    server.set_route("/empty.html", lambda req: None)
+    server.set_route("/", lambda req: None)
     with pytest.raises(Error, match="Timeout 123ms exceeded"):
-        page.request.get(server.EMPTY_PAGE, timeout=123)
+        page.request.get(server.PREFIX, timeout=123)
     with pytest.raises(Error, match="Timeout 123ms exceeded"):
-        context.request.get(server.EMPTY_PAGE, timeout=123)
+        context.request.get(server.PREFIX, timeout=123)
 
     context.set_default_timeout(123)
     with pytest.raises(Error, match="Timeout 123ms exceeded"):
-        page.request.get(server.EMPTY_PAGE)
+        page.request.get(server.PREFIX)
     with pytest.raises(Error, match="Timeout 123ms exceeded"):
-        context.request.get(server.EMPTY_PAGE)
+        context.request.get(server.PREFIX)


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/39220 by mirroring: 

https://github.com/microsoft/playwright/blob/cb18921c32ded0b4069e0b42df986aaf676079d0/packages/playwright-core/src/client/browserContext.ts#L98