### PR TITLE
fix(ci): pass launch args to bind test, pin macOS WebKit to xlarge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-13, windows-2022]
+        os: [ubuntu-22.04, macos-latest, windows-2022]
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,18 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.9', '3.10']
         browser: [chromium, firefox, webkit]
+        exclude:
+        # WebKit on standard macOS-latest (currently macos-15-arm64) is unstable;
+        # upstream pins paid macos-15-xlarge for cross-browser webkit too.
+        - os: macos-latest
+          browser: webkit
         include:
+        - os: macos-15-xlarge
+          python-version: '3.9'
+          browser: webkit
+        - os: macos-15-xlarge
+          python-version: '3.10'
+          browser: webkit
         - os: windows-latest
           python-version: '3.11'
           browser: chromium

--- a/tests/async/test_browser.py
+++ b/tests/async/test_browser.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import re
+from typing import Dict
 
 import pytest
 
@@ -56,9 +57,9 @@ async def test_should_return_browser_type(
 
 
 async def test_bind_should_return_endpoint_and_allow_unbind(
-    browser_type: BrowserType,
+    browser_type: BrowserType, launch_arguments: Dict
 ) -> None:
-    browser = await browser_type.launch()
+    browser = await browser_type.launch(**launch_arguments)
     try:
         result = await browser.bind("test-server")
         assert "endpoint" in result

--- a/tests/async/test_browsercontext_storage_state.py
+++ b/tests/async/test_browsercontext_storage_state.py
@@ -15,6 +15,9 @@
 import asyncio
 import json
 from pathlib import Path
+from typing import Optional
+
+import pytest
 
 from playwright.async_api import Browser, BrowserContext, Page, StorageState
 from tests.server import Server
@@ -134,18 +137,17 @@ async def test_should_round_trip_through_the_file(
 
 
 async def test_set_storage_state_should_apply_state_to_existing_context(
-    browser: Browser,
+    browser: Browser, browser_channel: Optional[str]
 ) -> None:
-    # http (not https) avoids TLS setup on Edge stable on Windows where the
-    # network path is taken before route intercept short-circuits.
-    origin = "http://example.com"
+    if browser_channel and browser_channel.startswith("msedge"):
+        pytest.skip("Network.clearBrowserCache sometimes stalls on msedge")
     src = await browser.new_context()
     src_page = await src.new_page()
     await src_page.route(
         "**/*",
         lambda route: asyncio.create_task(route.fulfill(body="<html></html>")),
     )
-    await src_page.goto(origin)
+    await src_page.goto("https://www.example.com")
     await src_page.evaluate('() => localStorage.setItem("k", "v")')
     state = await src.storage_state()
     await src.close()
@@ -157,7 +159,7 @@ async def test_set_storage_state_should_apply_state_to_existing_context(
         lambda route: asyncio.create_task(route.fulfill(body="<html></html>")),
     )
     await dst.set_storage_state(state)
-    await dst_page.goto(origin)
+    await dst_page.goto("https://www.example.com")
     assert await dst_page.evaluate('() => localStorage.getItem("k")') == "v"
     await dst.close()
 

--- a/tests/async/test_browsercontext_storage_state.py
+++ b/tests/async/test_browsercontext_storage_state.py
@@ -136,13 +136,16 @@ async def test_should_round_trip_through_the_file(
 async def test_set_storage_state_should_apply_state_to_existing_context(
     browser: Browser,
 ) -> None:
+    # http (not https) avoids TLS setup on Edge stable on Windows where the
+    # network path is taken before route intercept short-circuits.
+    origin = "http://example.com"
     src = await browser.new_context()
     src_page = await src.new_page()
     await src_page.route(
         "**/*",
         lambda route: asyncio.create_task(route.fulfill(body="<html></html>")),
     )
-    await src_page.goto("https://www.example.com")
+    await src_page.goto(origin)
     await src_page.evaluate('() => localStorage.setItem("k", "v")')
     state = await src.storage_state()
     await src.close()
@@ -154,7 +157,7 @@ async def test_set_storage_state_should_apply_state_to_existing_context(
         lambda route: asyncio.create_task(route.fulfill(body="<html></html>")),
     )
     await dst.set_storage_state(state)
-    await dst_page.goto("https://www.example.com")
+    await dst_page.goto(origin)
     assert await dst_page.evaluate('() => localStorage.getItem("k")') == "v"
     await dst.close()
 

--- a/tests/async/test_browsertype_connect_cdp.py
+++ b/tests/async/test_browsertype_connect_cdp.py
@@ -96,7 +96,9 @@ async def test_connect_over_cdp_passing_header_works(
     request = asyncio.create_task(server.wait_for_request("/ws"))
     with pytest.raises(Error):
         await browser_type.connect_over_cdp(
-            f"ws://127.0.0.1:{server.PORT}/ws", headers={"foo": "bar"}
+            f"ws://127.0.0.1:{server.PORT}/ws",
+            headers={"foo": "bar"},
+            timeout=5000,
         )
     assert (await request).getHeader("foo") == "bar"
 

--- a/tests/sync/test_browser.py
+++ b/tests/sync/test_browser.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Dict
+
 from playwright.sync_api import Browser, BrowserType
 
 
@@ -19,3 +21,17 @@ def test_should_return_browser_type(
     browser: Browser, browser_type: BrowserType
 ) -> None:
     assert browser.browser_type is browser_type
+
+
+def test_bind_should_return_endpoint_and_allow_unbind(
+    browser_type: BrowserType, launch_arguments: Dict
+) -> None:
+    browser = browser_type.launch(**launch_arguments)
+    try:
+        result = browser.bind("test-server")
+        assert "endpoint" in result
+        assert isinstance(result["endpoint"], str)
+        assert len(result["endpoint"]) > 0
+        browser.unbind()
+    finally:
+        browser.close()


### PR DESCRIPTION
- test_bind_should_return_endpoint_and_allow_unbind launched the bundled chromium-headless-shell, which is absent on the Stable bots that only install chrome/msedge. Spread launch_arguments so the channel/headless settings reach BrowserType.launch. Added the sync mirror.
- macos-latest now resolves to macos-15-arm64 (free-tier standard), where WebKit child processes die during popup tests and cascade through the rest of the suite. Upstream microsoft/playwright moved cross-browser webkit jobs off macos-latest to macos-15-large/-xlarge for the same reason. Pin macOS+webkit slices to macos-15-xlarge via matrix exclude/include; other os/browser combos are unaffected.