### PR TITLE
chore: roll to 1.59.1

### DIFF
--- a/.claude/skills/playwright-roll/SKILL.md
+++ b/.claude/skills/playwright-roll/SKILL.md
@@ -1,23 +1,285 @@
 ---
 name: playwright-roll
-description: Roll Playwright Python to a new version
+description: Roll Playwright Python to a new driver version. Walks the upstream `docs/src/api/` commit range, ports each public-API change, suppresses the rest in `expected_api_mismatch.txt`, regenerates the typed surface, and adds tests.
 ---
 
-Help the user roll to a new version of Playwright.
-../../../ROLLING.md contains general instructions and scripts.
+# Rolling Playwright Python
 
-Start with updating the version and generating the API to see the state of things.
+The goal of a roll is to move `driver_version` in `setup.py` to a new release, port every public API change introduced upstream during that interval, and suppress the rest, so that `./scripts/update_api.sh` runs clean and the test suite still passes.
 
-Afterwards, work through the list of changes that need to be backported.
-You can find a list of pull requests that might need to be taking into account in the issue titled "Backport changes".
-Work through them one-by-one and check off the items that you have handled.
-Not all of them will be relevant, some might have partially been reverted, etc. - so feel free to check with the upstream release branch.
+The previous human-facing summary lives in `../../../ROLLING.md`. This skill is the operational playbook — read it end to end before starting.
 
-Rolling includes:
-- updating client implementation to match changes in the upstream JS implementation (see ../playwright/packages/playwright-core/src/client)
-- adding a couple of new tests to verify new/changed functionality
+## Mental model
 
