### PR TITLE
fix: network task handles leak

### DIFF
--- a/tests/async/test_page_network_response.py
+++ b/tests/async/test_page_network_response.py
@@ -71,6 +71,34 @@ async def test_should_reject_response_finished_if_context_closes(
     error = exc_info.value
     assert "closed" in error.message
 
+async def test_response_finished_should_not_leave_page_close_waiter(
+    page: Page, server: Server
+) -> None:
+    def response_finished_waiters() -> list[asyncio.Task]:
+        return [
+            task
+            for task in asyncio.all_tasks()
+            if not task.done()
+            and getattr(task.get_coro(), "__qualname__", "")
+            == "Response.finished.<locals>.on_finished"
+        ]
+
+    baseline = set(response_finished_waiters())
+    leaked_waiters = []
+    try:
+        response = await page.goto(server.EMPTY_PAGE)
+        assert response
+        await response.finished()
+        await asyncio.sleep(0)
+
+        leaked_waiters = [
+            task for task in response_finished_waiters() if task not in baseline
+        ]
+        assert not leaked_waiters, "Response.finished() leaked page-close waiter tasks"
+    finally:
+        await page.close()
+        if leaked_waiters:
+            await asyncio.gather(*leaked_waiters, return_exceptions=True)
 
 async def test_should_return_http_version(page: Page, server: Server) -> None:
     response = await page.goto(server.EMPTY_PAGE)


### PR DESCRIPTION
Hello 😄 

Given several reports of memory leaks, and my personal experience of long-running contexts getting bloated after some time, leading to OOM problems, I wanted to investigate a bit with some help from Codex (and my personal investigation)

I added a failing test case to start

Findings

  - High confidence: playwright/_impl/_network.py:896 leaks a close-watcher task on normal completion. It creates on_finished_task, waits for either response-finished or page-close, but
  never cancels the page-close task when the response wins. I reproduced this with a local micro-check: normal finish leaves one pending close-watch task attached to the page close
  future.
  - High confidence: repeated browser_type.connect() can retain closed child connections. playwright/_impl/_browser_type.py:244 appends each child Connection to parent
  _child_ws_connections at playwright/_impl/_browser_type.py:291, but nothing removes it. playwright/_impl/_connection.py:327 also does not clear _objects, so a retained closed child can
  keep its object graph alive.
  - Medium confidence: disposed channel owners do not cancel pending async event tasks. playwright/_impl/_connection.py:177 removes protocol objects from maps, but does not cancel pyee
  pending futures or clear listeners. This is risky for long-running route/request handlers, because route events are scheduled as tasks in playwright/_impl/_page.py:287 and active route
  invocations retain routes in playwright/_impl/_helper.py:416. This matches the shape of GitHub issue #1779 (https://github.com/microsoft/playwright-python/issues/1779).
  - Expected-but-important: APIResponse bodies from request.fetch() / route.fetch() stay in memory until explicit dispose or context close. The implementation only releases them via pla
  ywright/_impl/_fetch.py:516, and the official docs state the body remains in memory until dispose/context close: https://playwright.dev/python/docs/api/class-apiresponse. In a long-li
  ved context, missing await response.dispose() after route.fetch() is enough to look like a leak.
  - Lower confidence: tracing cleanup still has exception-path risks. The known tracing object leak #2977 (https://github.com/microsoft/playwright-python/issues/2977) has a regression t
  est in tests/test_reference_count_async.py:78, but playwright/_impl/_tracing.py:68 increments global tracing state before tracing_started() completes, and playwright/_impl/_tracing.py
  :86 is not exception-safe around local zip/export cleanup. That lines up with trace-stop hang reports like #1847 (https://github.com/microsoft/playwright-python/issues/1847).