### PR TITLE
Fix #3037: Playwright + AnyIO loop conflict on Windows

### DIFF
--- a/playwright/_impl/_connection.py
+++ b/playwright/_impl/_connection.py
@@ -303,7 +303,6 @@ class Connection(EventEmitter):
         await self.run()
 
     async def run(self) -> None:
-        self._loop = asyncio.get_running_loop()
         self._root_object = RootChannelOwner(self)
 
         async def init() -> None:


### PR DESCRIPTION
## Summary
- Fixes event loop conflict between Playwright and AnyIO on Windows
Generated by [OwlMind](https://owlmind.dev)