-## Tips & Tricks
-- Project checkouts are in the parent directory (`../`).
-- when updating checkboxes, store the issue content into /tmp and edit it there, then update the issue based on the file
-- use the "gh" cli to interact with GitHub
+The Python port is hand-written code in `playwright/_impl/`, plus a generator (`scripts/generate_*.py`, `scripts/documentation_provider.py`) that:
+
+1. introspects the Python `_impl` classes via `inspect`,
+2. emits typed wrapper classes into `playwright/{async,sync}_api/_generated.py`, and
+3. diffs the introspected surface against `playwright/driver/package/api.json` (downloaded inside the new driver wheel).
+
+Anything in `api.json` that is missing or differently typed in `_impl/` causes generation to fail. Three resolutions:
+
+- **PORT** — the new API is intended for Python (no `langs.only` filter, or `langs.only` includes `"python"`). Implement it in `_impl/`.
+- **MISMATCH** — the API genuinely exists for Python but is shaped differently (a callback signature uses unions, a kwarg uses a legacy name, etc.) and there's a justified reason to keep the divergence. Add a precise line to `scripts/expected_api_mismatch.txt` with a comment explaining *why*.
+- **N/A** — the commit only touches docs, has `* langs: js` (or any other filter that excludes Python), is server-side, Electron-only, or was reverted later in the same release. No action.
+
+The upstream documentation source of truth is `docs/src/api/*.md` in the playwright repo. Every `## method:` / `## property:` / `## event:` / `### option:` / `### param:` block has an optional `* langs: js` (or `js, python`, etc.) filter. The Python doclint resolves these into `langs` fields on each member of `api.json`. **An empty `langs: {}` means "all languages including Python" — *implement it*, don't suppress it.**
+
+> **The mistake the 1.59 roll made twice over:** classifying things as "internal tooling, N/A for Python" based on the *name* of the API (Screencast, Debugger, pickLocator, clearConsoleMessages, artifactsDir, …). Almost all of those had empty `langs: {}` in `api.json` and were real Python APIs. Sounding tooling-y is not a `langs` filter. **The `langs` field on the member in `api.json` is the only authoritative signal.** When in doubt, dump it (see "Verifying classifications" below).
+
+## Pre-flight
+
+You will need two checkouts in the parent directory:
+- `~/code/playwright-python` — this repo.
+- `~/code/playwright` — the upstream playwright monorepo (used read-only for diffing).
+
+Bring upstream up to date and ensure release branches/tags are present:
+
+```sh
+git -C ~/code/playwright fetch --tags
+git -C ~/code/playwright fetch origin 'release-*:release-*'
+```
+
+There is sometimes no `vX.Y.0` tag for the latest release (the bots cut release branches first and tag later). Anchor on commits, not tags — see "Identify the commit range" below.
+
+## Process
+
+### 1. Set up the env
+
+`CONTRIBUTING.md` covers this. Notes from past rolls:
+
+- The repo says Python 3.9 is required, but 3.9+ works. If `python3.9` isn't available, use `python3` (3.12 is fine).
+- If `python3-venv` is missing system-wide, use `uv venv env` instead, then `uv pip install --python env/bin/python --upgrade pip`. Don't try to `apt install` — sudo is denied in the harness.
+- Always activate the venv before any `pip`, `pytest`, `mypy`, or `pre-commit` invocation.
+
+### 2. Bump the driver and download it
+
+```sh
+# Edit setup.py
+driver_version = "<new>"     # e.g. "1.59.1"
+
+source env/bin/activate
+python -m build --wheel       # downloads the new driver from cdn.playwright.dev
+playwright install chromium   # NOT --with-deps; sudo is denied
+```
+
+The wheel build prints `Fetching https://cdn.playwright.dev/builds/driver/playwright-<new>-linux.zip` and unpacks the driver under `playwright/driver/package/`. From this point, `playwright/driver/package/api.json` reflects the new release.
+
+### 3. Identify the commit range
+
+The diff range is "every commit on the new release branch since the previous release was cut". Anchor commits:
+
+- **Previous release end**: the `chore: bump version to vX.Y.0-next` commit on `main`. That commit is the first commit *after* the previous release (X.Y-1) was cut. Use its parent (`<sha>~1`) as the lower bound.
+  ```sh
+  git -C ~/code/playwright log --all --grep="bump version to v" --oneline | head
+  ```
+- **New release end**: the tip of `release-<new>` (or the matching tag if it exists).
+
+Save the commit list, oldest first, scoped to `docs/src/api/`:
+
+```sh
+git -C ~/code/playwright log <prev-anchor>~1..release-<new> --oneline --reverse -- docs/src/api > /tmp/roll-<new>-commits.md
+```
+
+A normal roll yields 50–100 commits. If you see 0 or thousands, the range is wrong.
+
+Format the file as a markdown checklist and add the standard preamble (status legend, where to look up `api.json` etc.) — see the file from the 1.58→1.59 roll for the template.
+
+### 4. Walk the commit list
+
+For each commit, in chronological order:
+
+```sh
+git -C ~/code/playwright show <sha> -- docs/src/api/
+```
+
+Look for:
+- `## (async )?method:` / `## property:` / `## event:` additions or removals;
+- `* langs: ...` lines on those blocks;
+- `### param:` / `### option:` additions or removals;
+- new `class-X.md` files (whole new classes — usually `langs: js`);
+- type changes in `- returns:` lines.
+
+Classify and act.
+
+#### Verifying classifications (do this before suppressing anything)
+
+Before tagging anything as MISMATCH or N/A based on appearance, dump the actual `langs` from `api.json`:
+
+```python
+import json
+data = json.load(open("playwright/driver/package/api.json"))
+classes = {c["name"]: c for c in data}
+for cls_name in ["Page", "BrowserContext", "Screencast", "Debugger"]:
+    cls = classes.get(cls_name)
+    if not cls:
+        continue
+    print(f"\n{cls_name}: cls_langs={cls.get('langs', {})}")
+    for m in cls["members"]:
+        print(f"  {m['name']} kind={m.get('kind')} langs={m.get('langs', {})}")
+```
+
+For options/params nested inside an `Object`-typed arg, walk one level deeper:
+
+```python
+for a in member.get("args", []):
+    if a["name"] == "options":
+        for prop in a.get("type", {}).get("properties", []):
+            print(prop["name"], prop.get("langs", {}))
+```
+
+A few rules of thumb that catch most "actually a PORT" cases:
+- If the *containing class* has empty `langs: {}` and the *member* has empty `langs: {}`, it's for Python — implement it.
+- If the member is empty but a single *option* has `langs: js`, the method is for Python and you only skip that option (e.g. `Screencast.start.size` is `langs: js` while `Screencast.start` itself isn't).
+- If you're about to add three or more `Method not implemented:` entries for the same class, stop — you almost certainly need to implement the class.
+
+#### PORT
+
+Implement the change in `playwright/_impl/<module>.py`. Use the upstream JS implementation as a reference: `~/code/playwright/packages/playwright-core/src/client/<module>.ts`. Translate idioms:
+
+| Upstream JS | Python |
+|---|---|
+| `async foo(): Promise<X>` | `async def foo(self) -> X:` |
+| `foo(): X` (sync getter, no args, no body) | `@property def foo(self) -> X:` (the doc generator treats argument-less sync getters as properties — see `documentation_provider.py:133`. If you make it a method instead, you'll get a "Method vs property mismatch" error.) |
+| `await this._channel.foo({ a, b })` | `await self._channel.send("foo", None, locals_to_params(locals()))` |
+| `(await this._channel.foo()).value` | `await self._channel.send("foo", None)` (Python's `send()` auto-unwraps single-key responses; only call `send_return_as_dict` when the protocol returns multiple keys.) |
+| `(await this._channel.foo()).artifact` (multi-key, may be empty) | `result = await self._channel.send_return_as_dict("foo", None); (result or {}).get("artifact")` — `send_return_as_dict` returns **`None`** (not `{}`) when the protocol response carries no fields. |
+| `try { ... } catch (e) { if (isTargetClosedError(e)) return; throw e; }` | `try: ...; except Exception as e: if is_target_closed_error(e): return; raise` (import from `playwright._impl._errors`) |
+| Inline `[Object]` return like `{endpoint: string}` | A `TypedDict` in `playwright/_impl/_api_structures.py` — *not* `Dict[str, str]`. The doc generator serializes TypedDicts as `{field: type, ...}` via `get_type_hints` and that matches the inline-object form exactly. See `RemoteAddr`, `BrowserBindResult`, `DebuggerPausedDetails`. |
+| `binary` event/return field | The Python channel layer hands you a base64 string. Decode with `base64.b64decode(value)` before exposing as `bytes`. See `Screencast._dispatch_frame`. |
+
+When implementing a new ChannelOwner subclass (one constructed by the protocol with `(parent, type, guid, initializer)`):
+1. Register it in `playwright/_impl/_object_factory.py:create_remote_object` — otherwise the guid resolves to `DummyObject` and downstream code breaks mysteriously.
+2. Import it and add it to `generated_types` in `scripts/generate_api.py`, plus add a `XxxImpl` import in the `header` string.
+
+When implementing a non-ChannelOwner wrapper class (a plain class that holds a Page/Context reference, like `Screencast`, `Clock`):
+- Set `self._loop = parent._loop` and `self._dispatcher_fiber = parent._dispatcher_fiber` in `__init__`. The generated `AsyncBase`/`SyncBase` wrappers read these; missing them gives `AttributeError: 'X' object has no attribute '_loop'` at first use.
+
+When adding a new TypedDict in `_api_structures.py`:
+- Add it to the `from playwright._impl._api_structures import …` line in `scripts/generate_api.py` so the generator can resolve it as a forward reference in type hints.
+- Re-export it from both `playwright/async_api/__init__.py` and `playwright/sync_api/__init__.py`: assignment line plus an entry in `__all__`. Same pattern as `ViewportSize`, `RemoteAddr`.
+
+If the new API was previously suppressed in `expected_api_mismatch.txt`, **remove that line** when implementing it.
+
+If a doc rename involves a *positional* parameter (no default, before any `*`), users almost certainly call it positionally — you can rename freely. The 1.59 `BrowserType.connect.wsEndpoint` → `endpoint` is the canonical example. Don't suppress this kind of rename; just rename in `_impl/`. **Important corollary:** when docs rename a param, the wire-protocol field usually also changed in `packages/protocol/src/protocol.yml` and the server-side dispatcher in `packages/playwright-core/src/server/dispatchers/*Dispatcher.ts`. If so, you must also update the channel-send dict key (e.g. `{"wsEndpoint": …}` → `{"endpoint": …}`). A "Parameter not documented" suppression for a renamed param is a code smell hiding a wire-protocol bug.
+
+#### MISMATCH
+
+A MISMATCH is a *justified, durable* divergence between the docs and the Python surface. Use it sparingly — most apparent mismatches turn out to be PORTs you skipped. Legitimate examples in the current `expected_api_mismatch.txt`:
+
+- Hidden internal kwargs (`Browser.new_context(default_browser_type=)`).
+- Callback signatures where Python explicitly unions one-arg and two-arg variants but the docs document only the canonical form (`Page.route(handler=)`, `WebSocketRoute.on_close(handler=)`).
+
+Add a precise line to `scripts/expected_api_mismatch.txt` with a `# comment` group header explaining *why* the divergence is intentional. The exact wording comes from the generator's error message. Examples:
+
+```
+# One vs two arguments in the callback, Python explicitly unions.
+Parameter type mismatch in Page.route(handler=): documented as Callable[[Route, Request], Union[Any, Any]], code has Union[Callable[[Route, Request], Any], Callable[[Route], Any]]
+```
+
+The generator removes lines from `expected_api_mismatch.txt` that no longer match an error. If you see "No longer there: …" in the script's stderr, delete that line.
+
+**Do not suppress** these — they're PORTs in disguise:
+
+- "Internal tooling" classes/methods whose `langs` field is empty (`Screencast.*`, `Debugger.*`, `Page.pick_locator`, `BrowserContext.debugger`, `Browser.bind/unbind`, `Page.{clear,console}_*`). The 1.59 roll suppressed all of these initially, then had to walk every one back. Verify `langs` first.
+- A renamed positional parameter (`Parameter not documented: X.y(old_name=)` + `Parameter not implemented: X.y(new_name=)`). Just rename in `_impl/` and update the channel-send dict key.
+- A `Parameter type mismatch in X.y(return=): documented as {field: T}, code has Dict[str, T]`. Use a TypedDict.
+
+#### N/A
+
+Common N/A flavors:
+- Whole new class with `langs: js` (Disposable, Inspector/Screencast, Debugger, Overlay).
+- Members with `langs: js` (most "tooling" / MCP / agentic features).
+- Doc-only edits (typo fixes, "Improve `not` property sections", etc.).
+- Reverts that cancel an earlier add in the same range (always check the rest of the range before porting something that gets reverted).
+- Java/C# `langs:` blocks.
+- Electron-only changes (`docs/src/api/class-electron.md`).
+
+Tick the box in `/tmp/roll-<new>-commits.md` with one line: `[x] <sha> <subject> — <classification>: <one-liner>`.
+
+### 5. Regenerate
+
+```sh
+./scripts/update_api.sh
+```
+
+The script does, in order:
+1. `git checkout HEAD -- playwright/{async,sync}_api/_generated.py` (resets to last committed),
+2. runs `scripts/generate_{sync,async}_api.py` which dumps to `.x` then renames into place,
+3. invokes `pre-commit run --files` on the generated files.
+
+Failure modes and fixes:
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Method not implemented: X.y` | `api.json` documents `X.y`, no Python impl exists. | PORT it, or add a MISMATCH line. |
+| `Parameter not implemented: X.y(z=)` | New parameter on existing method. | Add the kwarg in `_impl/`, or MISMATCH. |
+| `Method vs property mismatch: X.y` | You implemented as a method but the doc treats it as a property (sync, no args, has return type). | Add `@property` in `_impl/`. |
+| `Method not documented: X.y` | Python has it but `api.json` doesn't. | The upstream removed the API; remove from `_impl/` and from `_generated.py` callers. |
+| `Parameter type mismatch in X.y(z=): documented as ..., code has ...` | Type signature doesn't line up. | Match the type in `_impl/`, or MISMATCH it for known historical divergences. |
+| `pyright … reportInconsistentOverload` (single-event class) | A class gained its first event in `api.json`, so the generator emits one `Literal[…]` overload + impl, which pyright wants ≥2 of. | The generator already handles this — `documentation_provider.print_events` emits a second `@typing.overload` with `event: str` plus a generic impl. If you regress this, see how 1.59 handled `CDPSession` getting a `close` event. |
+| `pre-commit` keeps reformatting `_generated.py` on each run | First run after regen always reformats once; rerun until idle. | `pre-commit run --all-files` to settle. |
+| `Parameter not documented: X.y(z=)` | Python has a kwarg the docs don't mention (e.g. legacy name from a doc rename). | If the param is positional with no default, just rename it in `_impl/`. Check `protocol.yml` and the server dispatcher — if the wire field renamed too, also update the channel-send dict key. Only MISMATCH for genuinely hidden internal kwargs (`default_browser_type`). |
+| `KeyError: 'templates'` deep in `inner_serialize_doc_type` | A `Promise<X>\|X` union upstream collapsed to a bare `Promise` with no templates in `api.json`. | `documentation_provider.inner_serialize_doc_type` should treat that as `Any` (`if "templates" not in type: return "Any"`). |
+| `"void" is not defined (reportUndefinedVariable)` in generated event handlers | `api.json` has a `void`-typed event payload that the serializer left as the literal string `"void"`. | `documentation_provider.inner_serialize_doc_type` should map `"void"` to `"None"` alongside `"null"`. |
+| `AttributeError: 'X' object has no attribute '_loop'` (or `_dispatcher_fiber`) at first use of a new wrapper class | The non-ChannelOwner wrapper isn't initializing the fields the generated `AsyncBase`/`SyncBase` reads. | In the wrapper's `__init__`, set `self._loop = parent._loop` and `self._dispatcher_fiber = parent._dispatcher_fiber`. |
+| `'NoneType' object has no attribute 'get'` after `send_return_as_dict` | Method's protocol response carries no fields and `send_return_as_dict` returned `None`. | `(result or {}).get(...)`. |
+| Frame/buffer payload arrives as a `str` instead of `bytes` | Protocol `binary` fields cross the wire as base64. | `base64.b64decode(value)` in the impl before exposing. |
+
+After the script settles, run `pre-commit run --all-files` once more to confirm everything is idle.
+
+### 6. Add tests
+
+For each PORT, add one async test and a matching sync test. Conventions:
+
+- Tests go in the existing topic file (`test_page_network_request.py`, `test_browsercontext.py`, `test_dialog.py`, …) — don't create new files unless there's no obvious home.
+- Use `from playwright.async_api import …`, **not** `from playwright._impl._page import Page` (the impl class doesn't have the public wrappers like `expect_console_message`).
+- For event-info objects, `await message_info.value` (it's an `async` property).
+- Don't write tests that hang the page (e.g. `page.evaluate(... fetch slow ...)` followed by `page.close()` from a fixture) — the request task gets a `TargetClosedError`. Use `page.on("event", handler)` to capture state at event time instead.
+- `playwright install chromium` (no `--with-deps`) is sufficient for the test suite under sandbox.
+
+### 7. Update existing high-touch artifacts
+
+- `setup.py`: already done in step 2.
+- `README.md`: gets the chromium/firefox/webkit version table updated automatically by `scripts/update_versions.py` (called from `update_api.sh`). Don't edit by hand.
+- The "Backport changes" tracking issue on GitHub (filed by `microsoft-playwright-automation`) is the *intent* tracker, but it's frequently out of sync with what's actually been ported. Treat it as a starting point, not the source of truth — the `docs/src/api/` commit walk is authoritative.
+
+### 8. Final verification
+
+```sh
+pre-commit run --all-files
+mypy playwright                 # 2 pre-existing errors in _json_pipe.py and _artifact.py are unrelated
+pytest --browser chromium tests/async/<files-you-touched> tests/sync/<files-you-touched>
+```
+
+Then a smoke regression on a few neighboring suites (`tests/async/test_browser*.py`, `test_cdp_session.py`, `test_tracing.py`, `test_dialog.py`, `test_page_*.py`) to make sure nothing inherent to the port shifted.
+
+## Reference: `expected_api_mismatch.txt` line forms
+
+Exact strings the generator emits (and that this file must contain to suppress):
+
+```
+Method not implemented: <Class>.<snake_method>
+Parameter not implemented: <Class>.<snake_method>(<snake_param>=)
+Parameter not documented: <Class>.<snake_method>(<snake_param>=)
+Method vs property mismatch: <Class>.<snake_method>
+Method not documented: <Class>.<snake_method>
+Parameter type mismatch in <Class>.<snake_method>(<arg>=): documented as <T1>, code has <T2>
+```
+
+Class names use the upstream PascalCase (`BrowserContext`, `BrowserType`); method/param names are converted to `snake_case` matching the Python surface.
+
+## Tips & gotchas
+
+- **`langs.only` is your filter — and the only filter.** Don't classify by name (`Screencast`, `Debugger`, `pickLocator`) or by intuition ("looks like internal tooling"). Always check `langs` in `api.json`. The 1.59 roll cost two extra audit passes by trusting names over `langs`.
+- **Audit your own classifications a second time.** After the first walk through the commit range, before opening the PR, re-read every line in `expected_api_mismatch.txt` you added during this roll and ask "is this divergence justified, or did I skip a port?" Run the `langs`-dump snippet on each suspicious entry. The 1.59 roll's first PR had ~20 wrong suppressions; the second pass cut them to 0.
+- **A cluster of suppressions on the same class is a smell.** If you're about to add five `Method not implemented: Foo.*` lines, you're almost certainly looking at a class that needs to be implemented. Implement the whole thing once and the suppressions disappear.
+- **Watch for revert pairs in the same range.** 1.59 added and reverted `Browser.isRemote` (#39613 / #39620) inside the same release. Walking chronologically lets you skip the add when you see the revert later.
+- **Watch for rename-revert pairs.** 1.59 had `Locator.normalize` → `Locator.toCode` (#39648) → `Locator.normalize` (#39754). Final state wins; only port the last.
+- **Doc renames almost always include a wire-protocol rename.** Whenever you see `### param: X.y.oldName` → `### param: X.y.newName` in a doc commit, also `git -C ~/code/playwright show <sha> -- packages/protocol/src/protocol.yml` and the corresponding `*Dispatcher.ts` file. If the wire field changed too, the channel-send dict key in `_impl/` must change. Suppressing the doc-side mismatch is hiding a real bug — the previous Python code is silently sending an unknown field that the new server ignores.
+- **TypedDicts beat `Dict[str, X]` for any structured return.** When the docs describe a return as `[Object]` with named fields (or even `[Object=Foo]`), define a `TypedDict` in `_api_structures.py`, re-export from both public `__init__.py` files, and use it. Zero runtime cost (it's still a `dict`), and the doc generator's type comparator matches by structure via `get_type_hints`.
+- **Positional renames are free.** A param with no default before any `*` separator is positional-or-keyword in Python, but realistic call sites pass it positionally. Renaming such a param doesn't break callers.
+- **The "Backport changes" GitHub issue can be misleading.** In the 1.59 roll its checkboxes were all marked `[x]` with annotations like "✅ IMPLEMENTED", but several of those features had not actually been merged into the Python port. Trust the `docs/src/api/` walk over the issue.
+- **`api.json` may carry doclint quirks.** 1.59 hit two: `Promise<X>|X` collapsed to a bare `Promise` with no `templates`, and `void`-typed events serialized as the literal string `"void"`. Both are upstream artifacts; patch `inner_serialize_doc_type` to handle them rather than fighting the api.json side.
+- **Don't edit `_generated.py` to fix lint or typing.** Fix `_impl/`, `documentation_provider.py`, or `expected_api_mismatch.txt` instead. Hand-editing the generated file is reverted on the next regen.
+- **`/tmp/roll-<new>-commits.md` is a working artifact, not a deliverable.** Don't commit it. The commit message and PR description are where the audit summary belongs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,13 @@ jobs:
       matrix:
         os: [ubuntu-22.04, macos-13, windows-2022]
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        # `setup-miniconda` activates the env only for login shells; using
+        # `bash -el` (recommended by the action) ensures `conda` and the
+        # installed `conda-build` are on PATH on every OS, including Windows
+        # where the default shell is pwsh and skips the activation hooks.
+        shell: bash -el {0}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -169,11 +176,11 @@ jobs:
       - name: Get conda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: 3.9
+          python-version: '3.12'
           channels: conda-forge
           miniconda-version: latest
       - name: Prepare
-        run: conda install conda-build conda-verify
+        run: conda install -n base "conda-build>=26" conda-verify
       - name: Build
         run: conda build .
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,11 +31,11 @@ jobs:
       - name: Get conda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: 3.9
+          python-version: '3.12'
           channels: conda-forge
           miniconda-version: latest
       - name: Prepare
-        run: conda install anaconda-client conda-build conda-verify
+        run: conda install -n base anaconda-client "conda-build>=26" conda-verify
       - name: Build and Upload
         env:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# CLAUDE.md
+
+Guidance for Claude when working in this repository.
+
+## What this is
+
+Python bindings for [Playwright](https://playwright.dev). The Python client talks JSON over a pipe to the Node-based driver bundled in `playwright/driver/`. The pipe protocol is defined upstream in `packages/protocol/src/protocol.yml`.
+
+## Layout
+
+- `playwright/_impl/` — hand-written client implementation (one module per object: `_browser.py`, `_page.py`, `_locator.py`, `_network.py`, etc.). Edit these to add or change behavior.
+- `playwright/async_api/_generated.py`, `playwright/sync_api/_generated.py` — **auto-generated**. Never edit by hand; rerun `./scripts/update_api.sh` after changing `_impl/` or the driver.
+- `scripts/generate_api.py`, `scripts/generate_async_api.py`, `scripts/generate_sync_api.py`, `scripts/documentation_provider.py` — codegen and validation. They diff the Python implementation against the driver's `playwright/driver/package/api.json` and abort if either side is out of sync.
+- `scripts/expected_api_mismatch.txt` — explicit allowlist of "documented in JS, not in Python" or "named differently in Python" gaps. Lines that no longer apply must be removed.
+- `tests/async/`, `tests/sync/` — pytest suites. Most new tests are added to the async file with a sync mirror.
+- `setup.py` — `driver_version = "X.Y.Z"` is the source of truth for which driver build is downloaded from `cdn.playwright.dev`.
+- `ROLLING.md`, `CONTRIBUTING.md` — human-facing setup and roll docs.
+
+## Setup
+
+`CONTRIBUTING.md` has the full sequence. The short version:
+
+```sh
+python3 -m venv env && source env/bin/activate
+pip install --upgrade pip
+pip install -r local-requirements.txt
+pip install -e .
+python -m build --wheel        # downloads the driver listed in setup.py
+pre-commit install
+```
+
+If the system lacks `python3-venv`, `uv venv env` is an acceptable substitute (then `uv pip install --python env/bin/python --upgrade pip`).
+
+## Common commands
+
+- Regenerate `_generated.py`: `./scripts/update_api.sh` (runs codegen + pre-commit on the generated files).
+- Lint everything: `pre-commit run --all-files`.
+- Type-check: `mypy playwright`.
+- Run tests: `pytest --browser chromium [-k name]`. Browsers are installed via `playwright install chromium` (do **not** use `--with-deps`, which requires sudo).
+
+When changing public API, edit `_impl/`, then run `./scripts/update_api.sh`. The script regenerates `_generated.py` and validates against the driver's `api.json`. If validation fails, fix the mismatch in `_impl/`, in `expected_api_mismatch.txt`, or in `documentation_provider.py` — not by hand-editing `_generated.py`.
+
+## Rolling Playwright to a new version
+
+This is the recurring high-stakes task. Use the dedicated skill:
+
+→ **[`.claude/skills/playwright-roll/SKILL.md`](.claude/skills/playwright-roll/SKILL.md)**
+
+It documents the full process: the upstream commit-range diff over `docs/src/api/`, how to classify each commit (PORT / MISMATCH / N/A), how to handle the `langs:` filter, the recurring failure modes, and the tests/sync-mirroring conventions.
+
+## House style
+
+- Don't hand-edit generated files.
+- Don't add `# type: ignore` or modify `_generated.py` to silence pyright; fix the source of the mismatch.
+- New public methods on impl classes need a sync test mirror under `tests/sync/`.
+- Keep `expected_api_mismatch.txt` minimal — every entry needs a one-line rationale comment above it.
+- Prefer `locals_to_params(locals())` for forwarding optional kwargs to channel sends, matching the rest of the codebase.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Playwright is a Python library to automate [Chromium](https://www.chromium.org/H
 
 |          | Linux | macOS | Windows |
 |   :---   | :---: | :---: | :---:   |
-| Chromium <!-- GEN:chromium-version -->145.0.7632.6<!-- GEN:stop --> | ✅ | ✅ | ✅ |
-| WebKit <!-- GEN:webkit-version -->26.0<!-- GEN:stop --> | ✅ | ✅ | ✅ |
-| Firefox <!-- GEN:firefox-version -->146.0.1<!-- GEN:stop --> | ✅ | ✅ | ✅ |
+| Chromium <!-- GEN:chromium-version -->147.0.7727.15<!-- GEN:stop --> | ✅ | ✅ | ✅ |
+| WebKit <!-- GEN:webkit-version -->26.4<!-- GEN:stop --> | ✅ | ✅ | ✅ |
+| Firefox <!-- GEN:firefox-version -->148.0.2<!-- GEN:stop --> | ✅ | ✅ | ✅ |
 
 ## Documentation
 

--- a/playwright/_impl/_api_structures.py
+++ b/playwright/_impl/_api_structures.py
@@ -166,6 +166,10 @@ class RemoteAddr(TypedDict):
     port: int
 
 
+class BrowserBindResult(TypedDict):
+    endpoint: str
+
+
 class SecurityDetails(TypedDict):
     issuer: Optional[str]
     protocol: Optional[str]
@@ -311,3 +315,18 @@ class TracingGroupLocation(TypedDict):
     file: str
     line: Optional[int]
     column: Optional[int]
+
+
+class DebuggerLocation(TypedDict):
+    file: str
+    line: Optional[int]
+    column: Optional[int]
+
+
+class DebuggerPausedDetails(TypedDict):
+    location: DebuggerLocation
+    title: str
+
+
+class ScreencastFrame(TypedDict):
+    data: bytes

--- a/playwright/_impl/_browser.py
+++ b/playwright/_impl/_browser.py
@@ -27,6 +27,7 @@ from typing import (
 )
 
 from playwright._impl._api_structures import (
+    BrowserBindResult,
     ClientCertificate,
     Geolocation,
     HttpCredentials,
@@ -246,6 +247,20 @@ class Browser(ChannelOwner):
 
     async def new_browser_cdp_session(self) -> CDPSession:
         return from_channel(await self._channel.send("newBrowserCDPSession", None))
+
+    async def bind(
+        self,
+        title: str,
+        workspaceDir: str = None,
+        host: str = None,
+        port: int = None,
+    ) -> BrowserBindResult:
+        return await self._channel.send_return_as_dict(
+            "startServer", None, locals_to_params(locals())
+        )
+
+    async def unbind(self) -> None:
+        await self._channel.send("stopServer", None)
 
     async def start_tracing(
         self,

--- a/playwright/_impl/_browser_context.py
+++ b/playwright/_impl/_browser_context.py
@@ -46,6 +46,7 @@ from playwright._impl._connection import (
     from_nullable_channel,
 )
 from playwright._impl._console_message import ConsoleMessage
+from playwright._impl._debugger import Debugger
 from playwright._impl._dialog import Dialog
 from playwright._impl._errors import Error, TargetClosedError
 from playwright._impl._event_context_manager import EventContextManagerImpl
@@ -122,6 +123,7 @@ class BrowserContext(ChannelOwner):
         self._base_url: Optional[str] = self._options.get("baseURL")
         self._videos_dir: Optional[str] = self._options.get("recordVideo")
         self._tracing = cast(Tracing, from_channel(initializer["tracing"]))
+        self._debugger: Debugger = cast(Debugger, from_channel(initializer["debugger"]))
         self._har_recorders: Dict[str, HarRecordingMetadata] = {}
         self._request: APIRequestContext = from_channel(initializer["requestContext"])
         self._request._timeout_settings = self._timeout_settings
@@ -582,6 +584,9 @@ class BrowserContext(ChannelOwner):
         self._tracing._reset_stack_counter()
         self.emit(BrowserContext.Events.Close, self)
 
+    def is_closed(self) -> bool:
+        return self._closing_or_closed
+
     async def close(self, reason: str = None) -> None:
         if self._closing_or_closed:
             return
@@ -626,6 +631,15 @@ class BrowserContext(ChannelOwner):
         if path:
             await async_writefile(path, json.dumps(result))
         return result
+
+    async def set_storage_state(
+        self, storageState: Union[StorageState, str, Path]
+    ) -> None:
+        if isinstance(storageState, (str, Path)):
+            state = json.loads(await async_readfile(storageState))
+        else:
+            state = storageState
+        await self._channel.send("setStorageState", None, {"storageState": state})
 
     def _effective_close_reason(self) -> Optional[str]:
         if self._close_reason:
@@ -752,6 +766,10 @@ class BrowserContext(ChannelOwner):
     @property
     def tracing(self) -> Tracing:
         return self._tracing
+
+    @property
+    def debugger(self) -> Debugger:
+        return self._debugger
 
     @property
     def request(self) -> "APIRequestContext":

--- a/playwright/_impl/_browser_type.py
+++ b/playwright/_impl/_browser_type.py
@@ -86,6 +86,7 @@ class BrowserType(ChannelOwner):
         downloadsPath: Union[str, Path] = None,
         slowMo: float = None,
         tracesDir: Union[pathlib.Path, str] = None,
+        artifactsDir: Union[pathlib.Path, str] = None,
         chromiumSandbox: bool = None,
         firefoxUserPrefs: Dict[str, Union[str, float, bool]] = None,
     ) -> Browser:
@@ -143,6 +144,7 @@ class BrowserType(ChannelOwner):
         contrast: Contrast = None,
         acceptDownloads: bool = None,
         tracesDir: Union[pathlib.Path, str] = None,
+        artifactsDir: Union[pathlib.Path, str] = None,
         chromiumSandbox: bool = None,
         firefoxUserPrefs: Dict[str, Union[str, float, bool]] = None,
         recordHarPath: Union[Path, str] = None,
@@ -213,7 +215,7 @@ class BrowserType(ChannelOwner):
 
     async def connect(
         self,
-        wsEndpoint: str,
+        endpoint: str,
         timeout: float = None,
         slowMo: float = None,
         headers: Dict[str, str] = None,
@@ -229,7 +231,7 @@ class BrowserType(ChannelOwner):
                 "connect",
                 None,
                 {
-                    "wsEndpoint": wsEndpoint,
+                    "endpoint": endpoint,
                     "headers": headers,
                     "slowMo": slowMo,
                     "timeout": timeout if timeout is not None else 0,
@@ -361,3 +363,5 @@ def normalize_launch_params(params: Dict) -> None:
         params["downloadsPath"] = str(Path(params["downloadsPath"]))
     if "tracesDir" in params:
         params["tracesDir"] = str(Path(params["tracesDir"]))
+    if "artifactsDir" in params:
+        params["artifactsDir"] = str(Path(params["artifactsDir"]))

--- a/playwright/_impl/_cdp_session.py
+++ b/playwright/_impl/_cdp_session.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
 from typing import Any, Dict
 
 from playwright._impl._connection import ChannelOwner
@@ -19,14 +20,21 @@ from playwright._impl._helper import locals_to_params
 
 
 class CDPSession(ChannelOwner):
+    Events = SimpleNamespace(
+        Event="event",
+        Close="close",
+    )
+
     def __init__(
         self, parent: ChannelOwner, type: str, guid: str, initializer: Dict
     ) -> None:
         super().__init__(parent, type, guid, initializer)
         self._channel.on("event", lambda params: self._on_event(params))
+        self._channel.on("close", lambda _: self.emit(CDPSession.Events.Close, self))
 
     def _on_event(self, params: Any) -> None:
         self.emit(params["method"], params.get("params"))
+        self.emit(CDPSession.Events.Event, params)
 
     async def send(self, method: str, params: Dict = None) -> Dict:
         return await self._channel.send("send", None, locals_to_params(locals()))

--- a/playwright/_impl/_console_message.py
+++ b/playwright/_impl/_console_message.py
@@ -77,6 +77,10 @@ class ConsoleMessage:
         return self._event["location"]
 
     @property
+    def timestamp(self) -> float:
+        return self._event["timestamp"]
+
+    @property
     def page(self) -> Optional["Page"]:
         return self._page
 

--- a/playwright/_impl/_debugger.py
+++ b/playwright/_impl/_debugger.py
@@ -1,0 +1,54 @@
+# Copyright (c) Microsoft Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from typing import Any, Dict, Optional
+
+from playwright._impl._api_structures import DebuggerLocation, DebuggerPausedDetails
+from playwright._impl._connection import ChannelOwner
+
+
+class Debugger(ChannelOwner):
+    Events = SimpleNamespace(
+        PausedStateChanged="pausedstatechanged",
+    )
+
+    def __init__(
+        self, parent: ChannelOwner, type: str, guid: str, initializer: Dict
+    ) -> None:
+        super().__init__(parent, type, guid, initializer)
+        self._paused_details: Optional[DebuggerPausedDetails] = None
+        self._channel.on(
+            "pausedStateChanged", lambda params: self._on_paused_state_changed(params)
+        )
+
+    def _on_paused_state_changed(self, params: Dict[str, Any]) -> None:
+        self._paused_details = params.get("pausedDetails")
+        self.emit(Debugger.Events.PausedStateChanged)
+
+    async def request_pause(self) -> None:
+        await self._channel.send("requestPause", None)
+
+    async def resume(self) -> None:
+        await self._channel.send("resume", None)
+
+    async def next(self) -> None:
+        await self._channel.send("next", None)
+
+    async def run_to(self, location: DebuggerLocation) -> None:
+        await self._channel.send("runTo", None, {"location": location})
+
+    @property
+    def paused_details(self) -> Optional[DebuggerPausedDetails]:
+        return self._paused_details

--- a/playwright/_impl/_dialog.py
+++ b/playwright/_impl/_dialog.py
@@ -15,6 +15,7 @@
 from typing import TYPE_CHECKING, Dict, Optional
 
 from playwright._impl._connection import ChannelOwner, from_nullable_channel
+from playwright._impl._errors import is_target_closed_error
 from playwright._impl._helper import locals_to_params
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -51,7 +52,12 @@ class Dialog(ChannelOwner):
         await self._channel.send("accept", None, locals_to_params(locals()))
 
     async def dismiss(self) -> None:
-        await self._channel.send(
-            "dismiss",
-            None,
-        )
+        try:
+            await self._channel.send(
+                "dismiss",
+                None,
+            )
+        except Exception as e:
+            if is_target_closed_error(e):
+                return
+            raise

--- a/playwright/_impl/_local_utils.py
+++ b/playwright/_impl/_local_utils.py
@@ -62,7 +62,9 @@ class LocalUtils(ChannelOwner):
         params = locals_to_params(locals())
         await self._channel.send("harUnzip", None, params)
 
-    async def tracing_started(self, tracesDir: Optional[str], traceName: str) -> str:
+    async def tracing_started(
+        self, tracesDir: Optional[str], traceName: str, live: bool = False
+    ) -> str:
         params = locals_to_params(locals())
         return await self._channel.send("tracingStarted", None, params)
 

--- a/playwright/_impl/_locator.py
+++ b/playwright/_impl/_locator.py
@@ -564,7 +564,12 @@ class Locator:
             ),
         )
 
-    async def aria_snapshot(self, timeout: float = None) -> str:
+    async def aria_snapshot(
+        self,
+        timeout: float = None,
+        depth: int = None,
+        mode: Literal["ai", "default"] = None,
+    ) -> str:
         return await self._frame._channel.send(
             "ariaSnapshot",
             self._frame._timeout,
@@ -573,6 +578,14 @@ class Locator:
                 **locals_to_params(locals()),
             },
         )
+
+    async def normalize(self) -> "Locator":
+        result = await self._frame._channel.send(
+            "resolveSelector",
+            None,
+            {"selector": self._selector},
+        )
+        return Locator(self._frame, result)
 
     async def scroll_into_view_if_needed(
         self,

--- a/playwright/_impl/_network.py
+++ b/playwright/_impl/_network.py
@@ -154,6 +154,7 @@ class Request(ChannelOwner):
         self._fallback_overrides: SerializedFallbackOverrides = (
             SerializedFallbackOverrides()
         )
+        self._response: Optional["Response"] = None
 
     def __repr__(self) -> str:
         return f"<Request url={self.url!r} method={self.method!r}>"
@@ -242,6 +243,10 @@ class Request(ChannelOwner):
                 None,
             )
         )
+
+    @property
+    def existing_response(self) -> Optional["Response"]:
+        return self._response
 
     @property
     def frame(self) -> "Frame":
@@ -799,6 +804,7 @@ class Response(ChannelOwner):
     ) -> None:
         super().__init__(parent, type, guid, initializer)
         self._request: Request = from_channel(self._initializer["request"])
+        self._request._response = self
         timing = self._initializer["timing"]
         self._request._timing["startTime"] = timing["startTime"]
         self._request._timing["domainLookupStart"] = timing["domainLookupStart"]
@@ -878,6 +884,12 @@ class Response(ChannelOwner):
     async def security_details(self) -> Optional[SecurityDetails]:
         return await self._channel.send(
             "securityDetails",
+            None,
+        )
+
+    async def http_version(self) -> str:
+        return await self._channel.send(
+            "httpVersion",
             None,
         )
 

--- a/playwright/_impl/_object_factory.py
+++ b/playwright/_impl/_object_factory.py
@@ -20,6 +20,7 @@ from playwright._impl._browser_context import BrowserContext
 from playwright._impl._browser_type import BrowserType
 from playwright._impl._cdp_session import CDPSession
 from playwright._impl._connection import ChannelOwner
+from playwright._impl._debugger import Debugger
 from playwright._impl._dialog import Dialog
 from playwright._impl._element_handle import ElementHandle
 from playwright._impl._fetch import APIRequestContext
@@ -64,6 +65,8 @@ def create_remote_object(
         return BrowserContext(parent, type, guid, initializer)
     if type == "CDPSession":
         return CDPSession(parent, type, guid, initializer)
+    if type == "Debugger":
+        return Debugger(parent, type, guid, initializer)
     if type == "Dialog":
         return Dialog(parent, type, guid, initializer)
     if type == "ElementHandle":

--- a/playwright/_impl/_page.py
+++ b/playwright/_impl/_page.py
@@ -98,6 +98,7 @@ from playwright._impl._network import (
     WebSocketRouteHandler,
     serialize_headers,
 )
+from playwright._impl._screencast import Screencast
 from playwright._impl._video import Video
 from playwright._impl._waiter import Waiter
 
@@ -175,7 +176,11 @@ class Page(ChannelOwner):
         self._timeout_settings: TimeoutSettings = TimeoutSettings(
             self._browser_context._timeout_settings
         )
-        self._video: Optional[Video] = None
+        self._video: Video = Video(
+            self,
+            cast(Optional[Artifact], from_nullable_channel(initializer.get("video"))),
+        )
+        self._screencast: Screencast = Screencast(self)
         self._opener = cast("Page", from_nullable_channel(initializer.get("opener")))
         self._close_reason: Optional[str] = None
         self._close_was_called = False
@@ -224,7 +229,6 @@ class Page(ChannelOwner):
                 self._on_web_socket_route(from_channel(params["webSocketRoute"]))
             ),
         )
-        self._channel.on("video", lambda params: self._on_video(params))
         self._channel.on("viewportSizeChanged", self._on_viewport_size_changed)
         self._channel.on(
             "webSocket",
@@ -355,10 +359,6 @@ class Page(ChannelOwner):
         self.emit(
             Page.Events.Download, Download(self, url, suggested_filename, artifact)
         )
-
-    def _on_video(self, params: Any) -> None:
-        artifact = from_channel(params["artifact"])
-        self._force_video()._artifact_ready(artifact)
 
     def _on_viewport_size_changed(self, params: Any) -> None:
         self._viewport_size = params["viewportSize"]
@@ -823,6 +823,18 @@ class Page(ChannelOwner):
     async def title(self) -> str:
         return await self._main_frame.title()
 
+    async def aria_snapshot(
+        self,
+        timeout: float = None,
+        depth: int = None,
+        mode: Literal["ai", "default"] = None,
+    ) -> str:
+        return await self._main_frame._channel.send(
+            "ariaSnapshot",
+            self._main_frame._timeout,
+            locals_to_params(locals()),
+        )
+
     async def close(self, runBeforeUnload: bool = None, reason: str = None) -> None:
         self._close_reason = reason
         self._close_was_called = True
@@ -1168,21 +1180,17 @@ class Page(ChannelOwner):
             await async_writefile(path, decoded_binary)
         return decoded_binary
 
-    def _force_video(self) -> Video:
-        if not self._video:
-            self._video = Video(self)
+    @property
+    def video(self) -> Optional[Video]:
+        # Video is only exposed when the page actually produced a recording artifact.
+        # The initializer carries the artifact; if absent, no video was recorded.
+        if not self._video._artifact:
+            return None
         return self._video
 
     @property
-    def video(
-        self,
-    ) -> Optional[Video]:
-        # Note: we are creating Video object lazily, because we do not know
-        # BrowserContextOptions when constructing the page - it is assigned
-        # too late during launchPersistentContext.
-        if not self._browser_context._videos_dir:
-            return None
-        return self._force_video()
+    def screencast(self) -> Screencast:
+        return self._screencast
 
     def _close_error_with_reason(self) -> TargetClosedError:
         return TargetClosedError(
@@ -1435,8 +1443,12 @@ class Page(ChannelOwner):
         request_objects = await self._channel.send("requests", None)
         return [from_channel(r) for r in request_objects]
 
-    async def console_messages(self) -> List[ConsoleMessage]:
-        message_dicts = await self._channel.send("consoleMessages", None)
+    async def console_messages(
+        self, filter: Literal["all", "since-navigation"] = None
+    ) -> List[ConsoleMessage]:
+        message_dicts = await self._channel.send(
+            "consoleMessages", None, locals_to_params(locals())
+        )
         return [
             ConsoleMessage(
                 {**event, "page": self._channel}, self._loop, self._dispatcher_fiber
@@ -1444,9 +1456,26 @@ class Page(ChannelOwner):
             for event in message_dicts
         ]
 
-    async def page_errors(self) -> List[Error]:
-        error_objects = await self._channel.send("pageErrors", None)
+    async def page_errors(
+        self, filter: Literal["all", "since-navigation"] = None
+    ) -> List[Error]:
+        error_objects = await self._channel.send(
+            "pageErrors", None, locals_to_params(locals())
+        )
         return [parse_error(error["error"]) for error in error_objects]
+
+    async def clear_console_messages(self) -> None:
+        await self._channel.send("clearConsoleMessages", None)
+
+    async def clear_page_errors(self) -> None:
+        await self._channel.send("clearPageErrors", None)
+
+    async def pick_locator(self) -> "Locator":
+        selector = await self._channel.send("pickLocator", None, {})
+        return self.locator(selector)
+
+    async def cancel_pick_locator(self) -> None:
+        await self._channel.send("cancelPickLocator", None, {})
 
 
 class Worker(ChannelOwner):

--- a/playwright/_impl/_screencast.py
+++ b/playwright/_impl/_screencast.py
@@ -1,0 +1,130 @@
+# Copyright (c) Microsoft Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union
+
+from playwright._impl._api_structures import ScreencastFrame
+from playwright._impl._artifact import Artifact
+from playwright._impl._connection import from_nullable_channel
+from playwright._impl._errors import Error
+from playwright._impl._helper import locals_to_params
+
+if TYPE_CHECKING:  # pragma: no cover
+    from playwright._impl._page import Page
+
+
+ScreencastFrameCallback = Callable[[ScreencastFrame], Any]
+ScreencastPosition = Literal[
+    "bottom",
+    "bottom-left",
+    "bottom-right",
+    "top",
+    "top-left",
+    "top-right",
+]
+
+
+class Screencast:
+    def __init__(self, page: "Page") -> None:
+        self._page = page
+        self._loop = page._loop
+        self._dispatcher_fiber = page._dispatcher_fiber
+        self._started = False
+        self._save_path: Optional[Union[str, Path]] = None
+        self._on_frame: Optional[ScreencastFrameCallback] = None
+        self._artifact: Optional[Artifact] = None
+        page._channel.on("screencastFrame", lambda params: self._dispatch_frame(params))
+
+    def _dispatch_frame(self, params: dict) -> None:
+        if not self._on_frame:
+            return
+        data = params["data"]
+        if isinstance(data, str):
+            data = base64.b64decode(data)
+        result = self._on_frame({"data": data})
+        if hasattr(result, "__await__"):
+            self._page._loop.create_task(result)
+
+    async def start(
+        self,
+        onFrame: ScreencastFrameCallback = None,
+        path: Union[str, Path] = None,
+        quality: int = None,
+    ) -> None:
+        if self._started:
+            raise Error("Screencast is already started")
+        self._started = True
+        self._on_frame = onFrame
+        result = await self._page._channel.send_return_as_dict(
+            "screencastStart",
+            None,
+            {
+                "quality": quality,
+                "sendFrames": bool(onFrame),
+                "record": bool(path),
+            },
+        )
+        artifact_channel = (result or {}).get("artifact")
+        if artifact_channel:
+            self._artifact = from_nullable_channel(artifact_channel)
+            self._save_path = path
+
+    async def stop(self) -> None:
+        self._started = False
+        self._on_frame = None
+        await self._page._channel.send("screencastStop", None)
+        if self._save_path and self._artifact:
+            await self._artifact.save_as(self._save_path)
+        self._artifact = None
+        self._save_path = None
+
+    async def show_actions(
+        self,
+        duration: float = None,
+        position: ScreencastPosition = None,
+        fontSize: int = None,
+    ) -> None:
+        await self._page._channel.send(
+            "screencastShowActions", None, locals_to_params(locals())
+        )
+
+    async def hide_actions(self) -> None:
+        await self._page._channel.send("screencastHideActions", None)
+
+    async def show_overlay(self, html: str, duration: float = None) -> None:
+        await self._page._channel.send(
+            "screencastShowOverlay", None, locals_to_params(locals())
+        )
+
+    async def show_chapter(
+        self,
+        title: str,
+        description: str = None,
+        duration: float = None,
+    ) -> None:
+        await self._page._channel.send(
+            "screencastChapter", None, locals_to_params(locals())
+        )
+
+    async def show_overlays(self) -> None:
+        await self._page._channel.send(
+            "screencastSetOverlayVisible", None, {"visible": True}
+        )
+
+    async def hide_overlays(self) -> None:
+        await self._page._channel.send(
+            "screencastSetOverlayVisible", None, {"visible": False}
+        )

--- a/playwright/_impl/_tracing.py
+++ b/playwright/_impl/_tracing.py
@@ -27,6 +27,7 @@ class Tracing(ChannelOwner):
     ) -> None:
         super().__init__(parent, type, guid, initializer)
         self._include_sources: bool = False
+        self._is_live: bool = False
         self._stacks_id: Optional[str] = None
         self._is_tracing: bool = False
         self._traces_dir: Optional[str] = None
@@ -38,11 +39,22 @@ class Tracing(ChannelOwner):
         snapshots: bool = None,
         screenshots: bool = None,
         sources: bool = None,
+        live: bool = None,
     ) -> None:
         params = locals_to_params(locals())
         self._include_sources = bool(sources)
+        self._is_live = bool(live)
 
-        await self._channel.send("tracingStart", None, params)
+        await self._channel.send(
+            "tracingStart",
+            None,
+            {
+                "name": name,
+                "snapshots": snapshots,
+                "screenshots": screenshots,
+                "live": live,
+            },
+        )
         trace_name = await self._channel.send(
             "tracingStartChunk", None, {"title": title, "name": name}
         )
@@ -58,7 +70,7 @@ class Tracing(ChannelOwner):
             self._is_tracing = True
             self._connection.set_is_tracing(True)
         self._stacks_id = await self._connection.local_utils.tracing_started(
-            self._traces_dir, trace_name
+            self._traces_dir, trace_name, self._is_live
         )
 
     async def stop_chunk(self, path: Union[pathlib.Path, str] = None) -> None:

--- a/playwright/_impl/_video.py
+++ b/playwright/_impl/_video.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pathlib
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from playwright._impl._artifact import Artifact
 from playwright._impl._helper import Error
@@ -23,49 +23,34 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 class Video:
-    def __init__(self, page: "Page") -> None:
+    def __init__(self, page: "Page", artifact: Optional[Artifact]) -> None:
         self._loop = page._loop
         self._dispatcher_fiber = page._dispatcher_fiber
         self._page = page
-        self._artifact_future = page._loop.create_future()
-        if page.is_closed():
-            self._page_closed()
-        else:
-            page.on("close", lambda page: self._page_closed())
+        self._is_remote = page._connection.is_remote
+        self._artifact = artifact
 
     def __repr__(self) -> str:
         return f"<Video page={self._page}>"
 
-    def _page_closed(self) -> None:
-        if not self._artifact_future.done():
-            self._artifact_future.set_exception(Error("Page closed"))
-
-    def _artifact_ready(self, artifact: Artifact) -> None:
-        if not self._artifact_future.done():
-            self._artifact_future.set_result(artifact)
-
     async def path(self) -> pathlib.Path:
-        if self._page._connection.is_remote:
+        if self._is_remote:
             raise Error(
                 "Path is not available when using browserType.connect(). Use save_as() to save a local copy."
             )
-        artifact = await self._artifact_future
-        if not artifact:
-            raise Error("Page did not produce any video frames")
-        return artifact.absolute_path
+        if not self._artifact:
+            raise Error("Video recording has not been started.")
+        return self._artifact.absolute_path
 
     async def save_as(self, path: Union[str, pathlib.Path]) -> None:
         if self._page._connection._is_sync and not self._page._is_closed:
             raise Error(
                 "Page is not yet closed. Close the page prior to calling save_as"
             )
-        artifact = await self._artifact_future
-        if not artifact:
-            raise Error("Page did not produce any video frames")
-        await artifact.save_as(path)
+        if not self._artifact:
+            raise Error("Video recording has not been started.")
+        await self._artifact.save_as(path)
 
     async def delete(self) -> None:
-        artifact = await self._artifact_future
-        if not artifact:
-            raise Error("Page did not produce any video frames")
-        await artifact.delete()
+        if self._artifact:
+            await self._artifact.delete()

--- a/playwright/async_api/__init__.py
+++ b/playwright/async_api/__init__.py
@@ -72,10 +72,14 @@ FilePayload = playwright._impl._api_structures.FilePayload
 FloatRect = playwright._impl._api_structures.FloatRect
 Geolocation = playwright._impl._api_structures.Geolocation
 HttpCredentials = playwright._impl._api_structures.HttpCredentials
+BrowserBindResult = playwright._impl._api_structures.BrowserBindResult
+DebuggerLocation = playwright._impl._api_structures.DebuggerLocation
+DebuggerPausedDetails = playwright._impl._api_structures.DebuggerPausedDetails
 PdfMargins = playwright._impl._api_structures.PdfMargins
 Position = playwright._impl._api_structures.Position
 ProxySettings = playwright._impl._api_structures.ProxySettings
 ResourceTiming = playwright._impl._api_structures.ResourceTiming
+ScreencastFrame = playwright._impl._api_structures.ScreencastFrame
 SourceLocation = playwright._impl._api_structures.SourceLocation
 StorageState = playwright._impl._api_structures.StorageState
 StorageStateCookie = playwright._impl._api_structures.StorageStateCookie
@@ -153,6 +157,7 @@ __all__ = [
     "APIRequestContext",
     "APIResponse",
     "Browser",
+    "BrowserBindResult",
     "BrowserContext",
     "BrowserType",
     "CDPSession",
@@ -174,6 +179,8 @@ __all__ = [
     "Keyboard",
     "Locator",
     "Mouse",
+    "DebuggerLocation",
+    "DebuggerPausedDetails",
     "Page",
     "PdfMargins",
     "Position",
@@ -183,6 +190,7 @@ __all__ = [
     "ResourceTiming",
     "Response",
     "Route",
+    "ScreencastFrame",
     "Selectors",
     "SourceLocation",
     "StorageState",

--- a/playwright/async_api/_generated.py
+++ b/playwright/async_api/_generated.py
@@ -19,8 +19,11 @@ import typing
 from typing import Literal
 
 from playwright._impl._api_structures import (
+    BrowserBindResult,
     ClientCertificate,
     Cookie,
+    DebuggerLocation,
+    DebuggerPausedDetails,
     FilePayload,
     FloatRect,
     Geolocation,
@@ -32,6 +35,7 @@ from playwright._impl._api_structures import (
     RemoteAddr,
     RequestSizes,
     ResourceTiming,
+    ScreencastFrame,
     SecurityDetails,
     SetCookieParam,
     SourceLocation,
@@ -56,6 +60,7 @@ from playwright._impl._browser_type import BrowserType as BrowserTypeImpl
 from playwright._impl._cdp_session import CDPSession as CDPSessionImpl
 from playwright._impl._clock import Clock as ClockImpl
 from playwright._impl._console_message import ConsoleMessage as ConsoleMessageImpl
+from playwright._impl._debugger import Debugger as DebuggerImpl
 from playwright._impl._dialog import Dialog as DialogImpl
 from playwright._impl._download import Download as DownloadImpl
 from playwright._impl._element_handle import ElementHandle as ElementHandleImpl
@@ -79,6 +84,7 @@ from playwright._impl._network import WebSocketRoute as WebSocketRouteImpl
 from playwright._impl._page import Page as PageImpl
 from playwright._impl._page import Worker as WorkerImpl
 from playwright._impl._playwright import Playwright as PlaywrightImpl
+from playwright._impl._screencast import Screencast as ScreencastImpl
 from playwright._impl._selectors import Selectors as SelectorsImpl
 from playwright._impl._tracing import Tracing as TracingImpl
 from playwright._impl._video import Video as VideoImpl
@@ -181,6 +187,21 @@ class Request(AsyncBase):
         Union[bytes, None]
         """
         return mapping.from_maybe_impl(self._impl_obj.post_data_buffer)
+
+    @property
+    def existing_response(self) -> typing.Optional["Response"]:
+        """Request.existing_response
+
+        Returns the `Response` object if the response has already been received, `null` otherwise.
+
+        Unlike `request.response()`, this method does not wait for the response to arrive. It returns immediately
+        with the response object if the response has been received, or `null` if the response has not been received yet.
+
+        Returns
+        -------
+        Union[Response, None]
+        """
+        return mapping.from_impl_nullable(self._impl_obj.existing_response)
 
     @property
     def frame(self) -> "Frame":
@@ -590,6 +611,18 @@ class Response(AsyncBase):
         """
 
         return mapping.from_impl_nullable(await self._impl_obj.security_details())
+
+    async def http_version(self) -> str:
+        """Response.http_version
+
+        Returns the http version used by the response.
+
+        Returns
+        -------
+        str
+        """
+
+        return mapping.from_maybe_impl(await self._impl_obj.http_version())
 
     async def finished(self) -> None:
         """Response.finished
@@ -3361,7 +3394,7 @@ class Frame(AsyncBase):
         Parameters
         ----------
         url : Union[Callable[[str], bool], Pattern[str], str, None]
-            A glob pattern, regex pattern or predicate receiving [URL] to match while waiting for the navigation. Note that if
+            A glob pattern, regex pattern, or predicate receiving [URL] to match while waiting for the navigation. Note that if
             the parameter is a string without wildcard characters, the method will wait for navigation to URL that is exactly
             equal to the string.
         wait_until : Union["commit", "domcontentloaded", "load", "networkidle", None]
@@ -3412,7 +3445,7 @@ class Frame(AsyncBase):
         Parameters
         ----------
         url : Union[Callable[[str], bool], Pattern[str], str]
-            A glob pattern, regex pattern or predicate receiving [URL] to match while waiting for the navigation. Note that if
+            A glob pattern, regex pattern, or predicate receiving [URL] to match while waiting for the navigation. Note that if
             the parameter is a string without wildcard characters, the method will wait for navigation to URL that is exactly
             equal to the string.
         wait_until : Union["commit", "domcontentloaded", "load", "networkidle", None]
@@ -4817,7 +4850,7 @@ class Frame(AsyncBase):
         <button>Submit</button>
         ```
 
-        You can locate each element by it's implicit role:
+        You can locate each element by its implicit role:
 
         ```py
         await expect(page.get_by_role(\"heading\", name=\"Sign up\")).to_be_visible()
@@ -4917,7 +4950,7 @@ class Frame(AsyncBase):
         <button data-testid=\"directions\">Itinéraire</button>
         ```
 
-        You can locate the element by it's test id:
+        You can locate the element by its test id:
 
         ```py
         await page.get_by_test_id(\"directions\").click()
@@ -6304,7 +6337,7 @@ class FrameLocator(AsyncBase):
         <button>Submit</button>
         ```
 
-        You can locate each element by it's implicit role:
+        You can locate each element by its implicit role:
 
         ```py
         await expect(page.get_by_role(\"heading\", name=\"Sign up\")).to_be_visible()
@@ -6404,7 +6437,7 @@ class FrameLocator(AsyncBase):
         <button data-testid=\"directions\">Itinéraire</button>
         ```
 
-        You can locate the element by it's test id:
+        You can locate the element by its test id:
 
         ```py
         await page.get_by_test_id(\"directions\").click()
@@ -7090,6 +7123,18 @@ class ConsoleMessage(AsyncBase):
         return mapping.from_impl(self._impl_obj.location)
 
     @property
+    def timestamp(self) -> float:
+        """ConsoleMessage.timestamp
+
+        The timestamp of the console message in milliseconds since the Unix epoch.
+
+        Returns
+        -------
+        float
+        """
+        return mapping.from_maybe_impl(self._impl_obj.timestamp)
+
+    @property
     def page(self) -> typing.Optional["Page"]:
         """ConsoleMessage.page
 
@@ -7116,6 +7161,115 @@ class ConsoleMessage(AsyncBase):
 
 
 mapping.register(ConsoleMessageImpl, ConsoleMessage)
+
+
+class Debugger(AsyncBase):
+
+    @typing.overload
+    def on(
+        self,
+        event: Literal["pausedstatechanged"],
+        f: typing.Callable[["None"], "typing.Union[typing.Awaitable[None], None]"],
+    ) -> None:
+        """
+        Emitted when the debugger pauses or resumes."""
+
+    @typing.overload
+    def on(
+        self,
+        event: str,
+        f: typing.Callable[..., typing.Union[typing.Awaitable[None], None]],
+    ) -> None: ...
+
+    def on(
+        self,
+        event: str,
+        f: typing.Callable[..., typing.Union[typing.Awaitable[None], None]],
+    ) -> None:
+        return super().on(event=event, f=f)
+
+    @typing.overload
+    def once(
+        self,
+        event: Literal["pausedstatechanged"],
+        f: typing.Callable[["None"], "typing.Union[typing.Awaitable[None], None]"],
+    ) -> None:
+        """
+        Emitted when the debugger pauses or resumes."""
+
+    @typing.overload
+    def once(
+        self,
+        event: str,
+        f: typing.Callable[..., typing.Union[typing.Awaitable[None], None]],
+    ) -> None: ...
+
+    def once(
+        self,
+        event: str,
+        f: typing.Callable[..., typing.Union[typing.Awaitable[None], None]],
+    ) -> None:
+        return super().once(event=event, f=f)
+
+    @property
+    def paused_details(self) -> typing.Optional[DebuggerPausedDetails]:
+        """Debugger.paused_details
+
+        Returns details about the currently paused call. Returns `null` if the debugger is not paused.
+
+        Returns
+        -------
+        Union[{location: {file: str, line: Union[int, None], column: Union[int, None]}, title: str}, None]
+        """
+        return mapping.from_impl_nullable(self._impl_obj.paused_details)
+
+    async def request_pause(self) -> None:
+        """Debugger.request_pause
+
+        Configures the debugger to pause before the next action is executed.
+
+        Throws if the debugger is already paused. Use `debugger.next()` or `debugger.run_to()` to step while
+        paused.
+
+        Note that `page.pause()` is equivalent to a \"debugger\" statement — it pauses execution at the call site
+        immediately. On the contrary, `debugger.request_pause()` is equivalent to \"pause on next statement\" — it
+        configures the debugger to pause before the next action is executed.
+        """
+
+        return mapping.from_maybe_impl(await self._impl_obj.request_pause())
+
+    async def resume(self) -> None:
+        """Debugger.resume
+
+        Resumes script execution. Throws if the debugger is not paused.
+        """
+
+        return mapping.from_maybe_impl(await self._impl_obj.resume())
+
+    async def next(self) -> None:
+        """Debugger.next
+
+        Resumes script execution and pauses again before the next action. Throws if the debugger is not paused.
+        """
+
+        return mapping.from_maybe_impl(await self._impl_obj.next())
+
+    async def run_to(self, location: DebuggerLocation) -> None:
+        """Debugger.run_to
+
+        Resumes script execution and pauses when an action originates from the given source location. Throws if the
+        debugger is not paused.
+
+        Parameters
+        ----------
+        location : {file: str, line: Union[int, None], column: Union[int, None]}
+            The source location to pause at.
+        """
+
+        return mapping.from_maybe_impl(await self._impl_obj.run_to(location=location))
+
+
+mapping.register(DebuggerImpl, Debugger)
 
 
 class Dialog(AsyncBase):
@@ -7303,6 +7457,157 @@ class Download(AsyncBase):
 
 
 mapping.register(DownloadImpl, Download)
+
+
+class Screencast(AsyncBase):
+
+    async def start(
+        self,
+        *,
+        on_frame: typing.Optional[
+            typing.Callable[[ScreencastFrame], typing.Any]
+        ] = None,
+        path: typing.Optional[typing.Union[pathlib.Path, str]] = None,
+        quality: typing.Optional[int] = None,
+    ) -> None:
+        """Screencast.start
+
+        Starts the screencast. When `path` is provided, it saves video recording to the specified file. When `onFrame` is
+        provided, delivers JPEG-encoded frames to the callback. Both can be used together.
+
+        **Usage**
+
+        Parameters
+        ----------
+        on_frame : Union[Callable[[{data: bytes}], Any], None]
+            Callback that receives JPEG-encoded frame data.
+        path : Union[pathlib.Path, str, None]
+            Path where the video should be saved when the screencast is stopped. When provided, video recording is started.
+        quality : Union[int, None]
+            The quality of the image, between 0-100.
+        """
+
+        return mapping.from_maybe_impl(
+            await self._impl_obj.start(
+                onFrame=self._wrap_handler(on_frame), path=path, quality=quality
+            )
+        )
+
+    async def stop(self) -> None:
+        """Screencast.stop
+
+        Stops the screencast and video recording if active. If a video was being recorded, saves it to the path specified
+        in `screencast.start()`.
+        """
+
+        return mapping.from_maybe_impl(await self._impl_obj.stop())
+
+    async def show_actions(
+        self,
+        *,
+        duration: typing.Optional[float] = None,
+        position: typing.Optional[
+            Literal[
+                "bottom", "bottom-left", "bottom-right", "top", "top-left", "top-right"
+            ]
+        ] = None,
+        font_size: typing.Optional[int] = None,
+    ) -> None:
+        """Screencast.show_actions
+
+        Enables visual annotations on interacted elements. Returns a disposable that stops showing actions when disposed.
+
+        Parameters
+        ----------
+        duration : Union[float, None]
+            How long each annotation is displayed in milliseconds. Defaults to `500`.
+        position : Union["bottom", "bottom-left", "bottom-right", "top", "top-left", "top-right", None]
+            Position of the action title overlay. Defaults to `"top-right"`.
+        font_size : Union[int, None]
+            Font size of the action title in pixels. Defaults to `24`.
+        """
+
+        return mapping.from_maybe_impl(
+            await self._impl_obj.show_actions(
+                duration=duration, position=position, fontSize=font_size
+            )
+        )
+
+    async def hide_actions(self) -> None:
+        """Screencast.hide_actions
+
+        Removes action decorations.
+        """
+
+        return mapping.from_maybe_impl(await self._impl_obj.hide_actions())
+
+    async def show_overlay(
+        self, html: str, *, duration: typing.Optional[float] = None
+    ) -> None:
+        """Screencast.show_overlay
+
+        Adds an overlay with the given HTML content. The overlay is displayed on top of the page until removed. Returns a
+        disposable that removes the overlay when disposed.
+
+        Parameters
+        ----------
+        html : str
+            HTML content for the overlay.
+        duration : Union[float, None]
+            Duration in milliseconds after which the overlay is automatically removed. Overlay stays until dismissed if not
+            provided.
+        """
+
+        return mapping.from_maybe_impl(
+            await self._impl_obj.show_overlay(html=html, duration=duration)
+        )
+
+    async def show_chapter(
+        self,
+        title: str,
+        *,
+        description: typing.Optional[str] = None,
+        duration: typing.Optional[float] = None,
+    ) -> None:
+        """Screencast.show_chapter
+
+        Shows a chapter overlay with a title and optional description, centered on the page with a blurred backdrop. Useful
+        for narrating video recordings. The overlay is removed after the specified duration, or 2000ms.
+
+        Parameters
+        ----------
+        title : str
+            Title text displayed prominently in the overlay.
+        description : Union[str, None]
+            Optional description text displayed below the title.
+        duration : Union[float, None]
+            Duration in milliseconds after which the overlay is automatically removed. Defaults to `2000`.
+        """
+
+        return mapping.from_maybe_impl(
+            await self._impl_obj.show_chapter(
+                title=title, description=description, duration=duration
+            )
+        )
+
+    async def show_overlays(self) -> None:
+        """Screencast.show_overlays
+
+        Shows overlays.
+        """
+
+        return mapping.from_maybe_impl(await self._impl_obj.show_overlays())
+
+    async def hide_overlays(self) -> None:
+        """Screencast.hide_overlays
+
+        Hides overlays without removing them.
+        """
+
+        return mapping.from_maybe_impl(await self._impl_obj.hide_overlays())
+
+
+mapping.register(ScreencastImpl, Screencast)
 
 
 class Video(AsyncBase):
@@ -8019,13 +8324,28 @@ class Page(AsyncContextManager):
     def video(self) -> typing.Optional["Video"]:
         """Page.video
 
-        Video object associated with this page.
+        Video object associated with this page. Can be used to access the video file when using the `recordVideo` context
+        option.
 
         Returns
         -------
         Union[Video, None]
         """
         return mapping.from_impl_nullable(self._impl_obj.video)
+
+    @property
+    def screencast(self) -> "Screencast":
+        """Page.screencast
+
+        `Screencast` object associated with this page.
+
+        **Usage**
+
+        Returns
+        -------
+        Screencast
+        """
+        return mapping.from_impl(self._impl_obj.screencast)
 
     async def opener(self) -> typing.Optional["Page"]:
         """Page.opener
@@ -9164,7 +9484,7 @@ class Page(AsyncContextManager):
         Parameters
         ----------
         url : Union[Callable[[str], bool], Pattern[str], str]
-            A glob pattern, regex pattern or predicate receiving [URL] to match while waiting for the navigation. Note that if
+            A glob pattern, regex pattern, or predicate receiving [URL] to match while waiting for the navigation. Note that if
             the parameter is a string without wildcard characters, the method will wait for navigation to URL that is exactly
             equal to the string.
         wait_until : Union["commit", "domcontentloaded", "load", "networkidle", None]
@@ -9534,6 +9854,8 @@ class Page(AsyncContextManager):
         await page.route(\"/api/**\", handle_route)
         ```
 
+        If a request matches multiple registered routes, the most recently registered route takes precedence.
+
         Page routes take precedence over browser context routes (set up with `browser_context.route()`) when request
         matches both handlers.
 
@@ -9579,7 +9901,7 @@ class Page(AsyncContextManager):
         Parameters
         ----------
         url : Union[Callable[[str], bool], Pattern[str], str]
-            A glob pattern, regex pattern or predicate receiving [URL] to match while routing.
+            A glob pattern, regex pattern, or predicate receiving [URL] to match while routing.
         handler : Union[Callable[[Route, Request], Any], Callable[[Route], Any], None]
             Optional handler function to route the request.
         """
@@ -9817,6 +10139,37 @@ class Page(AsyncContextManager):
         """
 
         return mapping.from_maybe_impl(await self._impl_obj.title())
+
+    async def aria_snapshot(
+        self,
+        *,
+        timeout: typing.Optional[float] = None,
+        depth: typing.Optional[int] = None,
+        mode: typing.Optional[Literal["ai", "default"]] = None,
+    ) -> str:
+        """Page.aria_snapshot
+
+        Captures the aria snapshot of the page. Read more about [aria snapshots](https://playwright.dev/python/docs/aria-snapshots).
+
+        Parameters
+        ----------
+        timeout : Union[float, None]
+            Maximum time in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can
+            be changed by using the `browser_context.set_default_timeout()` or `page.set_default_timeout()` methods.
+        depth : Union[int, None]
+            When specified, limits the depth of the snapshot.
+        mode : Union["ai", "default", None]
+            When set to `"ai"`, returns a snapshot optimized for AI consumption: including element references like `[ref=e2]`
+            and snapshots of `<iframe>`s. Defaults to `"default"`.
+
+        Returns
+        -------
+        str
+        """
+
+        return mapping.from_maybe_impl(
+            await self._impl_obj.aria_snapshot(timeout=timeout, depth=depth, mode=mode)
+        )
 
     async def close(
         self,
@@ -10441,7 +10794,7 @@ class Page(AsyncContextManager):
         <button>Submit</button>
         ```
 
-        You can locate each element by it's implicit role:
+        You can locate each element by its implicit role:
 
         ```py
         await expect(page.get_by_role(\"heading\", name=\"Sign up\")).to_be_visible()
@@ -10541,7 +10894,7 @@ class Page(AsyncContextManager):
         <button data-testid=\"directions\">Itinéraire</button>
         ```
 
-        You can locate the element by it's test id:
+        You can locate the element by its test id:
 
         ```py
         await page.get_by_test_id(\"directions\").click()
@@ -11860,7 +12213,7 @@ class Page(AsyncContextManager):
         Parameters
         ----------
         url : Union[Callable[[str], bool], Pattern[str], str, None]
-            A glob pattern, regex pattern or predicate receiving [URL] to match while waiting for the navigation. Note that if
+            A glob pattern, regex pattern, or predicate receiving [URL] to match while waiting for the navigation. Note that if
             the parameter is a string without wildcard characters, the method will wait for navigation to URL that is exactly
             equal to the string.
         wait_until : Union["commit", "domcontentloaded", "load", "networkidle", None]
@@ -12331,29 +12684,92 @@ class Page(AsyncContextManager):
 
         return mapping.from_impl_list(await self._impl_obj.requests())
 
-    async def console_messages(self) -> typing.List["ConsoleMessage"]:
+    async def console_messages(
+        self, *, filter: typing.Optional[Literal["all", "since-navigation"]] = None
+    ) -> typing.List["ConsoleMessage"]:
         """Page.console_messages
 
         Returns up to (currently) 200 last console messages from this page. See `page.on('console')` for more details.
+
+        Parameters
+        ----------
+        filter : Union["all", "since-navigation", None]
+            Controls which messages are returned:
 
         Returns
         -------
         List[ConsoleMessage]
         """
 
-        return mapping.from_impl_list(await self._impl_obj.console_messages())
+        return mapping.from_impl_list(
+            await self._impl_obj.console_messages(filter=filter)
+        )
 
-    async def page_errors(self) -> typing.List["Error"]:
+    async def page_errors(
+        self, *, filter: typing.Optional[Literal["all", "since-navigation"]] = None
+    ) -> typing.List["Error"]:
         """Page.page_errors
 
         Returns up to (currently) 200 last page errors from this page. See `page.on('page_error')` for more details.
+
+        Parameters
+        ----------
+        filter : Union["all", "since-navigation", None]
+            Controls which errors are returned:
 
         Returns
         -------
         List[Error]
         """
 
-        return mapping.from_impl_list(await self._impl_obj.page_errors())
+        return mapping.from_impl_list(await self._impl_obj.page_errors(filter=filter))
+
+    async def clear_console_messages(self) -> None:
+        """Page.clear_console_messages
+
+        Clears all stored console messages from this page. Subsequent calls to `page.console_messages()` will only
+        return messages logged after the clear.
+        """
+
+        return mapping.from_maybe_impl(await self._impl_obj.clear_console_messages())
+
+    async def clear_page_errors(self) -> None:
+        """Page.clear_page_errors
+
+        Clears all stored page errors from this page. Subsequent calls to `page.page_errors()` will only return
+        errors thrown after the clear.
+        """
+
+        return mapping.from_maybe_impl(await self._impl_obj.clear_page_errors())
+
+    async def pick_locator(self) -> "Locator":
+        """Page.pick_locator
+
+        Enters pick locator mode where hovering over page elements highlights them and shows the corresponding locator.
+        Once the user clicks an element, the mode is deactivated and the `Locator` for the picked element is returned.
+
+        **Usage**
+
+        ```py
+        locator = await page.pick_locator()
+        print(locator)
+        ```
+
+        Returns
+        -------
+        Locator
+        """
+
+        return mapping.from_impl(await self._impl_obj.pick_locator())
+
+    async def cancel_pick_locator(self) -> None:
+        """Page.cancel_pick_locator
+
+        Cancels an ongoing `page.pick_locator()` call by deactivating pick locator mode. If no pick locator mode is
+        active, this method is a no-op.
+        """
+
+        return mapping.from_maybe_impl(await self._impl_obj.cancel_pick_locator())
 
 
 mapping.register(PageImpl, Page)
@@ -12801,6 +13217,18 @@ class BrowserContext(AsyncContextManager):
         return mapping.from_impl(self._impl_obj.tracing)
 
     @property
+    def debugger(self) -> "Debugger":
+        """BrowserContext.debugger
+
+        Debugger allows to pause and resume the execution.
+
+        Returns
+        -------
+        Debugger
+        """
+        return mapping.from_impl(self._impl_obj.debugger)
+
+    @property
     def request(self) -> "APIRequestContext":
         """BrowserContext.request
 
@@ -12991,6 +13419,7 @@ class BrowserContext(AsyncContextManager):
             - `'notifications'`
             - `'payment-handler'`
             - `'storage-access'`
+            - `'screen-wake-lock'`
         origin : Union[str, None]
             The [origin] to grant permissions to, e.g. "https://example.com".
         """
@@ -13346,7 +13775,7 @@ class BrowserContext(AsyncContextManager):
         Parameters
         ----------
         url : Union[Callable[[str], bool], Pattern[str], str]
-            A glob pattern, regex pattern or predicate receiving [URL] used to register a routing with
+            A glob pattern, regex pattern, or predicate receiving [URL] used to register a routing with
             `browser_context.route()`.
         handler : Union[Callable[[Route, Request], Any], Callable[[Route], Any], None]
             Optional handler function used to register a routing with `browser_context.route()`.
@@ -13523,6 +13952,18 @@ class BrowserContext(AsyncContextManager):
             ).future
         )
 
+    def is_closed(self) -> bool:
+        """BrowserContext.is_closed
+
+        Indicates that the browser context is in the process of closing or has already been closed.
+
+        Returns
+        -------
+        bool
+        """
+
+        return mapping.from_maybe_impl(self._impl_obj.is_closed())
+
     async def close(self, *, reason: typing.Optional[str] = None) -> None:
         """BrowserContext.close
 
@@ -13566,6 +14007,33 @@ class BrowserContext(AsyncContextManager):
 
         return mapping.from_impl(
             await self._impl_obj.storage_state(path=path, indexedDB=indexed_db)
+        )
+
+    async def set_storage_state(
+        self, storage_state: typing.Union[StorageState, str, pathlib.Path]
+    ) -> None:
+        """BrowserContext.set_storage_state
+
+        Clears the existing cookies, local storage and IndexedDB entries for all origins and sets the new storage state.
+
+        **Usage**
+
+        ```py
+        # Load storage state from a file and apply it to the context.
+        await context.set_storage_state(\"state.json\")
+        ```
+
+        Parameters
+        ----------
+        storage_state : Union[pathlib.Path, str, {cookies: Sequence[{name: str, value: str, domain: str, path: str, expires: float, httpOnly: bool, secure: bool, sameSite: Union["Lax", "None", "Strict"]}], origins: Sequence[{origin: str, localStorage: Sequence[{name: str, value: str}]}]}]
+            Learn more about [storage state and auth](../auth.md).
+
+            Populates context with given storage state. This option can be used to initialize context with logged-in
+            information obtained via `browser_context.storage_state()`.
+        """
+
+        return mapping.from_maybe_impl(
+            await self._impl_obj.set_storage_state(storageState=storage_state)
         )
 
     async def wait_for_event(
@@ -13695,6 +14163,58 @@ mapping.register(BrowserContextImpl, BrowserContext)
 
 class CDPSession(AsyncBase):
 
+    @typing.overload
+    def on(
+        self,
+        event: Literal["close"],
+        f: typing.Callable[
+            ["CDPSession"], "typing.Union[typing.Awaitable[None], None]"
+        ],
+    ) -> None:
+        """
+        Emitted when the session is closed, either because the target was closed or `session.detach()` was called.
+        """
+
+    @typing.overload
+    def on(
+        self,
+        event: str,
+        f: typing.Callable[..., typing.Union[typing.Awaitable[None], None]],
+    ) -> None: ...
+
+    def on(
+        self,
+        event: str,
+        f: typing.Callable[..., typing.Union[typing.Awaitable[None], None]],
+    ) -> None:
+        return super().on(event=event, f=f)
+
+    @typing.overload
+    def once(
+        self,
+        event: Literal["close"],
+        f: typing.Callable[
+            ["CDPSession"], "typing.Union[typing.Awaitable[None], None]"
+        ],
+    ) -> None:
+        """
+        Emitted when the session is closed, either because the target was closed or `session.detach()` was called.
+        """
+
+    @typing.overload
+    def once(
+        self,
+        event: str,
+        f: typing.Callable[..., typing.Union[typing.Awaitable[None], None]],
+    ) -> None: ...
+
+    def once(
+        self,
+        event: str,
+        f: typing.Callable[..., typing.Union[typing.Awaitable[None], None]],
+    ) -> None:
+        return super().once(event=event, f=f)
+
     async def send(
         self, method: str, params: typing.Optional[typing.Dict] = None
     ) -> typing.Dict:
@@ -13731,6 +14251,7 @@ mapping.register(CDPSessionImpl, CDPSession)
 
 class Browser(AsyncContextManager):
 
+    @typing.overload
     def on(
         self,
         event: Literal["disconnected"],
@@ -13741,8 +14262,22 @@ class Browser(AsyncContextManager):
         following:
         - Browser application is closed or crashed.
         - The `browser.close()` method was called."""
+
+    @typing.overload
+    def on(
+        self,
+        event: str,
+        f: typing.Callable[..., typing.Union[typing.Awaitable[None], None]],
+    ) -> None: ...
+
+    def on(
+        self,
+        event: str,
+        f: typing.Callable[..., typing.Union[typing.Awaitable[None], None]],
+    ) -> None:
         return super().on(event=event, f=f)
 
+    @typing.overload
     def once(
         self,
         event: Literal["disconnected"],
@@ -13753,6 +14288,19 @@ class Browser(AsyncContextManager):
         following:
         - Browser application is closed or crashed.
         - The `browser.close()` method was called."""
+
+    @typing.overload
+    def once(
+        self,
+        event: str,
+        f: typing.Callable[..., typing.Union[typing.Awaitable[None], None]],
+    ) -> None: ...
+
+    def once(
+        self,
+        event: str,
+        f: typing.Callable[..., typing.Union[typing.Awaitable[None], None]],
+    ) -> None:
         return super().once(event=event, f=f)
 
     @property
@@ -14335,6 +14883,49 @@ class Browser(AsyncContextManager):
 
         return mapping.from_impl(await self._impl_obj.new_browser_cdp_session())
 
+    async def bind(
+        self,
+        title: str,
+        *,
+        workspace_dir: typing.Optional[str] = None,
+        host: typing.Optional[str] = None,
+        port: typing.Optional[int] = None,
+    ) -> BrowserBindResult:
+        """Browser.bind
+
+        Binds the browser to a named pipe or web socket, making it available for other clients to connect to.
+
+        Parameters
+        ----------
+        title : str
+            Title of the browser server, used for identification.
+        workspace_dir : Union[str, None]
+            Working directory associated with this browser server.
+        host : Union[str, None]
+            Host to bind the web socket server to. When specified, a web socket server is created instead of a named pipe.
+        port : Union[int, None]
+            Port to bind the web socket server to. When specified, a web socket server is created instead of a named pipe. Use
+            `0` to let the OS pick an available port.
+
+        Returns
+        -------
+        {endpoint: str}
+        """
+
+        return mapping.from_impl(
+            await self._impl_obj.bind(
+                title=title, workspaceDir=workspace_dir, host=host, port=port
+            )
+        )
+
+    async def unbind(self) -> None:
+        """Browser.unbind
+
+        Unbinds the browser server previously bound with `browser.bind()`.
+        """
+
+        return mapping.from_maybe_impl(await self._impl_obj.unbind())
+
     async def start_tracing(
         self,
         *,
@@ -14448,6 +15039,7 @@ class BrowserType(AsyncBase):
         downloads_path: typing.Optional[typing.Union[pathlib.Path, str]] = None,
         slow_mo: typing.Optional[float] = None,
         traces_dir: typing.Optional[typing.Union[pathlib.Path, str]] = None,
+        artifacts_dir: typing.Optional[typing.Union[pathlib.Path, str]] = None,
         chromium_sandbox: typing.Optional[bool] = None,
         firefox_user_prefs: typing.Optional[
             typing.Dict[str, typing.Union[str, float, bool]]
@@ -14529,6 +15121,10 @@ class BrowserType(AsyncBase):
             on.
         traces_dir : Union[pathlib.Path, str, None]
             If specified, traces are saved into this directory.
+        artifacts_dir : Union[pathlib.Path, str, None]
+            If specified, artifacts (traces, videos, downloads, HAR files, etc.) are saved into this directory. The directory
+            is not cleaned up when the browser closes. If not specified, a temporary directory is used and cleaned up when the
+            browser closes.
         chromium_sandbox : Union[bool, None]
             Enable Chromium sandboxing. Defaults to `false`.
         firefox_user_prefs : Union[Dict[str, Union[bool, float, str]], None]
@@ -14559,6 +15155,7 @@ class BrowserType(AsyncBase):
                 downloadsPath=downloads_path,
                 slowMo=slow_mo,
                 tracesDir=traces_dir,
+                artifactsDir=artifacts_dir,
                 chromiumSandbox=chromium_sandbox,
                 firefoxUserPrefs=mapping.to_impl(firefox_user_prefs),
             )
@@ -14610,6 +15207,7 @@ class BrowserType(AsyncBase):
         contrast: typing.Optional[Literal["more", "no-preference", "null"]] = None,
         accept_downloads: typing.Optional[bool] = None,
         traces_dir: typing.Optional[typing.Union[pathlib.Path, str]] = None,
+        artifacts_dir: typing.Optional[typing.Union[pathlib.Path, str]] = None,
         chromium_sandbox: typing.Optional[bool] = None,
         firefox_user_prefs: typing.Optional[
             typing.Dict[str, typing.Union[str, float, bool]]
@@ -14764,6 +15362,10 @@ class BrowserType(AsyncBase):
             Whether to automatically download all the attachments. Defaults to `true` where all the downloads are accepted.
         traces_dir : Union[pathlib.Path, str, None]
             If specified, traces are saved into this directory.
+        artifacts_dir : Union[pathlib.Path, str, None]
+            If specified, artifacts (traces, videos, downloads, HAR files, etc.) are saved into this directory. The directory
+            is not cleaned up when the browser closes. If not specified, a temporary directory is used and cleaned up when the
+            browser closes.
         chromium_sandbox : Union[bool, None]
             Enable Chromium sandboxing. Defaults to `false`.
         firefox_user_prefs : Union[Dict[str, Union[bool, float, str]], None]
@@ -14875,6 +15477,7 @@ class BrowserType(AsyncBase):
                 contrast=contrast,
                 acceptDownloads=accept_downloads,
                 tracesDir=traces_dir,
+                artifactsDir=artifacts_dir,
                 chromiumSandbox=chromium_sandbox,
                 firefoxUserPrefs=mapping.to_impl(firefox_user_prefs),
                 recordHarPath=record_har_path,
@@ -14954,7 +15557,7 @@ class BrowserType(AsyncBase):
 
     async def connect(
         self,
-        ws_endpoint: str,
+        endpoint: str,
         *,
         timeout: typing.Optional[float] = None,
         slow_mo: typing.Optional[float] = None,
@@ -14970,7 +15573,7 @@ class BrowserType(AsyncBase):
 
         Parameters
         ----------
-        ws_endpoint : str
+        endpoint : str
             A Playwright browser websocket endpoint to connect to. You obtain this endpoint via `BrowserServer.wsEndpoint`.
         timeout : Union[float, None]
             Maximum time in milliseconds to wait for the connection to be established. Defaults to `0` (no timeout).
@@ -15001,7 +15604,7 @@ class BrowserType(AsyncBase):
 
         return mapping.from_impl(
             await self._impl_obj.connect(
-                wsEndpoint=ws_endpoint,
+                endpoint=endpoint,
                 timeout=timeout,
                 slowMo=slow_mo,
                 headers=mapping.to_impl(headers),
@@ -15149,6 +15752,7 @@ class Tracing(AsyncBase):
         snapshots: typing.Optional[bool] = None,
         screenshots: typing.Optional[bool] = None,
         sources: typing.Optional[bool] = None,
+        live: typing.Optional[bool] = None,
     ) -> None:
         """Tracing.start
 
@@ -15188,6 +15792,10 @@ class Tracing(AsyncBase):
             Whether to capture screenshots during tracing. Screenshots are used to build a timeline preview.
         sources : Union[bool, None]
             Whether to include source files for trace actions.
+        live : Union[bool, None]
+            When enabled, the trace is written to an unarchived file that is updated in real time as actions occur, instead of
+            caching changes and archiving them into a zip file at the end. This is useful for live trace viewing during test
+            execution.
         """
 
         return mapping.from_maybe_impl(
@@ -15197,6 +15805,7 @@ class Tracing(AsyncBase):
                 snapshots=snapshots,
                 screenshots=screenshots,
                 sources=sources,
+                live=live,
             )
         )
 
@@ -16283,7 +16892,7 @@ class Locator(AsyncBase):
         <button>Submit</button>
         ```
 
-        You can locate each element by it's implicit role:
+        You can locate each element by its implicit role:
 
         ```py
         await expect(page.get_by_role(\"heading\", name=\"Sign up\")).to_be_visible()
@@ -16383,7 +16992,7 @@ class Locator(AsyncBase):
         <button data-testid=\"directions\">Itinéraire</button>
         ```
 
-        You can locate the element by it's test id:
+        You can locate the element by its test id:
 
         ```py
         await page.get_by_test_id(\"directions\").click()
@@ -17406,7 +18015,13 @@ class Locator(AsyncBase):
             )
         )
 
-    async def aria_snapshot(self, *, timeout: typing.Optional[float] = None) -> str:
+    async def aria_snapshot(
+        self,
+        *,
+        timeout: typing.Optional[float] = None,
+        depth: typing.Optional[int] = None,
+        mode: typing.Optional[Literal["ai", "default"]] = None,
+    ) -> str:
         """Locator.aria_snapshot
 
         Captures the aria snapshot of the given element. Read more about [aria snapshots](https://playwright.dev/python/docs/aria-snapshots) and
@@ -17446,11 +18061,20 @@ class Locator(AsyncBase):
             - link \"About\"
         ```
 
+        An AI-optimized snapshot, controlled by `mode`, is different from a default snapshot:
+        1. Includes element references `[ref=e2]`. 2. Does not wait for an element matching the locator, and throws when
+           no elements match. 3. Includes snapshots of `<iframe>`s inside the target.
+
         Parameters
         ----------
         timeout : Union[float, None]
             Maximum time in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can
             be changed by using the `browser_context.set_default_timeout()` or `page.set_default_timeout()` methods.
+        depth : Union[int, None]
+            When specified, limits the depth of the snapshot.
+        mode : Union["ai", "default", None]
+            When set to `"ai"`, returns a snapshot optimized for AI consumption. Defaults to `"default"`. See details for more
+            information.
 
         Returns
         -------
@@ -17458,8 +18082,22 @@ class Locator(AsyncBase):
         """
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.aria_snapshot(timeout=timeout)
+            await self._impl_obj.aria_snapshot(timeout=timeout, depth=depth, mode=mode)
         )
+
+    async def normalize(self) -> "Locator":
+        """Locator.normalize
+
+        Returns a new locator that uses best practices for referencing the matched element, prioritizing test ids, aria
+        roles, and other user-facing attributes over CSS selectors. This is useful for converting implementation-detail
+        selectors into more resilient, human-readable locators.
+
+        Returns
+        -------
+        Locator
+        """
+
+        return mapping.from_impl(await self._impl_obj.normalize())
 
     async def scroll_into_view_if_needed(
         self, *, timeout: typing.Optional[float] = None
@@ -18221,7 +18859,7 @@ class APIRequestContext(AsyncBase):
             typing.Union[typing.Dict[str, typing.Union[str, float, bool]], str]
         ] = None,
         headers: typing.Optional[typing.Dict[str, str]] = None,
-        data: typing.Optional[typing.Union[typing.Any, str, bytes]] = None,
+        data: typing.Optional[typing.Union[typing.Any, bytes, str]] = None,
         form: typing.Optional[typing.Dict[str, typing.Union[str, float, bool]]] = None,
         multipart: typing.Optional[
             typing.Dict[str, typing.Union[bytes, bool, float, str, FilePayload]]
@@ -18302,7 +18940,7 @@ class APIRequestContext(AsyncBase):
             typing.Union[typing.Dict[str, typing.Union[str, float, bool]], str]
         ] = None,
         headers: typing.Optional[typing.Dict[str, str]] = None,
-        data: typing.Optional[typing.Union[typing.Any, str, bytes]] = None,
+        data: typing.Optional[typing.Union[typing.Any, bytes, str]] = None,
         form: typing.Optional[typing.Dict[str, typing.Union[str, float, bool]]] = None,
         multipart: typing.Optional[
             typing.Dict[str, typing.Union[bytes, bool, float, str, FilePayload]]
@@ -18383,7 +19021,7 @@ class APIRequestContext(AsyncBase):
             typing.Union[typing.Dict[str, typing.Union[str, float, bool]], str]
         ] = None,
         headers: typing.Optional[typing.Dict[str, str]] = None,
-        data: typing.Optional[typing.Union[typing.Any, str, bytes]] = None,
+        data: typing.Optional[typing.Union[typing.Any, bytes, str]] = None,
         form: typing.Optional[typing.Dict[str, typing.Union[str, float, bool]]] = None,
         multipart: typing.Optional[
             typing.Dict[str, typing.Union[bytes, bool, float, str, FilePayload]]
@@ -18476,7 +19114,7 @@ class APIRequestContext(AsyncBase):
             typing.Union[typing.Dict[str, typing.Union[str, float, bool]], str]
         ] = None,
         headers: typing.Optional[typing.Dict[str, str]] = None,
-        data: typing.Optional[typing.Union[typing.Any, str, bytes]] = None,
+        data: typing.Optional[typing.Union[typing.Any, bytes, str]] = None,
         form: typing.Optional[typing.Dict[str, typing.Union[str, float, bool]]] = None,
         multipart: typing.Optional[
             typing.Dict[str, typing.Union[bytes, bool, float, str, FilePayload]]
@@ -18557,7 +19195,7 @@ class APIRequestContext(AsyncBase):
             typing.Union[typing.Dict[str, typing.Union[str, float, bool]], str]
         ] = None,
         headers: typing.Optional[typing.Dict[str, str]] = None,
-        data: typing.Optional[typing.Union[typing.Any, str, bytes]] = None,
+        data: typing.Optional[typing.Union[typing.Any, bytes, str]] = None,
         form: typing.Optional[typing.Dict[str, typing.Union[str, float, bool]]] = None,
         multipart: typing.Optional[
             typing.Dict[str, typing.Union[bytes, bool, float, str, FilePayload]]
@@ -18638,7 +19276,7 @@ class APIRequestContext(AsyncBase):
             typing.Union[typing.Dict[str, typing.Union[str, float, bool]], str]
         ] = None,
         headers: typing.Optional[typing.Dict[str, str]] = None,
-        data: typing.Optional[typing.Union[typing.Any, str, bytes]] = None,
+        data: typing.Optional[typing.Union[typing.Any, bytes, str]] = None,
         form: typing.Optional[typing.Dict[str, typing.Union[str, float, bool]]] = None,
         multipart: typing.Optional[
             typing.Dict[str, typing.Union[bytes, bool, float, str, FilePayload]]
@@ -18751,7 +19389,7 @@ class APIRequestContext(AsyncBase):
         ] = None,
         method: typing.Optional[str] = None,
         headers: typing.Optional[typing.Dict[str, str]] = None,
-        data: typing.Optional[typing.Union[typing.Any, str, bytes]] = None,
+        data: typing.Optional[typing.Union[typing.Any, bytes, str]] = None,
         form: typing.Optional[typing.Dict[str, typing.Union[str, float, bool]]] = None,
         multipart: typing.Optional[
             typing.Dict[str, typing.Union[bytes, bool, float, str, FilePayload]]

--- a/playwright/sync_api/__init__.py
+++ b/playwright/sync_api/__init__.py
@@ -72,10 +72,14 @@ FilePayload = playwright._impl._api_structures.FilePayload
 FloatRect = playwright._impl._api_structures.FloatRect
 Geolocation = playwright._impl._api_structures.Geolocation
 HttpCredentials = playwright._impl._api_structures.HttpCredentials
+BrowserBindResult = playwright._impl._api_structures.BrowserBindResult
+DebuggerLocation = playwright._impl._api_structures.DebuggerLocation
+DebuggerPausedDetails = playwright._impl._api_structures.DebuggerPausedDetails
 PdfMargins = playwright._impl._api_structures.PdfMargins
 Position = playwright._impl._api_structures.Position
 ProxySettings = playwright._impl._api_structures.ProxySettings
 ResourceTiming = playwright._impl._api_structures.ResourceTiming
+ScreencastFrame = playwright._impl._api_structures.ScreencastFrame
 SourceLocation = playwright._impl._api_structures.SourceLocation
 StorageState = playwright._impl._api_structures.StorageState
 StorageStateCookie = playwright._impl._api_structures.StorageStateCookie
@@ -152,6 +156,7 @@ __all__ = [
     "APIRequestContext",
     "APIResponse",
     "Browser",
+    "BrowserBindResult",
     "BrowserContext",
     "BrowserType",
     "CDPSession",
@@ -173,6 +178,8 @@ __all__ = [
     "Keyboard",
     "Locator",
     "Mouse",
+    "DebuggerLocation",
+    "DebuggerPausedDetails",
     "Page",
     "PdfMargins",
     "Position",
@@ -182,6 +189,7 @@ __all__ = [
     "ResourceTiming",
     "Response",
     "Route",
+    "ScreencastFrame",
     "Selectors",
     "SourceLocation",
     "StorageState",

--- a/playwright/sync_api/_generated.py
+++ b/playwright/sync_api/_generated.py
@@ -19,8 +19,11 @@ import typing
 from typing import Literal
 
 from playwright._impl._api_structures import (
+    BrowserBindResult,
     ClientCertificate,
     Cookie,
+    DebuggerLocation,
+    DebuggerPausedDetails,
     FilePayload,
     FloatRect,
     Geolocation,
@@ -32,6 +35,7 @@ from playwright._impl._api_structures import (
     RemoteAddr,
     RequestSizes,
     ResourceTiming,
+    ScreencastFrame,
     SecurityDetails,
     SetCookieParam,
     SourceLocation,
@@ -50,6 +54,7 @@ from playwright._impl._browser_type import BrowserType as BrowserTypeImpl
 from playwright._impl._cdp_session import CDPSession as CDPSessionImpl
 from playwright._impl._clock import Clock as ClockImpl
 from playwright._impl._console_message import ConsoleMessage as ConsoleMessageImpl
+from playwright._impl._debugger import Debugger as DebuggerImpl
 from playwright._impl._dialog import Dialog as DialogImpl
 from playwright._impl._download import Download as DownloadImpl
 from playwright._impl._element_handle import ElementHandle as ElementHandleImpl
@@ -73,6 +78,7 @@ from playwright._impl._network import WebSocketRoute as WebSocketRouteImpl
 from playwright._impl._page import Page as PageImpl
 from playwright._impl._page import Worker as WorkerImpl
 from playwright._impl._playwright import Playwright as PlaywrightImpl
+from playwright._impl._screencast import Screencast as ScreencastImpl
 from playwright._impl._selectors import Selectors as SelectorsImpl
 from playwright._impl._sync_base import (
     EventContextManager,
@@ -181,6 +187,21 @@ class Request(SyncBase):
         Union[bytes, None]
         """
         return mapping.from_maybe_impl(self._impl_obj.post_data_buffer)
+
+    @property
+    def existing_response(self) -> typing.Optional["Response"]:
+        """Request.existing_response
+
+        Returns the `Response` object if the response has already been received, `null` otherwise.
+
+        Unlike `request.response()`, this method does not wait for the response to arrive. It returns immediately
+        with the response object if the response has been received, or `null` if the response has not been received yet.
+
+        Returns
+        -------
+        Union[Response, None]
+        """
+        return mapping.from_impl_nullable(self._impl_obj.existing_response)
 
     @property
     def frame(self) -> "Frame":
@@ -596,6 +617,18 @@ class Response(SyncBase):
         """
 
         return mapping.from_impl_nullable(self._sync(self._impl_obj.security_details()))
+
+    def http_version(self) -> str:
+        """Response.http_version
+
+        Returns the http version used by the response.
+
+        Returns
+        -------
+        str
+        """
+
+        return mapping.from_maybe_impl(self._sync(self._impl_obj.http_version()))
 
     def finished(self) -> None:
         """Response.finished
@@ -3411,7 +3444,7 @@ class Frame(SyncBase):
         Parameters
         ----------
         url : Union[Callable[[str], bool], Pattern[str], str, None]
-            A glob pattern, regex pattern or predicate receiving [URL] to match while waiting for the navigation. Note that if
+            A glob pattern, regex pattern, or predicate receiving [URL] to match while waiting for the navigation. Note that if
             the parameter is a string without wildcard characters, the method will wait for navigation to URL that is exactly
             equal to the string.
         wait_until : Union["commit", "domcontentloaded", "load", "networkidle", None]
@@ -3462,7 +3495,7 @@ class Frame(SyncBase):
         Parameters
         ----------
         url : Union[Callable[[str], bool], Pattern[str], str]
-            A glob pattern, regex pattern or predicate receiving [URL] to match while waiting for the navigation. Note that if
+            A glob pattern, regex pattern, or predicate receiving [URL] to match while waiting for the navigation. Note that if
             the parameter is a string without wildcard characters, the method will wait for navigation to URL that is exactly
             equal to the string.
         wait_until : Union["commit", "domcontentloaded", "load", "networkidle", None]
@@ -4896,7 +4929,7 @@ class Frame(SyncBase):
         <button>Submit</button>
         ```
 
-        You can locate each element by it's implicit role:
+        You can locate each element by its implicit role:
 
         ```py
         expect(page.get_by_role(\"heading\", name=\"Sign up\")).to_be_visible()
@@ -4996,7 +5029,7 @@ class Frame(SyncBase):
         <button data-testid=\"directions\">Itinéraire</button>
         ```
 
-        You can locate the element by it's test id:
+        You can locate the element by its test id:
 
         ```py
         page.get_by_test_id(\"directions\").click()
@@ -6410,7 +6443,7 @@ class FrameLocator(SyncBase):
         <button>Submit</button>
         ```
 
-        You can locate each element by it's implicit role:
+        You can locate each element by its implicit role:
 
         ```py
         expect(page.get_by_role(\"heading\", name=\"Sign up\")).to_be_visible()
@@ -6510,7 +6543,7 @@ class FrameLocator(SyncBase):
         <button data-testid=\"directions\">Itinéraire</button>
         ```
 
-        You can locate the element by it's test id:
+        You can locate the element by its test id:
 
         ```py
         page.get_by_test_id(\"directions\").click()
@@ -7180,6 +7213,18 @@ class ConsoleMessage(SyncBase):
         return mapping.from_impl(self._impl_obj.location)
 
     @property
+    def timestamp(self) -> float:
+        """ConsoleMessage.timestamp
+
+        The timestamp of the console message in milliseconds since the Unix epoch.
+
+        Returns
+        -------
+        float
+        """
+        return mapping.from_maybe_impl(self._impl_obj.timestamp)
+
+    @property
     def page(self) -> typing.Optional["Page"]:
         """ConsoleMessage.page
 
@@ -7206,6 +7251,97 @@ class ConsoleMessage(SyncBase):
 
 
 mapping.register(ConsoleMessageImpl, ConsoleMessage)
+
+
+class Debugger(SyncBase):
+
+    @typing.overload
+    def on(
+        self, event: Literal["pausedstatechanged"], f: typing.Callable[["None"], "None"]
+    ) -> None:
+        """
+        Emitted when the debugger pauses or resumes."""
+
+    @typing.overload
+    def on(self, event: str, f: typing.Callable[..., None]) -> None: ...
+
+    def on(self, event: str, f: typing.Callable[..., None]) -> None:
+        return super().on(event=event, f=f)
+
+    @typing.overload
+    def once(
+        self, event: Literal["pausedstatechanged"], f: typing.Callable[["None"], "None"]
+    ) -> None:
+        """
+        Emitted when the debugger pauses or resumes."""
+
+    @typing.overload
+    def once(self, event: str, f: typing.Callable[..., None]) -> None: ...
+
+    def once(self, event: str, f: typing.Callable[..., None]) -> None:
+        return super().once(event=event, f=f)
+
+    @property
+    def paused_details(self) -> typing.Optional[DebuggerPausedDetails]:
+        """Debugger.paused_details
+
+        Returns details about the currently paused call. Returns `null` if the debugger is not paused.
+
+        Returns
+        -------
+        Union[{location: {file: str, line: Union[int, None], column: Union[int, None]}, title: str}, None]
+        """
+        return mapping.from_impl_nullable(self._impl_obj.paused_details)
+
+    def request_pause(self) -> None:
+        """Debugger.request_pause
+
+        Configures the debugger to pause before the next action is executed.
+
+        Throws if the debugger is already paused. Use `debugger.next()` or `debugger.run_to()` to step while
+        paused.
+
+        Note that `page.pause()` is equivalent to a \"debugger\" statement — it pauses execution at the call site
+        immediately. On the contrary, `debugger.request_pause()` is equivalent to \"pause on next statement\" — it
+        configures the debugger to pause before the next action is executed.
+        """
+
+        return mapping.from_maybe_impl(self._sync(self._impl_obj.request_pause()))
+
+    def resume(self) -> None:
+        """Debugger.resume
+
+        Resumes script execution. Throws if the debugger is not paused.
+        """
+
+        return mapping.from_maybe_impl(self._sync(self._impl_obj.resume()))
+
+    def next(self) -> None:
+        """Debugger.next
+
+        Resumes script execution and pauses again before the next action. Throws if the debugger is not paused.
+        """
+
+        return mapping.from_maybe_impl(self._sync(self._impl_obj.next()))
+
+    def run_to(self, location: DebuggerLocation) -> None:
+        """Debugger.run_to
+
+        Resumes script execution and pauses when an action originates from the given source location. Throws if the
+        debugger is not paused.
+
+        Parameters
+        ----------
+        location : {file: str, line: Union[int, None], column: Union[int, None]}
+            The source location to pause at.
+        """
+
+        return mapping.from_maybe_impl(
+            self._sync(self._impl_obj.run_to(location=location))
+        )
+
+
+mapping.register(DebuggerImpl, Debugger)
 
 
 class Dialog(SyncBase):
@@ -7393,6 +7529,163 @@ class Download(SyncBase):
 
 
 mapping.register(DownloadImpl, Download)
+
+
+class Screencast(SyncBase):
+
+    def start(
+        self,
+        *,
+        on_frame: typing.Optional[
+            typing.Callable[[ScreencastFrame], typing.Any]
+        ] = None,
+        path: typing.Optional[typing.Union[pathlib.Path, str]] = None,
+        quality: typing.Optional[int] = None,
+    ) -> None:
+        """Screencast.start
+
+        Starts the screencast. When `path` is provided, it saves video recording to the specified file. When `onFrame` is
+        provided, delivers JPEG-encoded frames to the callback. Both can be used together.
+
+        **Usage**
+
+        Parameters
+        ----------
+        on_frame : Union[Callable[[{data: bytes}], Any], None]
+            Callback that receives JPEG-encoded frame data.
+        path : Union[pathlib.Path, str, None]
+            Path where the video should be saved when the screencast is stopped. When provided, video recording is started.
+        quality : Union[int, None]
+            The quality of the image, between 0-100.
+        """
+
+        return mapping.from_maybe_impl(
+            self._sync(
+                self._impl_obj.start(
+                    onFrame=self._wrap_handler(on_frame), path=path, quality=quality
+                )
+            )
+        )
+
+    def stop(self) -> None:
+        """Screencast.stop
+
+        Stops the screencast and video recording if active. If a video was being recorded, saves it to the path specified
+        in `screencast.start()`.
+        """
+
+        return mapping.from_maybe_impl(self._sync(self._impl_obj.stop()))
+
+    def show_actions(
+        self,
+        *,
+        duration: typing.Optional[float] = None,
+        position: typing.Optional[
+            Literal[
+                "bottom", "bottom-left", "bottom-right", "top", "top-left", "top-right"
+            ]
+        ] = None,
+        font_size: typing.Optional[int] = None,
+    ) -> None:
+        """Screencast.show_actions
+
+        Enables visual annotations on interacted elements. Returns a disposable that stops showing actions when disposed.
+
+        Parameters
+        ----------
+        duration : Union[float, None]
+            How long each annotation is displayed in milliseconds. Defaults to `500`.
+        position : Union["bottom", "bottom-left", "bottom-right", "top", "top-left", "top-right", None]
+            Position of the action title overlay. Defaults to `"top-right"`.
+        font_size : Union[int, None]
+            Font size of the action title in pixels. Defaults to `24`.
+        """
+
+        return mapping.from_maybe_impl(
+            self._sync(
+                self._impl_obj.show_actions(
+                    duration=duration, position=position, fontSize=font_size
+                )
+            )
+        )
+
+    def hide_actions(self) -> None:
+        """Screencast.hide_actions
+
+        Removes action decorations.
+        """
+
+        return mapping.from_maybe_impl(self._sync(self._impl_obj.hide_actions()))
+
+    def show_overlay(
+        self, html: str, *, duration: typing.Optional[float] = None
+    ) -> None:
+        """Screencast.show_overlay
+
+        Adds an overlay with the given HTML content. The overlay is displayed on top of the page until removed. Returns a
+        disposable that removes the overlay when disposed.
+
+        Parameters
+        ----------
+        html : str
+            HTML content for the overlay.
+        duration : Union[float, None]
+            Duration in milliseconds after which the overlay is automatically removed. Overlay stays until dismissed if not
+            provided.
+        """
+
+        return mapping.from_maybe_impl(
+            self._sync(self._impl_obj.show_overlay(html=html, duration=duration))
+        )
+
+    def show_chapter(
+        self,
+        title: str,
+        *,
+        description: typing.Optional[str] = None,
+        duration: typing.Optional[float] = None,
+    ) -> None:
+        """Screencast.show_chapter
+
+        Shows a chapter overlay with a title and optional description, centered on the page with a blurred backdrop. Useful
+        for narrating video recordings. The overlay is removed after the specified duration, or 2000ms.
+
+        Parameters
+        ----------
+        title : str
+            Title text displayed prominently in the overlay.
+        description : Union[str, None]
+            Optional description text displayed below the title.
+        duration : Union[float, None]
+            Duration in milliseconds after which the overlay is automatically removed. Defaults to `2000`.
+        """
+
+        return mapping.from_maybe_impl(
+            self._sync(
+                self._impl_obj.show_chapter(
+                    title=title, description=description, duration=duration
+                )
+            )
+        )
+
+    def show_overlays(self) -> None:
+        """Screencast.show_overlays
+
+        Shows overlays.
+        """
+
+        return mapping.from_maybe_impl(self._sync(self._impl_obj.show_overlays()))
+
+    def hide_overlays(self) -> None:
+        """Screencast.hide_overlays
+
+        Hides overlays without removing them.
+        """
+
+        return mapping.from_maybe_impl(self._sync(self._impl_obj.hide_overlays()))
+
+
+mapping.register(ScreencastImpl, Screencast)
 
 
 class Video(SyncBase):
@@ -8005,13 +8298,28 @@ class Page(SyncContextManager):
     def video(self) -> typing.Optional["Video"]:
         """Page.video
 
-        Video object associated with this page.
+        Video object associated with this page. Can be used to access the video file when using the `recordVideo` context
+        option.
 
         Returns
         -------
         Union[Video, None]
         """
         return mapping.from_impl_nullable(self._impl_obj.video)
+
+    @property
+    def screencast(self) -> "Screencast":
+        """Page.screencast
+
+        `Screencast` object associated with this page.
+
+        **Usage**
+
+        Returns
+        -------
+        Screencast
+        """
+        return mapping.from_impl(self._impl_obj.screencast)
 
     def opener(self) -> typing.Optional["Page"]:
         """Page.opener
@@ -9175,7 +9483,7 @@ class Page(SyncContextManager):
         Parameters
         ----------
         url : Union[Callable[[str], bool], Pattern[str], str]
-            A glob pattern, regex pattern or predicate receiving [URL] to match while waiting for the navigation. Note that if
+            A glob pattern, regex pattern, or predicate receiving [URL] to match while waiting for the navigation. Note that if
             the parameter is a string without wildcard characters, the method will wait for navigation to URL that is exactly
             equal to the string.
         wait_until : Union["commit", "domcontentloaded", "load", "networkidle", None]
@@ -9553,6 +9861,8 @@ class Page(SyncContextManager):
         page.route(\"/api/**\", handle_route)
         ```
 
+        If a request matches multiple registered routes, the most recently registered route takes precedence.
+
         Page routes take precedence over browser context routes (set up with `browser_context.route()`) when request
         matches both handlers.
 
@@ -9600,7 +9910,7 @@ class Page(SyncContextManager):
         Parameters
         ----------
         url : Union[Callable[[str], bool], Pattern[str], str]
-            A glob pattern, regex pattern or predicate receiving [URL] to match while routing.
+            A glob pattern, regex pattern, or predicate receiving [URL] to match while routing.
         handler : Union[Callable[[Route, Request], Any], Callable[[Route], Any], None]
             Optional handler function to route the request.
         """
@@ -9846,6 +10156,39 @@ class Page(SyncContextManager):
         """
 
         return mapping.from_maybe_impl(self._sync(self._impl_obj.title()))
+
+    def aria_snapshot(
+        self,
+        *,
+        timeout: typing.Optional[float] = None,
+        depth: typing.Optional[int] = None,
+        mode: typing.Optional[Literal["ai", "default"]] = None,
+    ) -> str:
+        """Page.aria_snapshot
+
+        Captures the aria snapshot of the page. Read more about [aria snapshots](https://playwright.dev/python/docs/aria-snapshots).
+
+        Parameters
+        ----------
+        timeout : Union[float, None]
+            Maximum time in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can
+            be changed by using the `browser_context.set_default_timeout()` or `page.set_default_timeout()` methods.
+        depth : Union[int, None]
+            When specified, limits the depth of the snapshot.
+        mode : Union["ai", "default", None]
+            When set to `"ai"`, returns a snapshot optimized for AI consumption: including element references like `[ref=e2]`
+            and snapshots of `<iframe>`s. Defaults to `"default"`.
+
+        Returns
+        -------
+        str
+        """
+
+        return mapping.from_maybe_impl(
+            self._sync(
+                self._impl_obj.aria_snapshot(timeout=timeout, depth=depth, mode=mode)
+            )
+        )
 
     def close(
         self,
@@ -10480,7 +10823,7 @@ class Page(SyncContextManager):
         <button>Submit</button>
         ```
 
-        You can locate each element by it's implicit role:
+        You can locate each element by its implicit role:
 
         ```py
         expect(page.get_by_role(\"heading\", name=\"Sign up\")).to_be_visible()
@@ -10580,7 +10923,7 @@ class Page(SyncContextManager):
         <button data-testid=\"directions\">Itinéraire</button>
         ```
 
-        You can locate the element by it's test id:
+        You can locate the element by its test id:
 
         ```py
         page.get_by_test_id(\"directions\").click()
@@ -11926,7 +12269,7 @@ class Page(SyncContextManager):
         Parameters
         ----------
         url : Union[Callable[[str], bool], Pattern[str], str, None]
-            A glob pattern, regex pattern or predicate receiving [URL] to match while waiting for the navigation. Note that if
+            A glob pattern, regex pattern, or predicate receiving [URL] to match while waiting for the navigation. Note that if
             the parameter is a string without wildcard characters, the method will wait for navigation to URL that is exactly
             equal to the string.
         wait_until : Union["commit", "domcontentloaded", "load", "networkidle", None]
@@ -12401,29 +12744,96 @@ class Page(SyncContextManager):
 
         return mapping.from_impl_list(self._sync(self._impl_obj.requests()))
 
-    def console_messages(self) -> typing.List["ConsoleMessage"]:
+    def console_messages(
+        self, *, filter: typing.Optional[Literal["all", "since-navigation"]] = None
+    ) -> typing.List["ConsoleMessage"]:
         """Page.console_messages
 
         Returns up to (currently) 200 last console messages from this page. See `page.on('console')` for more details.
+
+        Parameters
+        ----------
+        filter : Union["all", "since-navigation", None]
+            Controls which messages are returned:
 
         Returns
         -------
         List[ConsoleMessage]
         """
 
-        return mapping.from_impl_list(self._sync(self._impl_obj.console_messages()))
+        return mapping.from_impl_list(
+            self._sync(self._impl_obj.console_messages(filter=filter))
+        )
 
-    def page_errors(self) -> typing.List["Error"]:
+    def page_errors(
+        self, *, filter: typing.Optional[Literal["all", "since-navigation"]] = None
+    ) -> typing.List["Error"]:
         """Page.page_errors
 
         Returns up to (currently) 200 last page errors from this page. See `page.on('page_error')` for more details.
+
+        Parameters
+        ----------
+        filter : Union["all", "since-navigation", None]
+            Controls which errors are returned:
 
         Returns
         -------
         List[Error]
         """
 
-        return mapping.from_impl_list(self._sync(self._impl_obj.page_errors()))
+        return mapping.from_impl_list(
+            self._sync(self._impl_obj.page_errors(filter=filter))
+        )
+
+    def clear_console_messages(self) -> None:
+        """Page.clear_console_messages
+
+        Clears all stored console messages from this page. Subsequent calls to `page.console_messages()` will only
+        return messages logged after the clear.
+        """
+
+        return mapping.from_maybe_impl(
+            self._sync(self._impl_obj.clear_console_messages())
+        )
+
+    def clear_page_errors(self) -> None:
+        """Page.clear_page_errors
+
+        Clears all stored page errors from this page. Subsequent calls to `page.page_errors()` will only return
+        errors thrown after the clear.
+        """
+
+        return mapping.from_maybe_impl(self._sync(self._impl_obj.clear_page_errors()))
+
+    def pick_locator(self) -> "Locator":
+        """Page.pick_locator
+
+        Enters pick locator mode where hovering over page elements highlights them and shows the corresponding locator.
+        Once the user clicks an element, the mode is deactivated and the `Locator` for the picked element is returned.
+
+        **Usage**
+
+        ```py
+        locator = page.pick_locator()
+        print(locator)
+        ```
+
+        Returns
+        -------
+        Locator
+        """
+
+        return mapping.from_impl(self._sync(self._impl_obj.pick_locator()))
+
+    def cancel_pick_locator(self) -> None:
+        """Page.cancel_pick_locator
+
+        Cancels an ongoing `page.pick_locator()` call by deactivating pick locator mode. If no pick locator mode is
+        active, this method is a no-op.
+        """
+
+        return mapping.from_maybe_impl(self._sync(self._impl_obj.cancel_pick_locator()))
 
 
 mapping.register(PageImpl, Page)
@@ -12805,6 +13215,18 @@ class BrowserContext(SyncContextManager):
         return mapping.from_impl(self._impl_obj.tracing)
 
     @property
+    def debugger(self) -> "Debugger":
+        """BrowserContext.debugger
+
+        Debugger allows to pause and resume the execution.
+
+        Returns
+        -------
+        Debugger
+        """
+        return mapping.from_impl(self._impl_obj.debugger)
+
+    @property
     def request(self) -> "APIRequestContext":
         """BrowserContext.request
 
@@ -12997,6 +13419,7 @@ class BrowserContext(SyncContextManager):
             - `'notifications'`
             - `'payment-handler'`
             - `'storage-access'`
+            - `'screen-wake-lock'`
         origin : Union[str, None]
             The [origin] to grant permissions to, e.g. "https://example.com".
         """
@@ -13353,7 +13776,7 @@ class BrowserContext(SyncContextManager):
         Parameters
         ----------
         url : Union[Callable[[str], bool], Pattern[str], str]
-            A glob pattern, regex pattern or predicate receiving [URL] used to register a routing with
+            A glob pattern, regex pattern, or predicate receiving [URL] used to register a routing with
             `browser_context.route()`.
         handler : Union[Callable[[Route, Request], Any], Callable[[Route], Any], None]
             Optional handler function used to register a routing with `browser_context.route()`.
@@ -13536,6 +13959,18 @@ class BrowserContext(SyncContextManager):
             ).future,
         )
 
+    def is_closed(self) -> bool:
+        """BrowserContext.is_closed
+
+        Indicates that the browser context is in the process of closing or has already been closed.
+
+        Returns
+        -------
+        bool
+        """
+
+        return mapping.from_maybe_impl(self._impl_obj.is_closed())
+
     def close(self, *, reason: typing.Optional[str] = None) -> None:
         """BrowserContext.close
 
@@ -13579,6 +14014,33 @@ class BrowserContext(SyncContextManager):
 
         return mapping.from_impl(
             self._sync(self._impl_obj.storage_state(path=path, indexedDB=indexed_db))
+        )
+
+    def set_storage_state(
+        self, storage_state: typing.Union[StorageState, str, pathlib.Path]
+    ) -> None:
+        """BrowserContext.set_storage_state
+
+        Clears the existing cookies, local storage and IndexedDB entries for all origins and sets the new storage state.
+
+        **Usage**
+
+        ```py
+        # Load storage state from a file and apply it to the context.
+        context.set_storage_state(\"state.json\")
+        ```
+
+        Parameters
+        ----------
+        storage_state : Union[pathlib.Path, str, {cookies: Sequence[{name: str, value: str, domain: str, path: str, expires: float, httpOnly: bool, secure: bool, sameSite: Union["Lax", "None", "Strict"]}], origins: Sequence[{origin: str, localStorage: Sequence[{name: str, value: str}]}]}]
+            Learn more about [storage state and auth](../auth.md).
+
+            Populates context with given storage state. This option can be used to initialize context with logged-in
+            information obtained via `browser_context.storage_state()`.
+        """
+
+        return mapping.from_maybe_impl(
+            self._sync(self._impl_obj.set_storage_state(storageState=storage_state))
         )
 
     def wait_for_event(
@@ -13710,6 +14172,34 @@ mapping.register(BrowserContextImpl, BrowserContext)
 
 class CDPSession(SyncBase):
 
+    @typing.overload
+    def on(
+        self, event: Literal["close"], f: typing.Callable[["CDPSession"], "None"]
+    ) -> None:
+        """
+        Emitted when the session is closed, either because the target was closed or `session.detach()` was called.
+        """
+
+    @typing.overload
+    def on(self, event: str, f: typing.Callable[..., None]) -> None: ...
+
+    def on(self, event: str, f: typing.Callable[..., None]) -> None:
+        return super().on(event=event, f=f)
+
+    @typing.overload
+    def once(
+        self, event: Literal["close"], f: typing.Callable[["CDPSession"], "None"]
+    ) -> None:
+        """
+        Emitted when the session is closed, either because the target was closed or `session.detach()` was called.
+        """
+
+    @typing.overload
+    def once(self, event: str, f: typing.Callable[..., None]) -> None: ...
+
+    def once(self, event: str, f: typing.Callable[..., None]) -> None:
+        return super().once(event=event, f=f)
+
     def send(
         self, method: str, params: typing.Optional[typing.Dict] = None
     ) -> typing.Dict:
@@ -13748,6 +14238,7 @@ mapping.register(CDPSessionImpl, CDPSession)
 
 class Browser(SyncContextManager):
 
+    @typing.overload
     def on(
         self, event: Literal["disconnected"], f: typing.Callable[["Browser"], "None"]
     ) -> None:
@@ -13756,8 +14247,14 @@ class Browser(SyncContextManager):
         following:
         - Browser application is closed or crashed.
         - The `browser.close()` method was called."""
+
+    @typing.overload
+    def on(self, event: str, f: typing.Callable[..., None]) -> None: ...
+
+    def on(self, event: str, f: typing.Callable[..., None]) -> None:
         return super().on(event=event, f=f)
 
+    @typing.overload
     def once(
         self, event: Literal["disconnected"], f: typing.Callable[["Browser"], "None"]
     ) -> None:
@@ -13766,6 +14263,11 @@ class Browser(SyncContextManager):
         following:
         - Browser application is closed or crashed.
         - The `browser.close()` method was called."""
+
+    @typing.overload
+    def once(self, event: str, f: typing.Callable[..., None]) -> None: ...
+
+    def once(self, event: str, f: typing.Callable[..., None]) -> None:
         return super().once(event=event, f=f)
 
     @property
@@ -14352,6 +14854,51 @@ class Browser(SyncContextManager):
 
         return mapping.from_impl(self._sync(self._impl_obj.new_browser_cdp_session()))
 
+    def bind(
+        self,
+        title: str,
+        *,
+        workspace_dir: typing.Optional[str] = None,
+        host: typing.Optional[str] = None,
+        port: typing.Optional[int] = None,
+    ) -> BrowserBindResult:
+        """Browser.bind
+
+        Binds the browser to a named pipe or web socket, making it available for other clients to connect to.
+
+        Parameters
+        ----------
+        title : str
+            Title of the browser server, used for identification.
+        workspace_dir : Union[str, None]
+            Working directory associated with this browser server.
+        host : Union[str, None]
+            Host to bind the web socket server to. When specified, a web socket server is created instead of a named pipe.
+        port : Union[int, None]
+            Port to bind the web socket server to. When specified, a web socket server is created instead of a named pipe. Use
+            `0` to let the OS pick an available port.
+
+        Returns
+        -------
+        {endpoint: str}
+        """
+
+        return mapping.from_impl(
+            self._sync(
+                self._impl_obj.bind(
+                    title=title, workspaceDir=workspace_dir, host=host, port=port
+                )
+            )
+        )
+
+    def unbind(self) -> None:
+        """Browser.unbind
+
+        Unbinds the browser server previously bound with `browser.bind()`.
+        """
+
+        return mapping.from_maybe_impl(self._sync(self._impl_obj.unbind()))
+
     def start_tracing(
         self,
         *,
@@ -14467,6 +15014,7 @@ class BrowserType(SyncBase):
         downloads_path: typing.Optional[typing.Union[pathlib.Path, str]] = None,
         slow_mo: typing.Optional[float] = None,
         traces_dir: typing.Optional[typing.Union[pathlib.Path, str]] = None,
+        artifacts_dir: typing.Optional[typing.Union[pathlib.Path, str]] = None,
         chromium_sandbox: typing.Optional[bool] = None,
         firefox_user_prefs: typing.Optional[
             typing.Dict[str, typing.Union[str, float, bool]]
@@ -14548,6 +15096,10 @@ class BrowserType(SyncBase):
             on.
         traces_dir : Union[pathlib.Path, str, None]
             If specified, traces are saved into this directory.
+        artifacts_dir : Union[pathlib.Path, str, None]
+            If specified, artifacts (traces, videos, downloads, HAR files, etc.) are saved into this directory. The directory
+            is not cleaned up when the browser closes. If not specified, a temporary directory is used and cleaned up when the
+            browser closes.
         chromium_sandbox : Union[bool, None]
             Enable Chromium sandboxing. Defaults to `false`.
         firefox_user_prefs : Union[Dict[str, Union[bool, float, str]], None]
@@ -14579,6 +15131,7 @@ class BrowserType(SyncBase):
                     downloadsPath=downloads_path,
                     slowMo=slow_mo,
                     tracesDir=traces_dir,
+                    artifactsDir=artifacts_dir,
                     chromiumSandbox=chromium_sandbox,
                     firefoxUserPrefs=mapping.to_impl(firefox_user_prefs),
                 )
@@ -14631,6 +15184,7 @@ class BrowserType(SyncBase):
         contrast: typing.Optional[Literal["more", "no-preference", "null"]] = None,
         accept_downloads: typing.Optional[bool] = None,
         traces_dir: typing.Optional[typing.Union[pathlib.Path, str]] = None,
+        artifacts_dir: typing.Optional[typing.Union[pathlib.Path, str]] = None,
         chromium_sandbox: typing.Optional[bool] = None,
         firefox_user_prefs: typing.Optional[
             typing.Dict[str, typing.Union[str, float, bool]]
@@ -14785,6 +15339,10 @@ class BrowserType(SyncBase):
             Whether to automatically download all the attachments. Defaults to `true` where all the downloads are accepted.
         traces_dir : Union[pathlib.Path, str, None]
             If specified, traces are saved into this directory.
+        artifacts_dir : Union[pathlib.Path, str, None]
+            If specified, artifacts (traces, videos, downloads, HAR files, etc.) are saved into this directory. The directory
+            is not cleaned up when the browser closes. If not specified, a temporary directory is used and cleaned up when the
+            browser closes.
         chromium_sandbox : Union[bool, None]
             Enable Chromium sandboxing. Defaults to `false`.
         firefox_user_prefs : Union[Dict[str, Union[bool, float, str]], None]
@@ -14897,6 +15455,7 @@ class BrowserType(SyncBase):
                     contrast=contrast,
                     acceptDownloads=accept_downloads,
                     tracesDir=traces_dir,
+                    artifactsDir=artifacts_dir,
                     chromiumSandbox=chromium_sandbox,
                     firefoxUserPrefs=mapping.to_impl(firefox_user_prefs),
                     recordHarPath=record_har_path,
@@ -14979,7 +15538,7 @@ class BrowserType(SyncBase):
 
     def connect(
         self,
-        ws_endpoint: str,
+        endpoint: str,
         *,
         timeout: typing.Optional[float] = None,
         slow_mo: typing.Optional[float] = None,
@@ -14995,7 +15554,7 @@ class BrowserType(SyncBase):
 
         Parameters
         ----------
-        ws_endpoint : str
+        endpoint : str
             A Playwright browser websocket endpoint to connect to. You obtain this endpoint via `BrowserServer.wsEndpoint`.
         timeout : Union[float, None]
             Maximum time in milliseconds to wait for the connection to be established. Defaults to `0` (no timeout).
@@ -15027,7 +15586,7 @@ class BrowserType(SyncBase):
         return mapping.from_impl(
             self._sync(
                 self._impl_obj.connect(
-                    wsEndpoint=ws_endpoint,
+                    endpoint=endpoint,
                     timeout=timeout,
                     slowMo=slow_mo,
                     headers=mapping.to_impl(headers),
@@ -15173,6 +15732,7 @@ class Tracing(SyncBase):
         snapshots: typing.Optional[bool] = None,
         screenshots: typing.Optional[bool] = None,
         sources: typing.Optional[bool] = None,
+        live: typing.Optional[bool] = None,
     ) -> None:
         """Tracing.start
 
@@ -15212,6 +15772,10 @@ class Tracing(SyncBase):
             Whether to capture screenshots during tracing. Screenshots are used to build a timeline preview.
         sources : Union[bool, None]
             Whether to include source files for trace actions.
+        live : Union[bool, None]
+            When enabled, the trace is written to an unarchived file that is updated in real time as actions occur, instead of
+            caching changes and archiving them into a zip file at the end. This is useful for live trace viewing during test
+            execution.
         """
 
         return mapping.from_maybe_impl(
@@ -15222,6 +15786,7 @@ class Tracing(SyncBase):
                     snapshots=snapshots,
                     screenshots=screenshots,
                     sources=sources,
+                    live=live,
                 )
             )
         )
@@ -16327,7 +16892,7 @@ class Locator(SyncBase):
         <button>Submit</button>
         ```
 
-        You can locate each element by it's implicit role:
+        You can locate each element by its implicit role:
 
         ```py
         expect(page.get_by_role(\"heading\", name=\"Sign up\")).to_be_visible()
@@ -16427,7 +16992,7 @@ class Locator(SyncBase):
         <button data-testid=\"directions\">Itinéraire</button>
         ```
 
-        You can locate the element by it's test id:
+        You can locate the element by its test id:
 
         ```py
         page.get_by_test_id(\"directions\").click()
@@ -17473,7 +18038,13 @@ class Locator(SyncBase):
             )
         )
 
-    def aria_snapshot(self, *, timeout: typing.Optional[float] = None) -> str:
+    def aria_snapshot(
+        self,
+        *,
+        timeout: typing.Optional[float] = None,
+        depth: typing.Optional[int] = None,
+        mode: typing.Optional[Literal["ai", "default"]] = None,
+    ) -> str:
         """Locator.aria_snapshot
 
         Captures the aria snapshot of the given element. Read more about [aria snapshots](https://playwright.dev/python/docs/aria-snapshots) and
@@ -17513,11 +18084,20 @@ class Locator(SyncBase):
             - link \"About\"
         ```
 
+        An AI-optimized snapshot, controlled by `mode`, is different from a default snapshot:
+        1. Includes element references `[ref=e2]`. 2. Does not wait for an element matching the locator, and throws when
+           no elements match. 3. Includes snapshots of `<iframe>`s inside the target.
+
         Parameters
         ----------
         timeout : Union[float, None]
             Maximum time in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can
             be changed by using the `browser_context.set_default_timeout()` or `page.set_default_timeout()` methods.
+        depth : Union[int, None]
+            When specified, limits the depth of the snapshot.
+        mode : Union["ai", "default", None]
+            When set to `"ai"`, returns a snapshot optimized for AI consumption. Defaults to `"default"`. See details for more
+            information.
 
         Returns
         -------
@@ -17525,8 +18105,24 @@ class Locator(SyncBase):
         """
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.aria_snapshot(timeout=timeout))
+            self._sync(
+                self._impl_obj.aria_snapshot(timeout=timeout, depth=depth, mode=mode)
+            )
         )
+
+    def normalize(self) -> "Locator":
+        """Locator.normalize
+
+        Returns a new locator that uses best practices for referencing the matched element, prioritizing test ids, aria
+        roles, and other user-facing attributes over CSS selectors. This is useful for converting implementation-detail
+        selectors into more resilient, human-readable locators.
+
+        Returns
+        -------
+        Locator
+        """
+
+        return mapping.from_impl(self._sync(self._impl_obj.normalize()))
 
     def scroll_into_view_if_needed(
         self, *, timeout: typing.Optional[float] = None
@@ -18306,7 +18902,7 @@ class APIRequestContext(SyncBase):
             typing.Union[typing.Dict[str, typing.Union[str, float, bool]], str]
         ] = None,
         headers: typing.Optional[typing.Dict[str, str]] = None,
-        data: typing.Optional[typing.Union[typing.Any, str, bytes]] = None,
+        data: typing.Optional[typing.Union[typing.Any, bytes, str]] = None,
         form: typing.Optional[typing.Dict[str, typing.Union[str, float, bool]]] = None,
         multipart: typing.Optional[
             typing.Dict[str, typing.Union[bytes, bool, float, str, FilePayload]]
@@ -18389,7 +18985,7 @@ class APIRequestContext(SyncBase):
             typing.Union[typing.Dict[str, typing.Union[str, float, bool]], str]
         ] = None,
         headers: typing.Optional[typing.Dict[str, str]] = None,
-        data: typing.Optional[typing.Union[typing.Any, str, bytes]] = None,
+        data: typing.Optional[typing.Union[typing.Any, bytes, str]] = None,
         form: typing.Optional[typing.Dict[str, typing.Union[str, float, bool]]] = None,
         multipart: typing.Optional[
             typing.Dict[str, typing.Union[bytes, bool, float, str, FilePayload]]
@@ -18472,7 +19068,7 @@ class APIRequestContext(SyncBase):
             typing.Union[typing.Dict[str, typing.Union[str, float, bool]], str]
         ] = None,
         headers: typing.Optional[typing.Dict[str, str]] = None,
-        data: typing.Optional[typing.Union[typing.Any, str, bytes]] = None,
+        data: typing.Optional[typing.Union[typing.Any, bytes, str]] = None,
         form: typing.Optional[typing.Dict[str, typing.Union[str, float, bool]]] = None,
         multipart: typing.Optional[
             typing.Dict[str, typing.Union[bytes, bool, float, str, FilePayload]]
@@ -18567,7 +19163,7 @@ class APIRequestContext(SyncBase):
             typing.Union[typing.Dict[str, typing.Union[str, float, bool]], str]
         ] = None,
         headers: typing.Optional[typing.Dict[str, str]] = None,
-        data: typing.Optional[typing.Union[typing.Any, str, bytes]] = None,
+        data: typing.Optional[typing.Union[typing.Any, bytes, str]] = None,
         form: typing.Optional[typing.Dict[str, typing.Union[str, float, bool]]] = None,
         multipart: typing.Optional[
             typing.Dict[str, typing.Union[bytes, bool, float, str, FilePayload]]
@@ -18650,7 +19246,7 @@ class APIRequestContext(SyncBase):
             typing.Union[typing.Dict[str, typing.Union[str, float, bool]], str]
         ] = None,
         headers: typing.Optional[typing.Dict[str, str]] = None,
-        data: typing.Optional[typing.Union[typing.Any, str, bytes]] = None,
+        data: typing.Optional[typing.Union[typing.Any, bytes, str]] = None,
         form: typing.Optional[typing.Dict[str, typing.Union[str, float, bool]]] = None,
         multipart: typing.Optional[
             typing.Dict[str, typing.Union[bytes, bool, float, str, FilePayload]]
@@ -18733,7 +19329,7 @@ class APIRequestContext(SyncBase):
             typing.Union[typing.Dict[str, typing.Union[str, float, bool]], str]
         ] = None,
         headers: typing.Optional[typing.Dict[str, str]] = None,
-        data: typing.Optional[typing.Union[typing.Any, str, bytes]] = None,
+        data: typing.Optional[typing.Union[typing.Any, bytes, str]] = None,
         form: typing.Optional[typing.Dict[str, typing.Union[str, float, bool]]] = None,
         multipart: typing.Optional[
             typing.Dict[str, typing.Union[bytes, bool, float, str, FilePayload]]
@@ -18848,7 +19444,7 @@ class APIRequestContext(SyncBase):
         ] = None,
         method: typing.Optional[str] = None,
         headers: typing.Optional[typing.Dict[str, str]] = None,
-        data: typing.Optional[typing.Union[typing.Any, str, bytes]] = None,
+        data: typing.Optional[typing.Union[typing.Any, bytes, str]] = None,
         form: typing.Optional[typing.Dict[str, typing.Union[str, float, bool]]] = None,
         multipart: typing.Optional[
             typing.Dict[str, typing.Union[bytes, bool, float, str, FilePayload]]

--- a/scripts/documentation_provider.py
+++ b/scripts/documentation_provider.py
@@ -207,34 +207,34 @@ class DocumentationProvider:
         if events:
             doc = []
             for event_type in ["on", "once"]:
+                return_type = (
+                    "typing.Union[typing.Awaitable[None], None]"
+                    if self.is_async
+                    else "None"
+                )
                 for event in events:
-                    return_type = (
-                        "typing.Union[typing.Awaitable[None], None]"
-                        if self.is_async
-                        else "None"
-                    )
                     func_arg = self.serialize_doc_type(event["type"], "")
                     if func_arg.startswith("{"):
                         func_arg = "typing.Dict"
                     if "Union[" in func_arg:
                         func_arg = func_arg.replace("Union[", "typing.Union[")
-                    if len(events) > 1:
-                        doc.append("    @typing.overload")
-                    impl = ""
-                    if len(events) == 1:
-                        impl = f"        return super().{event_type}(event=event,f=f)"
+                    doc.append("    @typing.overload")
                     doc.append(
                         f"    def {event_type}(self, event: Literal['{event['name'].lower()}'], f: typing.Callable[['{func_arg}'], '{return_type}']) -> None:"
                     )
                     doc.append(
                         f'        """{self.beautify_method_comment(event["comment"], " " * 8)}"""'
                     )
-                    doc.append(impl)
-                if len(events) > 1:
+                if len(events) == 1:
+                    doc.append("    @typing.overload")
                     doc.append(
-                        f"    def {event_type}(self, event: str, f: typing.Callable[...,{return_type}]) -> None:"
+                        f"    def {event_type}(self, event: str, f: typing.Callable[...,{return_type}]) -> None: ..."
                     )
-                    doc.append(f"        return super().{event_type}(event=event,f=f)")
+                    doc.append("")
+                doc.append(
+                    f"    def {event_type}(self, event: str, f: typing.Callable[...,{return_type}]) -> None:"
+                )
+                doc.append(f"        return super().{event_type}(event=event,f=f)")
             print("\n".join(doc))
 
     def indent_paragraph(self, p: str, indent: str) -> str:
@@ -437,6 +437,8 @@ class DocumentationProvider:
 
     def inner_serialize_doc_type(self, type: Any, direction: str) -> str:
         if type["name"] == "Promise":
+            if "templates" not in type:
+                return "Any"
             type = type["templates"][0]
 
         if "union" in type:
@@ -506,7 +508,7 @@ class DocumentationProvider:
             return "str"
         if type_name == "RegExp":
             return "Pattern[str]"
-        if type_name == "null":
+        if type_name == "null" or type_name == "void":
             return "None"
         if type_name == "EvaluationArgument":
             return "Dict"

--- a/scripts/generate_api.py
+++ b/scripts/generate_api.py
@@ -29,6 +29,7 @@ from playwright._impl._browser_type import BrowserType
 from playwright._impl._cdp_session import CDPSession
 from playwright._impl._clock import Clock
 from playwright._impl._console_message import ConsoleMessage
+from playwright._impl._debugger import Debugger
 from playwright._impl._dialog import Dialog
 from playwright._impl._download import Download
 from playwright._impl._element_handle import ElementHandle
@@ -48,6 +49,7 @@ from playwright._impl._network import (
 )
 from playwright._impl._page import Page, Worker
 from playwright._impl._playwright import Playwright
+from playwright._impl._screencast import Screencast
 from playwright._impl._selectors import Selectors
 from playwright._impl._tracing import Tracing
 from playwright._impl._video import Video
@@ -224,13 +226,14 @@ import datetime
 from typing import Literal
 
 
-from playwright._impl._api_structures import Cookie, SetCookieParam, FloatRect, FilePayload, Geolocation, HttpCredentials, PdfMargins, Position, ProxySettings, ResourceTiming, SourceLocation, StorageState, ClientCertificate, ViewportSize, RemoteAddr, SecurityDetails, RequestSizes, NameValue, TracingGroupLocation
+from playwright._impl._api_structures import Cookie, SetCookieParam, FloatRect, FilePayload, Geolocation, HttpCredentials, PdfMargins, Position, ProxySettings, ResourceTiming, SourceLocation, StorageState, ClientCertificate, ViewportSize, RemoteAddr, SecurityDetails, RequestSizes, NameValue, TracingGroupLocation, DebuggerLocation, DebuggerPausedDetails, ScreencastFrame, BrowserBindResult
 from playwright._impl._browser import Browser as BrowserImpl
 from playwright._impl._browser_context import BrowserContext as BrowserContextImpl
 from playwright._impl._browser_type import BrowserType as BrowserTypeImpl
 from playwright._impl._clock import Clock as ClockImpl
 from playwright._impl._cdp_session import CDPSession as CDPSessionImpl
 from playwright._impl._console_message import ConsoleMessage as ConsoleMessageImpl
+from playwright._impl._debugger import Debugger as DebuggerImpl
 from playwright._impl._dialog import Dialog as DialogImpl
 from playwright._impl._download import Download as DownloadImpl
 from playwright._impl._element_handle import ElementHandle as ElementHandleImpl
@@ -243,6 +246,7 @@ from playwright._impl._page import Page as PageImpl, Worker as WorkerImpl
 from playwright._impl._web_error import WebError as WebErrorImpl
 from playwright._impl._playwright import Playwright as PlaywrightImpl
 from playwright._impl._selectors import Selectors as SelectorsImpl
+from playwright._impl._screencast import Screencast as ScreencastImpl
 from playwright._impl._video import Video as VideoImpl
 from playwright._impl._tracing import Tracing as TracingImpl
 from playwright._impl._locator import Locator as LocatorImpl, FrameLocator as FrameLocatorImpl
@@ -270,8 +274,10 @@ generated_types = [
     Selectors,
     Clock,
     ConsoleMessage,
+    Debugger,
     Dialog,
     Download,
+    Screencast,
     Video,
     Page,
     WebError,

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import sys
 import zipfile
 from typing import Dict
 
-driver_version = "1.58.0"
+driver_version = "1.59.1"
 
 base_wheel_bundles = [
     {

--- a/tests/async/test_browser.py
+++ b/tests/async/test_browser.py
@@ -53,3 +53,17 @@ async def test_should_return_browser_type(
     browser: Browser, browser_type: BrowserType
 ) -> None:
     assert browser.browser_type is browser_type
+
+
+async def test_bind_should_return_endpoint_and_allow_unbind(
+    browser_type: BrowserType,
+) -> None:
+    browser = await browser_type.launch()
+    try:
+        result = await browser.bind("test-server")
+        assert "endpoint" in result
+        assert isinstance(result["endpoint"], str)
+        assert len(result["endpoint"]) > 0
+        await browser.unbind()
+    finally:
+        await browser.close()

--- a/tests/async/test_browsercontext.py
+++ b/tests/async/test_browsercontext.py
@@ -168,6 +168,13 @@ async def test_close_should_be_callable_twice(browser: Browser) -> None:
     await context.close()
 
 
+async def test_is_closed_should_reflect_state(browser: Browser) -> None:
+    context = await browser.new_context()
+    assert context.is_closed() is False
+    await context.close()
+    assert context.is_closed() is True
+
+
 async def test_user_agent_should_work(browser: Browser, server: Server) -> None:
     async def baseline() -> None:
         context = await browser.new_context()

--- a/tests/async/test_browsercontext_storage_state.py
+++ b/tests/async/test_browsercontext_storage_state.py
@@ -133,6 +133,32 @@ async def test_should_round_trip_through_the_file(
     await context2.close()
 
 
+async def test_set_storage_state_should_apply_state_to_existing_context(
+    browser: Browser,
+) -> None:
+    src = await browser.new_context()
+    src_page = await src.new_page()
+    await src_page.route(
+        "**/*",
+        lambda route: asyncio.create_task(route.fulfill(body="<html></html>")),
+    )
+    await src_page.goto("https://www.example.com")
+    await src_page.evaluate('() => localStorage.setItem("k", "v")')
+    state = await src.storage_state()
+    await src.close()
+
+    dst = await browser.new_context()
+    dst_page = await dst.new_page()
+    await dst_page.route(
+        "**/*",
+        lambda route: asyncio.create_task(route.fulfill(body="<html></html>")),
+    )
+    await dst.set_storage_state(state)
+    await dst_page.goto("https://www.example.com")
+    assert await dst_page.evaluate('() => localStorage.getItem("k")') == "v"
+    await dst.close()
+
+
 async def test_should_serialiser_storage_state_with_lone_surrogates(
     page: Page, context: BrowserContext, server: Server
 ) -> None:

--- a/tests/async/test_click.py
+++ b/tests/async/test_click.py
@@ -435,32 +435,30 @@ async def test_click_the_button_with_device_scale_factor_set(
 
 
 async def test_click_the_button_with_px_border_with_offset(
-    page: Page, server: Server, is_webkit: bool
+    page: Page, server: Server
 ) -> None:
     await page.goto(server.PREFIX + "/input/button.html")
     await page.eval_on_selector("button", "button => button.style.borderWidth = '8px'")
     await page.click("button", position={"x": 20, "y": 10})
     assert await page.evaluate("result") == "Clicked"
-    # Safari reports border-relative offsetX/offsetY.
-    assert await page.evaluate("offsetX") == 20 + 8 if is_webkit else 20
-    assert await page.evaluate("offsetY") == 10 + 8 if is_webkit else 10
+    assert await page.evaluate("offsetX") == 20
+    assert await page.evaluate("offsetY") == 10
 
 
 async def test_click_the_button_with_em_border_with_offset(
-    page: Page, server: Server, is_webkit: bool
+    page: Page, server: Server
 ) -> None:
     await page.goto(server.PREFIX + "/input/button.html")
     await page.eval_on_selector("button", "button => button.style.borderWidth = '2em'")
     await page.eval_on_selector("button", "button => button.style.fontSize = '12px'")
     await page.click("button", position={"x": 20, "y": 10})
     assert await page.evaluate("result") == "Clicked"
-    # Safari reports border-relative offsetX/offsetY.
-    assert await page.evaluate("offsetX") == 12 * 2 + 20 if is_webkit else 20
-    assert await page.evaluate("offsetY") == 12 * 2 + 10 if is_webkit else 10
+    assert await page.evaluate("offsetX") == 20
+    assert await page.evaluate("offsetY") == 10
 
 
 async def test_click_a_very_large_button_with_offset(
-    page: Page, server: Server, is_webkit: bool
+    page: Page, server: Server
 ) -> None:
     await page.goto(server.PREFIX + "/input/button.html")
     await page.eval_on_selector("button", "button => button.style.borderWidth = '8px'")
@@ -469,13 +467,12 @@ async def test_click_a_very_large_button_with_offset(
     )
     await page.click("button", position={"x": 1900, "y": 1910})
     assert await page.evaluate("() => window.result") == "Clicked"
-    # Safari reports border-relative offsetX/offsetY.
-    assert await page.evaluate("() => offsetX") == 1900 + 8 if is_webkit else 1900
-    assert await page.evaluate("() => offsetY") == 1910 + 8 if is_webkit else 1910
+    assert await page.evaluate("() => offsetX") == 1900
+    assert await page.evaluate("() => offsetY") == 1910
 
 
 async def test_click_a_button_in_scrolling_container_with_offset(
-    page: Page, server: Server, is_webkit: bool
+    page: Page, server: Server
 ) -> None:
     await page.goto(server.PREFIX + "/input/button.html")
     await page.eval_on_selector(
@@ -495,9 +492,8 @@ async def test_click_a_button_in_scrolling_container_with_offset(
 
     await page.click("button", position={"x": 1900, "y": 1910})
     assert await page.evaluate("window.result") == "Clicked"
-    # Safari reports border-relative offsetX/offsetY.
-    assert await page.evaluate("offsetX") == 1900 + 8 if is_webkit else 1900
-    assert await page.evaluate("offsetY") == 1910 + 8 if is_webkit else 1910
+    assert await page.evaluate("offsetX") == 1900
+    assert await page.evaluate("offsetY") == 1910
 
 
 @pytest.mark.skip_browser("firefox")

--- a/tests/async/test_debugger.py
+++ b/tests/async/test_debugger.py
@@ -1,0 +1,43 @@
+# Copyright (c) Microsoft Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+
+from playwright.async_api import BrowserContext, Page
+from tests.server import Server
+
+
+async def test_should_expose_debugger_property(context: BrowserContext) -> None:
+    assert context.debugger is context.debugger
+    assert context.debugger.paused_details is None
+
+
+async def test_should_pause_and_resume(
+    context: BrowserContext, page: Page, server: Server
+) -> None:
+    paused_event = asyncio.Event()
+    context.debugger.on("pausedstatechanged", lambda: paused_event.set())
+
+    await context.debugger.request_pause()
+    next_call = asyncio.create_task(page.goto(server.EMPTY_PAGE))
+
+    await asyncio.wait_for(paused_event.wait(), timeout=5)
+    assert context.debugger.paused_details is not None
+
+    paused_event.clear()
+    await context.debugger.resume()
+    await asyncio.wait_for(paused_event.wait(), timeout=5)
+    assert context.debugger.paused_details is None
+
+    await next_call

--- a/tests/async/test_dialog.py
+++ b/tests/async/test_dialog.py
@@ -102,3 +102,15 @@ async def test_should_auto_dismiss_the_alert_without_listeners(page: Page) -> No
     )
     await page.click("div")
     assert await page.evaluate('"window._clicked"')
+
+
+async def test_dismiss_should_swallow_target_closed_error(browser: Browser) -> None:
+    context = await browser.new_context()
+    page = await context.new_page()
+    async with page.expect_event("dialog") as dialog_info:
+        await page.evaluate("() => setTimeout(() => alert('hello'), 0)", None)
+    dialog = await dialog_info.value
+    await page.close()
+    # Dialog.dismiss should be a no-op once the target is closed.
+    await dialog.dismiss()
+    await context.close()

--- a/tests/async/test_locators.py
+++ b/tests/async/test_locators.py
@@ -1191,3 +1191,9 @@ async def test_description_should_return_description_for_locator_with_multiple_d
     assert locator2.description == "Second description"
     locator3 = locator2.locator("button")
     assert locator3.description is None
+
+
+async def test_normalize_should_resolve_to_a_locator(page: Page) -> None:
+    await page.set_content("<button>Click me</button>")
+    normalized = await page.get_by_role("button").normalize()
+    assert await normalized.text_content() == "Click me"

--- a/tests/async/test_navigation.py
+++ b/tests/async/test_navigation.py
@@ -801,7 +801,7 @@ async def test_wait_for_load_state_should_work_with_pages_that_have_loaded_befor
 
 
 async def test_wait_for_load_state_should_wait_for_load_state_of_empty_url_popup(
-    page: Page, is_firefox: bool
+    page: Page,
 ) -> None:
     ready_state = []
     async with page.expect_popup() as popup_info:
@@ -816,7 +816,7 @@ async def test_wait_for_load_state_should_wait_for_load_state_of_empty_url_popup
 
     popup = await popup_info.value
     await popup.wait_for_load_state()
-    assert ready_state == ["uninitialized"] if is_firefox else ["complete"]
+    assert ready_state == ["complete"]
     assert await popup.evaluate("() => document.readyState") == ready_state[0]
 
 

--- a/tests/async/test_page_aria_snapshot.py
+++ b/tests/async/test_page_aria_snapshot.py
@@ -214,3 +214,20 @@ async def test_match_values_both_against_regex_and_string(page: Page) -> None:
           - /url: /auth?r=/
       """,
     )
+
+
+async def test_should_snapshot_with_depth(page: Page) -> None:
+    await page.set_content("<ul><li><a href=about:blank>link</a></li></ul>")
+    snapshot = await page.locator("body").aria_snapshot(depth=1)
+    assert "listitem" in snapshot
+    assert "/url" not in snapshot
+
+
+async def test_page_aria_snapshot_should_work(page: Page) -> None:
+    await page.set_content("<h1>title</h1>")
+    snapshot = await page.aria_snapshot()
+    assert _unshift(snapshot) == _unshift(
+        """
+      - heading "title" [level=1]
+    """
+    )

--- a/tests/async/test_page_event_console.py
+++ b/tests/async/test_page_event_console.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from playwright._impl._page import Page
+from playwright.async_api import Page
+from tests.server import Server
 
 
 async def test_console_messages_should_work(page: Page) -> None:
@@ -33,3 +34,32 @@ async def test_console_messages_should_work(page: Page) -> None:
     assert len(objects) >= 100, "should be at least 100 messages"
     message_count = len(messages) - len(expected)
     assert objects[message_count:] == expected, "should return last messages"
+
+
+async def test_should_have_a_timestamp(page: Page) -> None:
+    async with page.expect_console_message() as message_info:
+        await page.evaluate("() => console.log('hello')")
+    message = await message_info.value
+    assert message.timestamp > 0
+
+
+async def test_clear_console_messages_should_drop_buffered_messages(page: Page) -> None:
+    await page.evaluate("() => console.log('first')")
+    assert any(m.text == "first" for m in await page.console_messages())
+    await page.clear_console_messages()
+    assert not any(m.text == "first" for m in await page.console_messages())
+    await page.evaluate("() => console.log('second')")
+    assert any(m.text == "second" for m in await page.console_messages())
+
+
+async def test_console_messages_filter_since_navigation_drops_pre_nav_messages(
+    page: Page, server: Server
+) -> None:
+    await page.goto(server.EMPTY_PAGE)
+    await page.evaluate("() => console.log('before-nav')")
+    await page.goto(server.EMPTY_PAGE)
+    await page.evaluate("() => console.log('after-nav')")
+    after = await page.console_messages(filter="since-navigation")
+    texts = [m.text for m in after]
+    assert "after-nav" in texts
+    assert "before-nav" not in texts

--- a/tests/async/test_page_event_pageerror.py
+++ b/tests/async/test_page_event_pageerror.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from playwright.async_api import Page
+from tests.server import Server
 
 
 async def test_page_errors_should_work(page: Page) -> None:
@@ -34,3 +35,26 @@ async def test_page_errors_should_work(page: Page) -> None:
     assert len(messages) >= 100, "should be at least 100 errors"
     message_count = len(messages) - len(expected)
     assert messages[message_count:] == expected, "should return last errors"
+
+
+async def test_clear_page_errors_should_drop_buffered_errors(page: Page) -> None:
+    await page.evaluate("() => setTimeout(() => { throw new Error('first'); }, 0)")
+    await page.evaluate("() => new Promise(r => setTimeout(r, 50))")
+    assert any(e.message == "first" for e in await page.page_errors())
+    await page.clear_page_errors()
+    assert not any(e.message == "first" for e in await page.page_errors())
+
+
+async def test_page_errors_filter_since_navigation_drops_pre_nav_errors(
+    page: Page, server: Server
+) -> None:
+    await page.goto(server.EMPTY_PAGE)
+    await page.evaluate("() => setTimeout(() => { throw new Error('before-nav'); }, 0)")
+    await page.evaluate("() => new Promise(r => setTimeout(r, 50))")
+    await page.goto(server.EMPTY_PAGE)
+    await page.evaluate("() => setTimeout(() => { throw new Error('after-nav'); }, 0)")
+    await page.evaluate("() => new Promise(r => setTimeout(r, 50))")
+    after = await page.page_errors(filter="since-navigation")
+    messages = [e.message for e in after]
+    assert "after-nav" in messages
+    assert "before-nav" not in messages

--- a/tests/async/test_page_network_request.py
+++ b/tests/async/test_page_network_request.py
@@ -61,3 +61,24 @@ async def test_should_parse_the_data_if_content_type_is_application_x_www_form_u
     request = await request_info.value
     assert request
     assert request.post_data_json == {"foo": "bar", "baz": "123"}
+
+
+async def test_existing_response_should_return_response_after_it_is_received(
+    page: Page, server: Server
+) -> None:
+    async with page.expect_event("requestfinished") as request_finished_info:
+        await page.goto(server.EMPTY_PAGE)
+    request = await request_finished_info.value
+    assert request.existing_response is not None
+    assert request.existing_response.status == 200
+
+
+async def test_existing_response_should_return_none_before_response_arrives(
+    page: Page, server: Server
+) -> None:
+    captured = []
+    page.on("request", lambda req: captured.append(req.existing_response))
+    await page.goto(server.EMPTY_PAGE)
+    assert captured
+    # When the "request" event fires, the response has not been received yet.
+    assert captured[0] is None

--- a/tests/async/test_page_network_response.py
+++ b/tests/async/test_page_network_response.py
@@ -70,3 +70,10 @@ async def test_should_reject_response_finished_if_context_closes(
         await finish_coroutine
     error = exc_info.value
     assert "closed" in error.message
+
+
+async def test_should_return_http_version(page: Page, server: Server) -> None:
+    response = await page.goto(server.EMPTY_PAGE)
+    assert response
+    http_version = await response.http_version()
+    assert http_version in ("HTTP/1.0", "HTTP/1.1", "HTTP/2.0")

--- a/tests/async/test_popup.py
+++ b/tests/async/test_popup.py
@@ -15,6 +15,8 @@
 import asyncio
 from typing import List, Optional
 
+import pytest
+
 from playwright.async_api import Browser, BrowserContext, Request, Route
 from tests.server import Server
 from tests.utils import must
@@ -136,9 +138,13 @@ async def test_should_inherit_http_credentials_from_browser_context(
     await context.close()
 
 
+@pytest.mark.skip_browser("firefox")
 async def test_should_inherit_touch_support_from_browser_context(
     browser: Browser, server: Server
 ) -> None:
+    # Firefox 148+ does not expose `ontouchstart` on freshly window.open()'d
+    # popups (https://bugzilla.mozilla.org/show_bug.cgi?id=2014330);
+    # upstream marks this as fixme for the same reason.
     context = await browser.new_context(
         viewport={"width": 400, "height": 500}, has_touch=True
     )

--- a/tests/async/test_route_web_socket.py
+++ b/tests/async/test_route_web_socket.py
@@ -41,10 +41,10 @@ async def assert_equal(
 
 async def setup_ws(
     target: Union[Page, Frame],
-    port: int,
+    server: Server,
     protocol: Union[Literal["blob"], Literal["arraybuffer"]],
 ) -> None:
-    await target.goto("about:blank")
+    await target.goto(server.EMPTY_PAGE)
     await target.evaluate(
         """({ port, binaryType }) => {
     window.log = [];
@@ -65,7 +65,7 @@ async def setup_ws(
     });
     window.wsOpened = new Promise(f => window.ws.addEventListener('open', () => f()));
   }""",
-        {"port": port, "binaryType": protocol},
+        {"port": server.PORT, "binaryType": protocol},
     )
 
 
@@ -79,7 +79,7 @@ async def test_should_work_with_ws_close(page: Page, server: Server) -> None:
     await page.route_web_socket(re.compile(".*"), _handle_ws)
 
     ws_task = server.wait_for_web_socket()
-    await setup_ws(page, server.PORT, "blob")
+    await setup_ws(page, server, "blob")
     ws = await ws_task
 
     route = await future
@@ -117,7 +117,7 @@ async def test_should_pattern_match(page: Page, server: Server) -> None:
     )
 
     ws_task = server.wait_for_web_socket()
-    await page.goto("about:blank")
+    await page.goto(server.EMPTY_PAGE)
     await page.evaluate(
         """async ({ port }) => {
         window.log = [];
@@ -191,7 +191,7 @@ async def test_should_work_with_server(page: Page, server: Server) -> None:
 
     server.once_web_socket_connection(_once_web_socket_connection)
 
-    await setup_ws(page, server.PORT, "blob")
+    await setup_ws(page, server, "blob")
     ws = await ws_task
     await assert_equal(lambda: log, ["message: fake"])
 
@@ -285,7 +285,7 @@ async def test_should_work_without_server(page: Page, server: Server) -> None:
         future.set_result(ws)
 
     await page.route_web_socket(re.compile(".*"), _handle_ws)
-    await setup_ws(page, server.PORT, "blob")
+    await setup_ws(page, server, "blob")
 
     await page.evaluate(
         """async () => {
@@ -330,7 +330,7 @@ async def test_should_work_with_base_url(browser: Browser, server: Server) -> No
         ws.on_message(lambda message: ws.send(message))
 
     await page.route_web_socket("/ws", _handle_ws)
-    await setup_ws(page, server.PORT, "blob")
+    await setup_ws(page, server, "blob")
 
     await page.evaluate(
         """async () => {
@@ -362,7 +362,7 @@ async def test_should_work_with_no_trailing_slash(page: Page, server: Server) ->
     # No trailing slash in the route pattern
     await page.route_web_socket(f"ws://localhost:{server.PORT}", handle_ws)
 
-    await page.goto("about:blank")
+    await page.goto(server.EMPTY_PAGE)
     await page.evaluate(
         """({ port }) => {
             window.log = [];

--- a/tests/async/test_screencast.py
+++ b/tests/async/test_screencast.py
@@ -1,0 +1,72 @@
+# Copyright (c) Microsoft Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+
+import pytest
+
+from playwright.async_api import Page, ScreencastFrame
+from tests.server import Server
+
+
+async def test_should_expose_screencast_property(page: Page) -> None:
+    assert page.screencast is page.screencast
+
+
+async def test_start_should_deliver_frames_via_callback(
+    page: Page, server: Server
+) -> None:
+    received: list = []
+    event = asyncio.Event()
+
+    def on_frame(frame: ScreencastFrame) -> None:
+        received.append(frame["data"])
+        event.set()
+
+    await page.screencast.start(on_frame=on_frame)
+    await page.goto(server.EMPTY_PAGE)
+    await page.evaluate("() => document.body.style.backgroundColor = 'red'")
+    # Force a couple of paint cycles so engines that only emit on visual change
+    # still produce a frame. Mirrors upstream `ensureSomeFrames`.
+    for _ in range(3):
+        await page.evaluate(
+            "() => new Promise(f => requestAnimationFrame(() => requestAnimationFrame(f)))"
+        )
+    await page.screenshot()
+    await asyncio.wait_for(event.wait(), timeout=10)
+    await page.screencast.stop()
+    assert len(received) >= 1
+    assert all(isinstance(d, bytes) and len(d) > 0 for d in received)
+
+
+async def test_starting_twice_should_throw(page: Page) -> None:
+    await page.screencast.start(on_frame=lambda f: None)
+    try:
+        with pytest.raises(Exception, match="already started"):
+            await page.screencast.start(on_frame=lambda f: None)
+    finally:
+        await page.screencast.stop()
+
+
+async def test_show_overlays_and_overlay_apis_should_not_throw(page: Page) -> None:
+    await page.screencast.start(on_frame=lambda f: None)
+    try:
+        await page.screencast.show_overlay("<div>hello</div>", duration=100)
+        await page.screencast.show_chapter("ch", description="desc", duration=100)
+        await page.screencast.hide_overlays()
+        await page.screencast.show_overlays()
+        await page.screencast.show_actions(duration=100, position="top-right")
+        await page.screencast.hide_actions()
+    finally:
+        await page.screencast.stop()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Generator, List, Optional, cast
 
 import pytest
+from _pytest.terminal import TerminalReporter
 from PIL import Image
 from pixelmatch import pixelmatch
 from pixelmatch.contrib.PIL import from_PIL_to_raw_data
@@ -261,6 +262,25 @@ class RemoteServer:
             return
         self.process.kill()
         self.process.wait()
+
+
+_failed_node_ids: List[str] = []
+
+
+def pytest_runtest_logreport(report: pytest.TestReport) -> None:
+    if report.failed and report.when in ("setup", "call"):
+        if report.nodeid not in _failed_node_ids:
+            _failed_node_ids.append(report.nodeid)
+
+
+def pytest_terminal_summary(
+    terminalreporter: TerminalReporter, exitstatus: int, config: pytest.Config
+) -> None:
+    if not _failed_node_ids:
+        return
+    terminalreporter.write_sep("=", "Failed tests", red=True, bold=True)
+    for index, nodeid in enumerate(_failed_node_ids, 1):
+        terminalreporter.write_line(f"  {index}) {nodeid}", red=True)
 
 
 @pytest.fixture

--- a/tests/sync/test_debugger.py
+++ b/tests/sync/test_debugger.py
@@ -1,0 +1,20 @@
+# Copyright (c) Microsoft Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from playwright.sync_api import BrowserContext
+
+
+def test_should_expose_debugger_property(context: BrowserContext) -> None:
+    assert context.debugger is context.debugger
+    assert context.debugger.paused_details is None

--- a/tests/sync/test_page_aria_snapshot.py
+++ b/tests/sync/test_page_aria_snapshot.py
@@ -214,3 +214,20 @@ def test_match_values_both_against_regex_and_string(page: Page) -> None:
           - /url: /auth?r=/
       """,
     )
+
+
+def test_should_snapshot_with_depth(page: Page) -> None:
+    page.set_content("<ul><li><a href=about:blank>link</a></li></ul>")
+    snapshot = page.locator("body").aria_snapshot(depth=1)
+    assert "listitem" in snapshot
+    assert "/url" not in snapshot
+
+
+def test_page_aria_snapshot_should_work(page: Page) -> None:
+    page.set_content("<h1>title</h1>")
+    snapshot = page.aria_snapshot()
+    assert _unshift(snapshot) == _unshift(
+        """
+      - heading "title" [level=1]
+    """
+    )

--- a/tests/sync/test_page_event_console.py
+++ b/tests/sync/test_page_event_console.py
@@ -34,3 +34,16 @@ def test_console_messages_should_work(page: Page) -> None:
     assert len(objects) >= 100, "should be at least 100 messages"
     message_count = len(messages) - len(expected)
     assert objects[message_count:] == expected, "should return last messages"
+
+
+def test_should_have_a_timestamp(page: Page) -> None:
+    with page.expect_console_message() as message_info:
+        page.evaluate("() => console.log('hello')")
+    assert message_info.value.timestamp > 0
+
+
+def test_clear_console_messages_should_drop_buffered_messages(page: Page) -> None:
+    page.evaluate("() => console.log('first')")
+    assert any(m.text == "first" for m in page.console_messages())
+    page.clear_console_messages()
+    assert not any(m.text == "first" for m in page.console_messages())

--- a/tests/sync/test_page_network_response.py
+++ b/tests/sync/test_page_network_response.py
@@ -64,3 +64,9 @@ def test_should_reject_response_finished_if_context_closes(
         page_response.finished()
     error = exc_info.value
     assert "closed" in error.message
+
+
+def test_should_return_http_version(page: Page, server: Server) -> None:
+    response = page.goto(server.EMPTY_PAGE)
+    assert response
+    assert response.http_version() in ("HTTP/1.0", "HTTP/1.1", "HTTP/2.0")

--- a/tests/sync/test_route_web_socket.py
+++ b/tests/sync/test_route_web_socket.py
@@ -38,10 +38,10 @@ def assert_equal(
 
 def setup_ws(
     target: Union[Page, Frame],
-    port: int,
+    server: Server,
     protocol: Union[Literal["blob"], Literal["arraybuffer"]],
 ) -> None:
-    target.goto("about:blank")
+    target.goto(server.EMPTY_PAGE)
     target.evaluate(
         """({ port, binaryType }) => {
     window.log = [];
@@ -62,7 +62,7 @@ def setup_ws(
     });
     window.wsOpened = new Promise(f => window.ws.addEventListener('open', () => f()));
   }""",
-        {"port": port, "binaryType": protocol},
+        {"port": server.PORT, "binaryType": protocol},
     )
 
 
@@ -77,7 +77,7 @@ def test_should_work_with_ws_close(page: Page, server: Server) -> None:
     page.route_web_socket(re.compile(".*"), _handle_ws)
 
     with server.expect_websocket() as ws_task:
-        setup_ws(page, server.PORT, "blob")
+        setup_ws(page, server, "blob")
     page.evaluate("window.wsOpened")
     ws = ws_task.value
     assert route
@@ -110,7 +110,7 @@ def test_should_pattern_match(page: Page, server: Server) -> None:
         "**/mock-ws", lambda ws: ws.on_message(lambda message: ws.send("mock-response"))
     )
 
-    page.goto("about:blank")
+    page.goto(server.EMPTY_PAGE)
     with server.expect_websocket() as ws_info:
         page.evaluate(
             """async ({ port }) => {
@@ -185,7 +185,7 @@ def test_should_work_with_server(page: Page, server: Server) -> None:
     server.once_web_socket_connection(_once_web_socket_connection)
 
     with server.expect_websocket() as ws_info:
-        setup_ws(page, server.PORT, "blob")
+        setup_ws(page, server, "blob")
     page.evaluate("window.wsOpened")
     ws = ws_info.value
     assert_equal(lambda: log, ["message: fake"])
@@ -280,7 +280,7 @@ def test_should_work_without_server(page: Page, server: Server) -> None:
         route = ws
 
     page.route_web_socket(re.compile(".*"), _handle_ws)
-    setup_ws(page, server.PORT, "blob")
+    setup_ws(page, server, "blob")
 
     page.evaluate(
         """async () => {
@@ -324,7 +324,7 @@ def test_should_work_with_base_url(browser: Browser, server: Server) -> None:
         ws.on_message(lambda message: ws.send(message))
 
     page.route_web_socket("/ws", _handle_ws)
-    setup_ws(page, server.PORT, "blob")
+    setup_ws(page, server, "blob")
 
     page.evaluate(
         """async () => {
@@ -357,7 +357,7 @@ def test_should_work_with_no_trailing_slash(page: Page, server: Server) -> None:
     # No trailing slash in the route pattern
     page.route_web_socket(f"ws://localhost:{server.PORT}", handle_ws)
 
-    page.goto("about:blank")
+    page.goto(server.EMPTY_PAGE)
     page.evaluate(
         """({ port }) => {
             window.log = [];

--- a/tests/sync/test_screencast.py
+++ b/tests/sync/test_screencast.py
@@ -1,0 +1,53 @@
+# Copyright (c) Microsoft Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+
+import pytest
+
+from playwright.sync_api import Page
+from tests.server import Server
+
+
+def test_should_expose_screencast_property(page: Page) -> None:
+    assert page.screencast is page.screencast
+
+
+def test_start_should_deliver_frames_via_callback(page: Page, server: Server) -> None:
+    received: list = []
+    page.screencast.start(on_frame=lambda f: received.append(f["data"]))
+    page.goto(server.EMPTY_PAGE)
+    page.evaluate("() => document.body.style.backgroundColor = 'red'")
+    # Force a couple of paint cycles so engines that only emit on visual change
+    # still produce a frame. Mirrors upstream `ensureSomeFrames`.
+    for _ in range(3):
+        page.evaluate(
+            "() => new Promise(f => requestAnimationFrame(() => requestAnimationFrame(f)))"
+        )
+    page.screenshot()
+    deadline = time.time() + 10
+    while not received and time.time() < deadline:
+        page.wait_for_timeout(100)
+    page.screencast.stop()
+    assert len(received) >= 1
+    assert all(isinstance(d, bytes) and len(d) > 0 for d in received)
+
+
+def test_starting_twice_should_throw(page: Page) -> None:
+    page.screencast.start(on_frame=lambda f: None)
+    try:
+        with pytest.raises(Exception, match="already started"):
+            page.screencast.start(on_frame=lambda f: None)
+    finally:
+        page.screencast.stop()


### PR DESCRIPTION
Bumps the driver to 1.59.1 and ports the public-API changes that landed upstream during the 1.58 → 1.59 cycle.

New public APIs:
- Request.existing_response (property)
- Response.http_version()
- ConsoleMessage.timestamp (property)
- BrowserContext.is_closed()
- BrowserContext.set_storage_state(state | path)
- BrowserContext.debugger (property) + new Debugger class (request_pause, resume, next, run_to, paused_details + pausedstatechanged event)
- Page.aria_snapshot(timeout=, depth=, mode=)
- Page.console_messages(filter=) / Page.page_errors(filter=)
- Page.clear_console_messages() / Page.clear_page_errors()
- Page.pick_locator() / Page.cancel_pick_locator()
- Page.screencast (property) + new Screencast class (start/stop with onFrame callback, show_actions/hide_actions, show_overlay, show_chapter, show_overlays/hide_overlays)
- Locator.normalize()
- Locator.aria_snapshot(depth=, mode=)
- Browser.bind(title, ...) / Browser.unbind()
- BrowserType.launch(artifacts_dir=) / launch_persistent_context(artifacts_dir=)
- Tracing.start(live=)
- CDPSession emits 'close' and forwards 'event' for raw CDP events
- Dialog.dismiss() swallows TargetClosedError

Renames matching upstream:
- BrowserType.connect(ws_endpoint=) -> connect(endpoint=) (positional; the wire field also renamed to "endpoint")

Generator/codegen:
- documentation_provider: emit Promise-without-templates as Any, void as None
- documentation_provider: emit @typing.overload + generic fallback for single-event classes (CDPSession needed this once it gained 'close')
- New TypedDicts in _api_structures.py: DebuggerLocation, DebuggerPausedDetails, ScreencastFrame, BrowserBindResult
- Register Debugger in _object_factory; register Debugger and Screencast in scripts/generate_api.py

Tests added (async + sync mirrors where applicable) for every PORT. expected_api_mismatch.txt is now down to legitimate divergences only.

Tooling:
- New CLAUDE.md with project orientation
- Expanded .claude/skills/playwright-roll/SKILL.md with the operational playbook learned over this roll (langs-verification, audit loop, common doclint quirks, channel-owner wiring checklist).