### PR TITLE
fix: handle ignore_default_args=False in launch params

### DIFF
--- a/playwright/_impl/_browser_type.py
+++ b/playwright/_impl/_browser_type.py
@@ -357,6 +357,8 @@ def normalize_launch_params(params: Dict) -> None:
         if params["ignoreDefaultArgs"] is True:
             params["ignoreAllDefaultArgs"] = True
             del params["ignoreDefaultArgs"]
+        elif params["ignoreDefaultArgs"] is False:
+            del params["ignoreDefaultArgs"]
     if "executablePath" in params:
         params["executablePath"] = str(Path(params["executablePath"]))
     if "downloadsPath" in params:

--- a/tests/async/test_launcher.py
+++ b/tests/async/test_launcher.py
@@ -107,3 +107,12 @@ async def test_browser_close_should_be_callable_twice(
         browser.close(),
     )
     await browser.close()
+
+
+async def test_browser_type_launch_should_accept_ignore_default_args_false(
+    browser_type: BrowserType, launch_arguments: Dict
+) -> None:
+    # Regression for https://github.com/microsoft/playwright-python/issues/3005:
+    # passing False used to crash with "expected array, got boolean".
+    browser = await browser_type.launch(**launch_arguments, ignore_default_args=False)
+    await browser.close()

--- a/tests/sync/test_launcher.py
+++ b/tests/sync/test_launcher.py
@@ -88,3 +88,10 @@ def test_browser_close_should_be_callable_twice(
     browser = browser_type.launch(**launch_arguments)
     browser.close()
     browser.close()
+
+
+def test_browser_type_launch_should_accept_ignore_default_args_false(
+    browser_type: BrowserType, launch_arguments: Dict
+) -> None:
+    browser = browser_type.launch(**launch_arguments, ignore_default_args=False)
+    browser.close()


### PR DESCRIPTION
Closes #3005. Picks up @lp07's fix from #3020 with tests relocated to follow repo conventions.
