### PR TITLE
fix: show not_ prefix in call log when negative assertions fail

### DIFF
--- a/playwright/_impl/_assertions.py
+++ b/playwright/_impl/_assertions.py
@@ -67,6 +67,8 @@ class AssertionsBase:
             expect_options["timeout"] = self._timeout or 5_000
         if expect_options["isNot"]:
             message = message.replace("expected to", "expected not to")
+            if title:
+                title = title.replace('"to_', '"not_to_')
         if "useInnerText" in expect_options and expect_options["useInnerText"] is None:
             del expect_options["useInnerText"]
         result = await self._call_expect(expression, expect_options, title)

--- a/tests/async/test_assertions.py
+++ b/tests/async/test_assertions.py
@@ -1023,6 +1023,15 @@ async def test_should_be_able_to_set_custom_timeout(page: Page) -> None:
     assert 'Expect "to_be_visible" with timeout 111ms' in str(exc_info.value)
 
 
+async def test_negative_assertion_should_show_not_prefix_in_call_log(
+    page: Page,
+) -> None:
+    await page.set_content("<button>hello</button>")
+    with pytest.raises(AssertionError) as exc_info:
+        await expect(page.locator("button")).not_to_be_visible(timeout=111)
+    assert 'Expect "not_to_be_visible" with timeout 111ms' in str(exc_info.value)
+
+
 async def test_should_be_able_to_set_custom_global_timeout(page: Page) -> None:
     try:
         expect.set_options(timeout=111)

--- a/tests/async/test_assertions.py
+++ b/tests/async/test_assertions.py
@@ -1023,7 +1023,7 @@ async def test_should_be_able_to_set_custom_timeout(page: Page) -> None:
     assert 'Expect "to_be_visible" with timeout 111ms' in str(exc_info.value)
 
 
-async def test_negative_assertion_should_show_not_prefix_in_call_log(
+async def test_negative_assertion_shows_not_prefix_in_call_log(
     page: Page,
 ) -> None:
     await page.set_content("<button>hello</button>")


### PR DESCRIPTION
When a negative assertion like `not_to_be_visible` fails, the call log prints the name of the **positive** assertion, which contradicts the error message and is kind of confusing if you're reading quickly. For example:
```
AssertionError: Locator expected not to be visible
Actual value: visible 
Call log:
  - Expect "to_be_visible" with timeout 3000ms
  - waiting for locator("#some-id").first
    7 × locator resolved to <svg id="some-id">…</svg>
      - unexpected value "visible"
```

With this PR, it will say `not_to_be_visible`, like so:
```
AssertionError: Locator expected not to be visible
Actual value: visible 
Call log:
  - Expect "not_to_be_visible" with timeout 3000ms
  - waiting for locator("#some-id").first
    7 × locator resolved to <svg id="some-id">…</svg>
      - unexpected value "visible"
```