### PR TITLE
feat: accept datetime.timedelta for timeout parameters

### DIFF
--- a/playwright/_impl/_helper.py
+++ b/playwright/_impl/_helper.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
+import datetime
 import math
 import os
 import re
@@ -574,3 +575,13 @@ TEXTUAL_MIME_TYPE = re.compile(
 
 def is_textual_mime_type(mime_type: str) -> bool:
     return bool(TEXTUAL_MIME_TYPE.match(mime_type))
+
+
+def to_milliseconds(
+    value: Union[float, datetime.timedelta, None],
+) -> Optional[float]:
+    if value is None:
+        return None
+    if isinstance(value, datetime.timedelta):
+        return value / datetime.timedelta(milliseconds=1)
+    return value

--- a/playwright/async_api/_generated.py
+++ b/playwright/async_api/_generated.py
@@ -71,6 +71,7 @@ from playwright._impl._fetch import APIRequestContext as APIRequestContextImpl
 from playwright._impl._fetch import APIResponse as APIResponseImpl
 from playwright._impl._file_chooser import FileChooser as FileChooserImpl
 from playwright._impl._frame import Frame as FrameImpl
+from playwright._impl._helper import to_milliseconds
 from playwright._impl._input import Keyboard as KeyboardImpl
 from playwright._impl._input import Mouse as MouseImpl
 from playwright._impl._input import Touchscreen as TouchscreenImpl
@@ -791,7 +792,7 @@ class Route(AsyncBase):
         post_data: typing.Optional[typing.Union[typing.Any, str, bytes]] = None,
         max_redirects: typing.Optional[int] = None,
         max_retries: typing.Optional[int] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> "APIResponse":
         """Route.fetch
 
@@ -850,7 +851,7 @@ class Route(AsyncBase):
                 postData=mapping.to_impl(post_data),
                 maxRedirects=max_redirects,
                 maxRetries=max_retries,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
             )
         )
 
@@ -1125,7 +1126,7 @@ class WebSocket(AsyncBase):
         event: str,
         predicate: typing.Optional[typing.Callable] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> AsyncEventContextManager:
         """WebSocket.expect_event
 
@@ -1149,7 +1150,9 @@ class WebSocket(AsyncBase):
 
         return AsyncEventContextManager(
             self._impl_obj.expect_event(
-                event=event, predicate=self._wrap_handler(predicate), timeout=timeout
+                event=event,
+                predicate=self._wrap_handler(predicate),
+                timeout=to_milliseconds(timeout),
             ).future
         )
 
@@ -1158,7 +1161,7 @@ class WebSocket(AsyncBase):
         event: str,
         predicate: typing.Optional[typing.Callable] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> typing.Any:
         """WebSocket.wait_for_event
 
@@ -1185,7 +1188,9 @@ class WebSocket(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.wait_for_event(
-                event=event, predicate=self._wrap_handler(predicate), timeout=timeout
+                event=event,
+                predicate=self._wrap_handler(predicate),
+                timeout=to_milliseconds(timeout),
             )
         )
 
@@ -2044,7 +2049,9 @@ class ElementHandle(JSHandle):
         )
 
     async def scroll_into_view_if_needed(
-        self, *, timeout: typing.Optional[float] = None
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """ElementHandle.scroll_into_view_if_needed
 
@@ -2065,7 +2072,9 @@ class ElementHandle(JSHandle):
         """
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.scroll_into_view_if_needed(timeout=timeout)
+            await self._impl_obj.scroll_into_view_if_needed(
+                timeout=to_milliseconds(timeout)
+            )
         )
 
     async def hover(
@@ -2075,7 +2084,7 @@ class ElementHandle(JSHandle):
             typing.Sequence[Literal["Alt", "Control", "ControlOrMeta", "Meta", "Shift"]]
         ] = None,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
         force: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
@@ -2118,7 +2127,7 @@ class ElementHandle(JSHandle):
             await self._impl_obj.hover(
                 modifiers=mapping.to_impl(modifiers),
                 position=position,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 noWaitAfter=no_wait_after,
                 force=force,
                 trial=trial,
@@ -2135,7 +2144,7 @@ class ElementHandle(JSHandle):
         delay: typing.Optional[float] = None,
         button: typing.Optional[Literal["left", "middle", "right"]] = None,
         click_count: typing.Optional[int] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
@@ -2194,7 +2203,7 @@ class ElementHandle(JSHandle):
                 delay=delay,
                 button=button,
                 clickCount=click_count,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 force=force,
                 noWaitAfter=no_wait_after,
                 trial=trial,
@@ -2211,7 +2220,7 @@ class ElementHandle(JSHandle):
         position: typing.Optional[Position] = None,
         delay: typing.Optional[float] = None,
         button: typing.Optional[Literal["left", "middle", "right"]] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
@@ -2266,7 +2275,7 @@ class ElementHandle(JSHandle):
                 position=position,
                 delay=delay,
                 button=button,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 force=force,
                 noWaitAfter=no_wait_after,
                 trial=trial,
@@ -2283,7 +2292,7 @@ class ElementHandle(JSHandle):
         element: typing.Optional[
             typing.Union["ElementHandle", typing.Sequence["ElementHandle"]]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
     ) -> typing.List[str]:
@@ -2344,7 +2353,7 @@ class ElementHandle(JSHandle):
                 index=mapping.to_impl(index),
                 label=mapping.to_impl(label),
                 element=mapping.to_impl(element),
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 force=force,
                 noWaitAfter=no_wait_after,
             )
@@ -2357,7 +2366,7 @@ class ElementHandle(JSHandle):
             typing.Sequence[Literal["Alt", "Control", "ControlOrMeta", "Meta", "Shift"]]
         ] = None,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
@@ -2402,7 +2411,7 @@ class ElementHandle(JSHandle):
             await self._impl_obj.tap(
                 modifiers=mapping.to_impl(modifiers),
                 position=position,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 force=force,
                 noWaitAfter=no_wait_after,
                 trial=trial,
@@ -2413,7 +2422,7 @@ class ElementHandle(JSHandle):
         self,
         value: str,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
         force: typing.Optional[bool] = None,
     ) -> None:
@@ -2445,7 +2454,10 @@ class ElementHandle(JSHandle):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.fill(
-                value=value, timeout=timeout, noWaitAfter=no_wait_after, force=force
+                value=value,
+                timeout=to_milliseconds(timeout),
+                noWaitAfter=no_wait_after,
+                force=force,
             )
         )
 
@@ -2453,7 +2465,7 @@ class ElementHandle(JSHandle):
         self,
         *,
         force: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """ElementHandle.select_text
 
@@ -2474,10 +2486,16 @@ class ElementHandle(JSHandle):
         """
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.select_text(force=force, timeout=timeout)
+            await self._impl_obj.select_text(
+                force=force, timeout=to_milliseconds(timeout)
+            )
         )
 
-    async def input_value(self, *, timeout: typing.Optional[float] = None) -> str:
+    async def input_value(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> str:
         """ElementHandle.input_value
 
         Returns `input.value` for the selected `<input>` or `<textarea>` or `<select>` element.
@@ -2498,7 +2516,7 @@ class ElementHandle(JSHandle):
         """
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.input_value(timeout=timeout)
+            await self._impl_obj.input_value(timeout=to_milliseconds(timeout))
         )
 
     async def set_input_files(
@@ -2511,7 +2529,7 @@ class ElementHandle(JSHandle):
             typing.Sequence[FilePayload],
         ],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
     ) -> None:
         """ElementHandle.set_input_files
@@ -2538,7 +2556,9 @@ class ElementHandle(JSHandle):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.set_input_files(
-                files=mapping.to_impl(files), timeout=timeout, noWaitAfter=no_wait_after
+                files=mapping.to_impl(files),
+                timeout=to_milliseconds(timeout),
+                noWaitAfter=no_wait_after,
             )
         )
 
@@ -2555,7 +2575,7 @@ class ElementHandle(JSHandle):
         text: str,
         *,
         delay: typing.Optional[float] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
     ) -> None:
         """ElementHandle.type
@@ -2583,7 +2603,10 @@ class ElementHandle(JSHandle):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.type(
-                text=text, delay=delay, timeout=timeout, noWaitAfter=no_wait_after
+                text=text,
+                delay=delay,
+                timeout=to_milliseconds(timeout),
+                noWaitAfter=no_wait_after,
             )
         )
 
@@ -2592,7 +2615,7 @@ class ElementHandle(JSHandle):
         key: str,
         *,
         delay: typing.Optional[float] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
     ) -> None:
         """ElementHandle.press
@@ -2637,7 +2660,10 @@ class ElementHandle(JSHandle):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.press(
-                key=key, delay=delay, timeout=timeout, noWaitAfter=no_wait_after
+                key=key,
+                delay=delay,
+                timeout=to_milliseconds(timeout),
+                noWaitAfter=no_wait_after,
             )
         )
 
@@ -2646,7 +2672,7 @@ class ElementHandle(JSHandle):
         checked: bool,
         *,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
@@ -2689,7 +2715,7 @@ class ElementHandle(JSHandle):
             await self._impl_obj.set_checked(
                 checked=checked,
                 position=position,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 force=force,
                 noWaitAfter=no_wait_after,
                 trial=trial,
@@ -2700,7 +2726,7 @@ class ElementHandle(JSHandle):
         self,
         *,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
@@ -2741,7 +2767,7 @@ class ElementHandle(JSHandle):
         return mapping.from_maybe_impl(
             await self._impl_obj.check(
                 position=position,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 force=force,
                 noWaitAfter=no_wait_after,
                 trial=trial,
@@ -2752,7 +2778,7 @@ class ElementHandle(JSHandle):
         self,
         *,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
@@ -2793,7 +2819,7 @@ class ElementHandle(JSHandle):
         return mapping.from_maybe_impl(
             await self._impl_obj.uncheck(
                 position=position,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 force=force,
                 noWaitAfter=no_wait_after,
                 trial=trial,
@@ -2833,7 +2859,7 @@ class ElementHandle(JSHandle):
     async def screenshot(
         self,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         type: typing.Optional[Literal["jpeg", "png"]] = None,
         path: typing.Optional[typing.Union[pathlib.Path, str]] = None,
         quality: typing.Optional[int] = None,
@@ -2908,7 +2934,7 @@ class ElementHandle(JSHandle):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.screenshot(
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 type=type,
                 path=path,
                 quality=quality,
@@ -3058,7 +3084,7 @@ class ElementHandle(JSHandle):
             "disabled", "editable", "enabled", "hidden", "stable", "visible"
         ],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """ElementHandle.wait_for_element_state
 
@@ -3087,7 +3113,9 @@ class ElementHandle(JSHandle):
         """
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.wait_for_element_state(state=state, timeout=timeout)
+            await self._impl_obj.wait_for_element_state(
+                state=state, timeout=to_milliseconds(timeout)
+            )
         )
 
     async def wait_for_selector(
@@ -3097,7 +3125,7 @@ class ElementHandle(JSHandle):
         state: typing.Optional[
             Literal["attached", "detached", "hidden", "visible"]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         strict: typing.Optional[bool] = None,
     ) -> typing.Optional["ElementHandle"]:
         """ElementHandle.wait_for_selector
@@ -3147,7 +3175,10 @@ class ElementHandle(JSHandle):
 
         return mapping.from_impl_nullable(
             await self._impl_obj.wait_for_selector(
-                selector=selector, state=state, timeout=timeout, strict=strict
+                selector=selector,
+                state=state,
+                timeout=to_milliseconds(timeout),
+                strict=strict,
             )
         )
 
@@ -3203,7 +3234,7 @@ class FileChooser(AsyncBase):
             typing.Sequence[FilePayload],
         ],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
     ) -> None:
         """FileChooser.set_files
@@ -3224,7 +3255,9 @@ class FileChooser(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.set_files(
-                files=mapping.to_impl(files), timeout=timeout, noWaitAfter=no_wait_after
+                files=mapping.to_impl(files),
+                timeout=to_milliseconds(timeout),
+                noWaitAfter=no_wait_after,
             )
         )
 
@@ -3301,7 +3334,7 @@ class Frame(AsyncBase):
         self,
         url: str,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         wait_until: typing.Optional[
             Literal["commit", "domcontentloaded", "load", "networkidle"]
         ] = None,
@@ -3357,7 +3390,10 @@ class Frame(AsyncBase):
 
         return mapping.from_impl_nullable(
             await self._impl_obj.goto(
-                url=url, timeout=timeout, waitUntil=wait_until, referer=referer
+                url=url,
+                timeout=to_milliseconds(timeout),
+                waitUntil=wait_until,
+                referer=referer,
             )
         )
 
@@ -3370,7 +3406,7 @@ class Frame(AsyncBase):
         wait_until: typing.Optional[
             Literal["commit", "domcontentloaded", "load", "networkidle"]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> AsyncEventContextManager["Response"]:
         """Frame.expect_navigation
 
@@ -3419,7 +3455,9 @@ class Frame(AsyncBase):
 
         return AsyncEventContextManager(
             self._impl_obj.expect_navigation(
-                url=self._wrap_handler(url), waitUntil=wait_until, timeout=timeout
+                url=self._wrap_handler(url),
+                waitUntil=wait_until,
+                timeout=to_milliseconds(timeout),
             ).future
         )
 
@@ -3430,7 +3468,7 @@ class Frame(AsyncBase):
         wait_until: typing.Optional[
             Literal["commit", "domcontentloaded", "load", "networkidle"]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """Frame.wait_for_url
 
@@ -3466,7 +3504,9 @@ class Frame(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.wait_for_url(
-                url=self._wrap_handler(url), waitUntil=wait_until, timeout=timeout
+                url=self._wrap_handler(url),
+                waitUntil=wait_until,
+                timeout=to_milliseconds(timeout),
             )
         )
 
@@ -3476,7 +3516,7 @@ class Frame(AsyncBase):
             Literal["domcontentloaded", "load", "networkidle"]
         ] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """Frame.wait_for_load_state
 
@@ -3513,7 +3553,9 @@ class Frame(AsyncBase):
         """
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.wait_for_load_state(state=state, timeout=timeout)
+            await self._impl_obj.wait_for_load_state(
+                state=state, timeout=to_milliseconds(timeout)
+            )
         )
 
     async def frame_element(self) -> "ElementHandle":
@@ -3709,7 +3751,7 @@ class Frame(AsyncBase):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         state: typing.Optional[
             Literal["attached", "detached", "hidden", "visible"]
         ] = None,
@@ -3776,7 +3818,10 @@ class Frame(AsyncBase):
 
         return mapping.from_impl_nullable(
             await self._impl_obj.wait_for_selector(
-                selector=selector, strict=strict, timeout=timeout, state=state
+                selector=selector,
+                strict=strict,
+                timeout=to_milliseconds(timeout),
+                state=state,
             )
         )
 
@@ -3785,7 +3830,7 @@ class Frame(AsyncBase):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> bool:
         """Frame.is_checked
 
@@ -3810,7 +3855,7 @@ class Frame(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.is_checked(
-                selector=selector, strict=strict, timeout=timeout
+                selector=selector, strict=strict, timeout=to_milliseconds(timeout)
             )
         )
 
@@ -3819,7 +3864,7 @@ class Frame(AsyncBase):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> bool:
         """Frame.is_disabled
 
@@ -3844,7 +3889,7 @@ class Frame(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.is_disabled(
-                selector=selector, strict=strict, timeout=timeout
+                selector=selector, strict=strict, timeout=to_milliseconds(timeout)
             )
         )
 
@@ -3853,7 +3898,7 @@ class Frame(AsyncBase):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> bool:
         """Frame.is_editable
 
@@ -3878,7 +3923,7 @@ class Frame(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.is_editable(
-                selector=selector, strict=strict, timeout=timeout
+                selector=selector, strict=strict, timeout=to_milliseconds(timeout)
             )
         )
 
@@ -3887,7 +3932,7 @@ class Frame(AsyncBase):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> bool:
         """Frame.is_enabled
 
@@ -3912,7 +3957,7 @@ class Frame(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.is_enabled(
-                selector=selector, strict=strict, timeout=timeout
+                selector=selector, strict=strict, timeout=to_milliseconds(timeout)
             )
         )
 
@@ -3975,7 +4020,7 @@ class Frame(AsyncBase):
         event_init: typing.Optional[typing.Dict] = None,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """Frame.dispatch_event
 
@@ -4035,7 +4080,7 @@ class Frame(AsyncBase):
                 type=type,
                 eventInit=mapping.to_impl(event_init),
                 strict=strict,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
             )
         )
 
@@ -4148,7 +4193,7 @@ class Frame(AsyncBase):
         self,
         html: str,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         wait_until: typing.Optional[
             Literal["commit", "domcontentloaded", "load", "networkidle"]
         ] = None,
@@ -4179,7 +4224,7 @@ class Frame(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.set_content(
-                html=html, timeout=timeout, waitUntil=wait_until
+                html=html, timeout=to_milliseconds(timeout), waitUntil=wait_until
             )
         )
 
@@ -4277,7 +4322,7 @@ class Frame(AsyncBase):
         delay: typing.Optional[float] = None,
         button: typing.Optional[Literal["left", "middle", "right"]] = None,
         click_count: typing.Optional[int] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
@@ -4342,7 +4387,7 @@ class Frame(AsyncBase):
                 delay=delay,
                 button=button,
                 clickCount=click_count,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 force=force,
                 noWaitAfter=no_wait_after,
                 strict=strict,
@@ -4360,7 +4405,7 @@ class Frame(AsyncBase):
         position: typing.Optional[Position] = None,
         delay: typing.Optional[float] = None,
         button: typing.Optional[Literal["left", "middle", "right"]] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
@@ -4422,7 +4467,7 @@ class Frame(AsyncBase):
                 position=position,
                 delay=delay,
                 button=button,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 force=force,
                 noWaitAfter=no_wait_after,
                 strict=strict,
@@ -4438,7 +4483,7 @@ class Frame(AsyncBase):
             typing.Sequence[Literal["Alt", "Control", "ControlOrMeta", "Meta", "Shift"]]
         ] = None,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
@@ -4493,7 +4538,7 @@ class Frame(AsyncBase):
                 selector=selector,
                 modifiers=mapping.to_impl(modifiers),
                 position=position,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 force=force,
                 noWaitAfter=no_wait_after,
                 strict=strict,
@@ -4506,7 +4551,7 @@ class Frame(AsyncBase):
         selector: str,
         value: str,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
         force: typing.Optional[bool] = None,
@@ -4548,7 +4593,7 @@ class Frame(AsyncBase):
             await self._impl_obj.fill(
                 selector=selector,
                 value=value,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 noWaitAfter=no_wait_after,
                 strict=strict,
                 force=force,
@@ -5110,7 +5155,7 @@ class Frame(AsyncBase):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """Frame.focus
 
@@ -5132,7 +5177,7 @@ class Frame(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.focus(
-                selector=selector, strict=strict, timeout=timeout
+                selector=selector, strict=strict, timeout=to_milliseconds(timeout)
             )
         )
 
@@ -5141,7 +5186,7 @@ class Frame(AsyncBase):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> typing.Optional[str]:
         """Frame.text_content
 
@@ -5166,7 +5211,7 @@ class Frame(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.text_content(
-                selector=selector, strict=strict, timeout=timeout
+                selector=selector, strict=strict, timeout=to_milliseconds(timeout)
             )
         )
 
@@ -5175,7 +5220,7 @@ class Frame(AsyncBase):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> str:
         """Frame.inner_text
 
@@ -5200,7 +5245,7 @@ class Frame(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.inner_text(
-                selector=selector, strict=strict, timeout=timeout
+                selector=selector, strict=strict, timeout=to_milliseconds(timeout)
             )
         )
 
@@ -5209,7 +5254,7 @@ class Frame(AsyncBase):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> str:
         """Frame.inner_html
 
@@ -5234,7 +5279,7 @@ class Frame(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.inner_html(
-                selector=selector, strict=strict, timeout=timeout
+                selector=selector, strict=strict, timeout=to_milliseconds(timeout)
             )
         )
 
@@ -5244,7 +5289,7 @@ class Frame(AsyncBase):
         name: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> typing.Optional[str]:
         """Frame.get_attribute
 
@@ -5271,7 +5316,10 @@ class Frame(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.get_attribute(
-                selector=selector, name=name, strict=strict, timeout=timeout
+                selector=selector,
+                name=name,
+                strict=strict,
+                timeout=to_milliseconds(timeout),
             )
         )
 
@@ -5283,7 +5331,7 @@ class Frame(AsyncBase):
             typing.Sequence[Literal["Alt", "Control", "ControlOrMeta", "Meta", "Shift"]]
         ] = None,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
         force: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
@@ -5336,7 +5384,7 @@ class Frame(AsyncBase):
                 selector=selector,
                 modifiers=mapping.to_impl(modifiers),
                 position=position,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 noWaitAfter=no_wait_after,
                 force=force,
                 strict=strict,
@@ -5354,7 +5402,7 @@ class Frame(AsyncBase):
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         trial: typing.Optional[bool] = None,
         steps: typing.Optional[int] = None,
     ) -> None:
@@ -5402,7 +5450,7 @@ class Frame(AsyncBase):
                 force=force,
                 noWaitAfter=no_wait_after,
                 strict=strict,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 trial=trial,
                 steps=steps,
             )
@@ -5418,7 +5466,7 @@ class Frame(AsyncBase):
         element: typing.Optional[
             typing.Union["ElementHandle", typing.Sequence["ElementHandle"]]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
         force: typing.Optional[bool] = None,
@@ -5486,7 +5534,7 @@ class Frame(AsyncBase):
                 index=mapping.to_impl(index),
                 label=mapping.to_impl(label),
                 element=mapping.to_impl(element),
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 noWaitAfter=no_wait_after,
                 strict=strict,
                 force=force,
@@ -5498,7 +5546,7 @@ class Frame(AsyncBase):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> str:
         """Frame.input_value
 
@@ -5527,7 +5575,7 @@ class Frame(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.input_value(
-                selector=selector, strict=strict, timeout=timeout
+                selector=selector, strict=strict, timeout=to_milliseconds(timeout)
             )
         )
 
@@ -5543,7 +5591,7 @@ class Frame(AsyncBase):
         ],
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
     ) -> None:
         """Frame.set_input_files
@@ -5578,7 +5626,7 @@ class Frame(AsyncBase):
                 selector=selector,
                 files=mapping.to_impl(files),
                 strict=strict,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 noWaitAfter=no_wait_after,
             )
         )
@@ -5590,7 +5638,7 @@ class Frame(AsyncBase):
         *,
         delay: typing.Optional[float] = None,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
     ) -> None:
         """Frame.type
@@ -5628,7 +5676,7 @@ class Frame(AsyncBase):
                 text=text,
                 delay=delay,
                 strict=strict,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 noWaitAfter=no_wait_after,
             )
         )
@@ -5640,7 +5688,7 @@ class Frame(AsyncBase):
         *,
         delay: typing.Optional[float] = None,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
     ) -> None:
         """Frame.press
@@ -5693,7 +5741,7 @@ class Frame(AsyncBase):
                 key=key,
                 delay=delay,
                 strict=strict,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 noWaitAfter=no_wait_after,
             )
         )
@@ -5703,7 +5751,7 @@ class Frame(AsyncBase):
         selector: str,
         *,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
@@ -5752,7 +5800,7 @@ class Frame(AsyncBase):
             await self._impl_obj.check(
                 selector=selector,
                 position=position,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 force=force,
                 noWaitAfter=no_wait_after,
                 strict=strict,
@@ -5765,7 +5813,7 @@ class Frame(AsyncBase):
         selector: str,
         *,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
@@ -5814,7 +5862,7 @@ class Frame(AsyncBase):
             await self._impl_obj.uncheck(
                 selector=selector,
                 position=position,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 force=force,
                 noWaitAfter=no_wait_after,
                 strict=strict,
@@ -5822,7 +5870,9 @@ class Frame(AsyncBase):
             )
         )
 
-    async def wait_for_timeout(self, timeout: float) -> None:
+    async def wait_for_timeout(
+        self, timeout: typing.Union[float, datetime.timedelta]
+    ) -> None:
         """Frame.wait_for_timeout
 
         Waits for the given `timeout` in milliseconds.
@@ -5837,7 +5887,7 @@ class Frame(AsyncBase):
         """
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.wait_for_timeout(timeout=timeout)
+            await self._impl_obj.wait_for_timeout(timeout=to_milliseconds(timeout))
         )
 
     async def wait_for_function(
@@ -5845,7 +5895,7 @@ class Frame(AsyncBase):
         expression: str,
         *,
         arg: typing.Optional[typing.Any] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         polling: typing.Optional[typing.Union[float, Literal["raf"]]] = None,
     ) -> "JSHandle":
         """Frame.wait_for_function
@@ -5906,7 +5956,7 @@ class Frame(AsyncBase):
             await self._impl_obj.wait_for_function(
                 expression=expression,
                 arg=mapping.to_impl(arg),
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 polling=polling,
             )
         )
@@ -5929,7 +5979,7 @@ class Frame(AsyncBase):
         checked: bool,
         *,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
@@ -5981,7 +6031,7 @@ class Frame(AsyncBase):
                 selector=selector,
                 checked=checked,
                 position=position,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 force=force,
                 noWaitAfter=no_wait_after,
                 strict=strict,
@@ -6742,7 +6792,7 @@ class Worker(AsyncBase):
         event: str,
         predicate: typing.Optional[typing.Callable] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> AsyncEventContextManager:
         """Worker.expect_event
 
@@ -6774,7 +6824,9 @@ class Worker(AsyncBase):
 
         return AsyncEventContextManager(
             self._impl_obj.expect_event(
-                event=event, predicate=self._wrap_handler(predicate), timeout=timeout
+                event=event,
+                predicate=self._wrap_handler(predicate),
+                timeout=to_milliseconds(timeout),
             ).future
         )
 
@@ -8406,7 +8458,9 @@ class Page(AsyncContextManager):
             self._impl_obj.frame(name=name, url=self._wrap_handler(url))
         )
 
-    def set_default_navigation_timeout(self, timeout: float) -> None:
+    def set_default_navigation_timeout(
+        self, timeout: typing.Union[float, datetime.timedelta]
+    ) -> None:
         """Page.set_default_navigation_timeout
 
         This setting will change the default maximum navigation time for the following methods and related shortcuts:
@@ -8428,10 +8482,14 @@ class Page(AsyncContextManager):
         """
 
         return mapping.from_maybe_impl(
-            self._impl_obj.set_default_navigation_timeout(timeout=timeout)
+            self._impl_obj.set_default_navigation_timeout(
+                timeout=to_milliseconds(timeout)
+            )
         )
 
-    def set_default_timeout(self, timeout: float) -> None:
+    def set_default_timeout(
+        self, timeout: typing.Union[float, datetime.timedelta]
+    ) -> None:
         """Page.set_default_timeout
 
         This setting will change the default maximum time for all the methods accepting `timeout` option.
@@ -8445,7 +8503,7 @@ class Page(AsyncContextManager):
         """
 
         return mapping.from_maybe_impl(
-            self._impl_obj.set_default_timeout(timeout=timeout)
+            self._impl_obj.set_default_timeout(timeout=to_milliseconds(timeout))
         )
 
     async def query_selector(
@@ -8497,7 +8555,7 @@ class Page(AsyncContextManager):
         self,
         selector: str,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         state: typing.Optional[
             Literal["attached", "detached", "hidden", "visible"]
         ] = None,
@@ -8565,7 +8623,10 @@ class Page(AsyncContextManager):
 
         return mapping.from_impl_nullable(
             await self._impl_obj.wait_for_selector(
-                selector=selector, timeout=timeout, state=state, strict=strict
+                selector=selector,
+                timeout=to_milliseconds(timeout),
+                state=state,
+                strict=strict,
             )
         )
 
@@ -8574,7 +8635,7 @@ class Page(AsyncContextManager):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> bool:
         """Page.is_checked
 
@@ -8599,7 +8660,7 @@ class Page(AsyncContextManager):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.is_checked(
-                selector=selector, strict=strict, timeout=timeout
+                selector=selector, strict=strict, timeout=to_milliseconds(timeout)
             )
         )
 
@@ -8608,7 +8669,7 @@ class Page(AsyncContextManager):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> bool:
         """Page.is_disabled
 
@@ -8633,7 +8694,7 @@ class Page(AsyncContextManager):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.is_disabled(
-                selector=selector, strict=strict, timeout=timeout
+                selector=selector, strict=strict, timeout=to_milliseconds(timeout)
             )
         )
 
@@ -8642,7 +8703,7 @@ class Page(AsyncContextManager):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> bool:
         """Page.is_editable
 
@@ -8667,7 +8728,7 @@ class Page(AsyncContextManager):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.is_editable(
-                selector=selector, strict=strict, timeout=timeout
+                selector=selector, strict=strict, timeout=to_milliseconds(timeout)
             )
         )
 
@@ -8676,7 +8737,7 @@ class Page(AsyncContextManager):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> bool:
         """Page.is_enabled
 
@@ -8701,7 +8762,7 @@ class Page(AsyncContextManager):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.is_enabled(
-                selector=selector, strict=strict, timeout=timeout
+                selector=selector, strict=strict, timeout=to_milliseconds(timeout)
             )
         )
 
@@ -8710,7 +8771,7 @@ class Page(AsyncContextManager):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> bool:
         """Page.is_hidden
 
@@ -8735,7 +8796,7 @@ class Page(AsyncContextManager):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.is_hidden(
-                selector=selector, strict=strict, timeout=timeout
+                selector=selector, strict=strict, timeout=to_milliseconds(timeout)
             )
         )
 
@@ -8744,7 +8805,7 @@ class Page(AsyncContextManager):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> bool:
         """Page.is_visible
 
@@ -8769,7 +8830,7 @@ class Page(AsyncContextManager):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.is_visible(
-                selector=selector, strict=strict, timeout=timeout
+                selector=selector, strict=strict, timeout=to_milliseconds(timeout)
             )
         )
 
@@ -8779,7 +8840,7 @@ class Page(AsyncContextManager):
         type: str,
         event_init: typing.Optional[typing.Dict] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         strict: typing.Optional[bool] = None,
     ) -> None:
         """Page.dispatch_event
@@ -8839,7 +8900,7 @@ class Page(AsyncContextManager):
                 selector=selector,
                 type=type,
                 eventInit=mapping.to_impl(event_init),
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 strict=strict,
             )
         )
@@ -9289,7 +9350,7 @@ class Page(AsyncContextManager):
         self,
         html: str,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         wait_until: typing.Optional[
             Literal["commit", "domcontentloaded", "load", "networkidle"]
         ] = None,
@@ -9320,7 +9381,7 @@ class Page(AsyncContextManager):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.set_content(
-                html=html, timeout=timeout, waitUntil=wait_until
+                html=html, timeout=to_milliseconds(timeout), waitUntil=wait_until
             )
         )
 
@@ -9328,7 +9389,7 @@ class Page(AsyncContextManager):
         self,
         url: str,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         wait_until: typing.Optional[
             Literal["commit", "domcontentloaded", "load", "networkidle"]
         ] = None,
@@ -9386,14 +9447,17 @@ class Page(AsyncContextManager):
 
         return mapping.from_impl_nullable(
             await self._impl_obj.goto(
-                url=url, timeout=timeout, waitUntil=wait_until, referer=referer
+                url=url,
+                timeout=to_milliseconds(timeout),
+                waitUntil=wait_until,
+                referer=referer,
             )
         )
 
     async def reload(
         self,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         wait_until: typing.Optional[
             Literal["commit", "domcontentloaded", "load", "networkidle"]
         ] = None,
@@ -9426,7 +9490,9 @@ class Page(AsyncContextManager):
         """
 
         return mapping.from_impl_nullable(
-            await self._impl_obj.reload(timeout=timeout, waitUntil=wait_until)
+            await self._impl_obj.reload(
+                timeout=to_milliseconds(timeout), waitUntil=wait_until
+            )
         )
 
     async def wait_for_load_state(
@@ -9435,7 +9501,7 @@ class Page(AsyncContextManager):
             Literal["domcontentloaded", "load", "networkidle"]
         ] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """Page.wait_for_load_state
 
@@ -9481,7 +9547,9 @@ class Page(AsyncContextManager):
         """
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.wait_for_load_state(state=state, timeout=timeout)
+            await self._impl_obj.wait_for_load_state(
+                state=state, timeout=to_milliseconds(timeout)
+            )
         )
 
     async def wait_for_url(
@@ -9491,7 +9559,7 @@ class Page(AsyncContextManager):
         wait_until: typing.Optional[
             Literal["commit", "domcontentloaded", "load", "networkidle"]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """Page.wait_for_url
 
@@ -9527,7 +9595,9 @@ class Page(AsyncContextManager):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.wait_for_url(
-                url=self._wrap_handler(url), waitUntil=wait_until, timeout=timeout
+                url=self._wrap_handler(url),
+                waitUntil=wait_until,
+                timeout=to_milliseconds(timeout),
             )
         )
 
@@ -9536,7 +9606,7 @@ class Page(AsyncContextManager):
         event: str,
         predicate: typing.Optional[typing.Callable] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> typing.Any:
         """Page.wait_for_event
 
@@ -9563,14 +9633,16 @@ class Page(AsyncContextManager):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.wait_for_event(
-                event=event, predicate=self._wrap_handler(predicate), timeout=timeout
+                event=event,
+                predicate=self._wrap_handler(predicate),
+                timeout=to_milliseconds(timeout),
             )
         )
 
     async def go_back(
         self,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         wait_until: typing.Optional[
             Literal["commit", "domcontentloaded", "load", "networkidle"]
         ] = None,
@@ -9604,13 +9676,15 @@ class Page(AsyncContextManager):
         """
 
         return mapping.from_impl_nullable(
-            await self._impl_obj.go_back(timeout=timeout, waitUntil=wait_until)
+            await self._impl_obj.go_back(
+                timeout=to_milliseconds(timeout), waitUntil=wait_until
+            )
         )
 
     async def go_forward(
         self,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         wait_until: typing.Optional[
             Literal["commit", "domcontentloaded", "load", "networkidle"]
         ] = None,
@@ -9644,7 +9718,9 @@ class Page(AsyncContextManager):
         """
 
         return mapping.from_impl_nullable(
-            await self._impl_obj.go_forward(timeout=timeout, waitUntil=wait_until)
+            await self._impl_obj.go_forward(
+                timeout=to_milliseconds(timeout), waitUntil=wait_until
+            )
         )
 
     async def request_gc(self) -> None:
@@ -10068,7 +10144,7 @@ class Page(AsyncContextManager):
     async def screenshot(
         self,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         type: typing.Optional[Literal["jpeg", "png"]] = None,
         path: typing.Optional[typing.Union[pathlib.Path, str]] = None,
         quality: typing.Optional[int] = None,
@@ -10143,7 +10219,7 @@ class Page(AsyncContextManager):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.screenshot(
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 type=type,
                 path=path,
                 quality=quality,
@@ -10174,7 +10250,7 @@ class Page(AsyncContextManager):
     async def aria_snapshot(
         self,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         depth: typing.Optional[int] = None,
         mode: typing.Optional[Literal["ai", "default"]] = None,
     ) -> str:
@@ -10199,7 +10275,9 @@ class Page(AsyncContextManager):
         """
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.aria_snapshot(timeout=timeout, depth=depth, mode=mode)
+            await self._impl_obj.aria_snapshot(
+                timeout=to_milliseconds(timeout), depth=depth, mode=mode
+            )
         )
 
     async def close(
@@ -10254,7 +10332,7 @@ class Page(AsyncContextManager):
         delay: typing.Optional[float] = None,
         button: typing.Optional[Literal["left", "middle", "right"]] = None,
         click_count: typing.Optional[int] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
@@ -10319,7 +10397,7 @@ class Page(AsyncContextManager):
                 delay=delay,
                 button=button,
                 clickCount=click_count,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 force=force,
                 noWaitAfter=no_wait_after,
                 trial=trial,
@@ -10337,7 +10415,7 @@ class Page(AsyncContextManager):
         position: typing.Optional[Position] = None,
         delay: typing.Optional[float] = None,
         button: typing.Optional[Literal["left", "middle", "right"]] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
@@ -10398,7 +10476,7 @@ class Page(AsyncContextManager):
                 position=position,
                 delay=delay,
                 button=button,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 force=force,
                 noWaitAfter=no_wait_after,
                 strict=strict,
@@ -10414,7 +10492,7 @@ class Page(AsyncContextManager):
             typing.Sequence[Literal["Alt", "Control", "ControlOrMeta", "Meta", "Shift"]]
         ] = None,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
@@ -10469,7 +10547,7 @@ class Page(AsyncContextManager):
                 selector=selector,
                 modifiers=mapping.to_impl(modifiers),
                 position=position,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 force=force,
                 noWaitAfter=no_wait_after,
                 strict=strict,
@@ -10482,7 +10560,7 @@ class Page(AsyncContextManager):
         selector: str,
         value: str,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
         force: typing.Optional[bool] = None,
@@ -10524,7 +10602,7 @@ class Page(AsyncContextManager):
             await self._impl_obj.fill(
                 selector=selector,
                 value=value,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 noWaitAfter=no_wait_after,
                 strict=strict,
                 force=force,
@@ -11084,7 +11162,7 @@ class Page(AsyncContextManager):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """Page.focus
 
@@ -11106,7 +11184,7 @@ class Page(AsyncContextManager):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.focus(
-                selector=selector, strict=strict, timeout=timeout
+                selector=selector, strict=strict, timeout=to_milliseconds(timeout)
             )
         )
 
@@ -11115,7 +11193,7 @@ class Page(AsyncContextManager):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> typing.Optional[str]:
         """Page.text_content
 
@@ -11140,7 +11218,7 @@ class Page(AsyncContextManager):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.text_content(
-                selector=selector, strict=strict, timeout=timeout
+                selector=selector, strict=strict, timeout=to_milliseconds(timeout)
             )
         )
 
@@ -11149,7 +11227,7 @@ class Page(AsyncContextManager):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> str:
         """Page.inner_text
 
@@ -11174,7 +11252,7 @@ class Page(AsyncContextManager):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.inner_text(
-                selector=selector, strict=strict, timeout=timeout
+                selector=selector, strict=strict, timeout=to_milliseconds(timeout)
             )
         )
 
@@ -11183,7 +11261,7 @@ class Page(AsyncContextManager):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> str:
         """Page.inner_html
 
@@ -11208,7 +11286,7 @@ class Page(AsyncContextManager):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.inner_html(
-                selector=selector, strict=strict, timeout=timeout
+                selector=selector, strict=strict, timeout=to_milliseconds(timeout)
             )
         )
 
@@ -11218,7 +11296,7 @@ class Page(AsyncContextManager):
         name: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> typing.Optional[str]:
         """Page.get_attribute
 
@@ -11245,7 +11323,10 @@ class Page(AsyncContextManager):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.get_attribute(
-                selector=selector, name=name, strict=strict, timeout=timeout
+                selector=selector,
+                name=name,
+                strict=strict,
+                timeout=to_milliseconds(timeout),
             )
         )
 
@@ -11257,7 +11338,7 @@ class Page(AsyncContextManager):
             typing.Sequence[Literal["Alt", "Control", "ControlOrMeta", "Meta", "Shift"]]
         ] = None,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
         force: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
@@ -11310,7 +11391,7 @@ class Page(AsyncContextManager):
                 selector=selector,
                 modifiers=mapping.to_impl(modifiers),
                 position=position,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 noWaitAfter=no_wait_after,
                 force=force,
                 strict=strict,
@@ -11327,7 +11408,7 @@ class Page(AsyncContextManager):
         target_position: typing.Optional[Position] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         strict: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
         steps: typing.Optional[int] = None,
@@ -11391,7 +11472,7 @@ class Page(AsyncContextManager):
                 targetPosition=target_position,
                 force=force,
                 noWaitAfter=no_wait_after,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 strict=strict,
                 trial=trial,
                 steps=steps,
@@ -11408,7 +11489,7 @@ class Page(AsyncContextManager):
         element: typing.Optional[
             typing.Union["ElementHandle", typing.Sequence["ElementHandle"]]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
         force: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
@@ -11477,7 +11558,7 @@ class Page(AsyncContextManager):
                 index=mapping.to_impl(index),
                 label=mapping.to_impl(label),
                 element=mapping.to_impl(element),
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 noWaitAfter=no_wait_after,
                 force=force,
                 strict=strict,
@@ -11489,7 +11570,7 @@ class Page(AsyncContextManager):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> str:
         """Page.input_value
 
@@ -11518,7 +11599,7 @@ class Page(AsyncContextManager):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.input_value(
-                selector=selector, strict=strict, timeout=timeout
+                selector=selector, strict=strict, timeout=to_milliseconds(timeout)
             )
         )
 
@@ -11533,7 +11614,7 @@ class Page(AsyncContextManager):
             typing.Sequence[FilePayload],
         ],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         strict: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
     ) -> None:
@@ -11569,7 +11650,7 @@ class Page(AsyncContextManager):
             await self._impl_obj.set_input_files(
                 selector=selector,
                 files=mapping.to_impl(files),
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 strict=strict,
                 noWaitAfter=no_wait_after,
             )
@@ -11581,7 +11662,7 @@ class Page(AsyncContextManager):
         text: str,
         *,
         delay: typing.Optional[float] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
     ) -> None:
@@ -11619,7 +11700,7 @@ class Page(AsyncContextManager):
                 selector=selector,
                 text=text,
                 delay=delay,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 noWaitAfter=no_wait_after,
                 strict=strict,
             )
@@ -11631,7 +11712,7 @@ class Page(AsyncContextManager):
         key: str,
         *,
         delay: typing.Optional[float] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
     ) -> None:
@@ -11700,7 +11781,7 @@ class Page(AsyncContextManager):
                 selector=selector,
                 key=key,
                 delay=delay,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 noWaitAfter=no_wait_after,
                 strict=strict,
             )
@@ -11711,7 +11792,7 @@ class Page(AsyncContextManager):
         selector: str,
         *,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
@@ -11760,7 +11841,7 @@ class Page(AsyncContextManager):
             await self._impl_obj.check(
                 selector=selector,
                 position=position,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 force=force,
                 noWaitAfter=no_wait_after,
                 strict=strict,
@@ -11773,7 +11854,7 @@ class Page(AsyncContextManager):
         selector: str,
         *,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
@@ -11822,7 +11903,7 @@ class Page(AsyncContextManager):
             await self._impl_obj.uncheck(
                 selector=selector,
                 position=position,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 force=force,
                 noWaitAfter=no_wait_after,
                 strict=strict,
@@ -11830,7 +11911,9 @@ class Page(AsyncContextManager):
             )
         )
 
-    async def wait_for_timeout(self, timeout: float) -> None:
+    async def wait_for_timeout(
+        self, timeout: typing.Union[float, datetime.timedelta]
+    ) -> None:
         """Page.wait_for_timeout
 
         Waits for the given `timeout` in milliseconds.
@@ -11852,7 +11935,7 @@ class Page(AsyncContextManager):
         """
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.wait_for_timeout(timeout=timeout)
+            await self._impl_obj.wait_for_timeout(timeout=to_milliseconds(timeout))
         )
 
     async def wait_for_function(
@@ -11860,7 +11943,7 @@ class Page(AsyncContextManager):
         expression: str,
         *,
         arg: typing.Optional[typing.Any] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         polling: typing.Optional[typing.Union[float, Literal["raf"]]] = None,
     ) -> "JSHandle":
         """Page.wait_for_function
@@ -11921,7 +12004,7 @@ class Page(AsyncContextManager):
             await self._impl_obj.wait_for_function(
                 expression=expression,
                 arg=mapping.to_impl(arg),
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 polling=polling,
             )
         )
@@ -12079,7 +12162,7 @@ class Page(AsyncContextManager):
         event: str,
         predicate: typing.Optional[typing.Callable] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> AsyncEventContextManager:
         """Page.expect_event
 
@@ -12111,7 +12194,9 @@ class Page(AsyncContextManager):
 
         return AsyncEventContextManager(
             self._impl_obj.expect_event(
-                event=event, predicate=self._wrap_handler(predicate), timeout=timeout
+                event=event,
+                predicate=self._wrap_handler(predicate),
+                timeout=to_milliseconds(timeout),
             ).future
         )
 
@@ -12119,7 +12204,7 @@ class Page(AsyncContextManager):
         self,
         predicate: typing.Optional[typing.Callable[["ConsoleMessage"], bool]] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> AsyncEventContextManager["ConsoleMessage"]:
         """Page.expect_console_message
 
@@ -12142,7 +12227,8 @@ class Page(AsyncContextManager):
 
         return AsyncEventContextManager(
             self._impl_obj.expect_console_message(
-                predicate=self._wrap_handler(predicate), timeout=timeout
+                predicate=self._wrap_handler(predicate),
+                timeout=to_milliseconds(timeout),
             ).future
         )
 
@@ -12150,7 +12236,7 @@ class Page(AsyncContextManager):
         self,
         predicate: typing.Optional[typing.Callable[["Download"], bool]] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> AsyncEventContextManager["Download"]:
         """Page.expect_download
 
@@ -12173,7 +12259,8 @@ class Page(AsyncContextManager):
 
         return AsyncEventContextManager(
             self._impl_obj.expect_download(
-                predicate=self._wrap_handler(predicate), timeout=timeout
+                predicate=self._wrap_handler(predicate),
+                timeout=to_milliseconds(timeout),
             ).future
         )
 
@@ -12181,7 +12268,7 @@ class Page(AsyncContextManager):
         self,
         predicate: typing.Optional[typing.Callable[["FileChooser"], bool]] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> AsyncEventContextManager["FileChooser"]:
         """Page.expect_file_chooser
 
@@ -12204,7 +12291,8 @@ class Page(AsyncContextManager):
 
         return AsyncEventContextManager(
             self._impl_obj.expect_file_chooser(
-                predicate=self._wrap_handler(predicate), timeout=timeout
+                predicate=self._wrap_handler(predicate),
+                timeout=to_milliseconds(timeout),
             ).future
         )
 
@@ -12217,7 +12305,7 @@ class Page(AsyncContextManager):
         wait_until: typing.Optional[
             Literal["commit", "domcontentloaded", "load", "networkidle"]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> AsyncEventContextManager["Response"]:
         """Page.expect_navigation
 
@@ -12268,7 +12356,9 @@ class Page(AsyncContextManager):
 
         return AsyncEventContextManager(
             self._impl_obj.expect_navigation(
-                url=self._wrap_handler(url), waitUntil=wait_until, timeout=timeout
+                url=self._wrap_handler(url),
+                waitUntil=wait_until,
+                timeout=to_milliseconds(timeout),
             ).future
         )
 
@@ -12276,7 +12366,7 @@ class Page(AsyncContextManager):
         self,
         predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> AsyncEventContextManager["Page"]:
         """Page.expect_popup
 
@@ -12299,7 +12389,8 @@ class Page(AsyncContextManager):
 
         return AsyncEventContextManager(
             self._impl_obj.expect_popup(
-                predicate=self._wrap_handler(predicate), timeout=timeout
+                predicate=self._wrap_handler(predicate),
+                timeout=to_milliseconds(timeout),
             ).future
         )
 
@@ -12311,7 +12402,7 @@ class Page(AsyncContextManager):
             typing.Callable[["Request"], typing.Union[bool, typing.Awaitable[bool]]],
         ],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> AsyncEventContextManager["Request"]:
         """Page.expect_request
 
@@ -12348,7 +12439,8 @@ class Page(AsyncContextManager):
 
         return AsyncEventContextManager(
             self._impl_obj.expect_request(
-                urlOrPredicate=self._wrap_handler(url_or_predicate), timeout=timeout
+                urlOrPredicate=self._wrap_handler(url_or_predicate),
+                timeout=to_milliseconds(timeout),
             ).future
         )
 
@@ -12356,7 +12448,7 @@ class Page(AsyncContextManager):
         self,
         predicate: typing.Optional[typing.Callable[["Request"], bool]] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> AsyncEventContextManager["Request"]:
         """Page.expect_request_finished
 
@@ -12379,7 +12471,8 @@ class Page(AsyncContextManager):
 
         return AsyncEventContextManager(
             self._impl_obj.expect_request_finished(
-                predicate=self._wrap_handler(predicate), timeout=timeout
+                predicate=self._wrap_handler(predicate),
+                timeout=to_milliseconds(timeout),
             ).future
         )
 
@@ -12391,7 +12484,7 @@ class Page(AsyncContextManager):
             typing.Callable[["Response"], typing.Union[bool, typing.Awaitable[bool]]],
         ],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> AsyncEventContextManager["Response"]:
         """Page.expect_response
 
@@ -12430,7 +12523,8 @@ class Page(AsyncContextManager):
 
         return AsyncEventContextManager(
             self._impl_obj.expect_response(
-                urlOrPredicate=self._wrap_handler(url_or_predicate), timeout=timeout
+                urlOrPredicate=self._wrap_handler(url_or_predicate),
+                timeout=to_milliseconds(timeout),
             ).future
         )
 
@@ -12438,7 +12532,7 @@ class Page(AsyncContextManager):
         self,
         predicate: typing.Optional[typing.Callable[["WebSocket"], bool]] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> AsyncEventContextManager["WebSocket"]:
         """Page.expect_websocket
 
@@ -12461,7 +12555,8 @@ class Page(AsyncContextManager):
 
         return AsyncEventContextManager(
             self._impl_obj.expect_websocket(
-                predicate=self._wrap_handler(predicate), timeout=timeout
+                predicate=self._wrap_handler(predicate),
+                timeout=to_milliseconds(timeout),
             ).future
         )
 
@@ -12469,7 +12564,7 @@ class Page(AsyncContextManager):
         self,
         predicate: typing.Optional[typing.Callable[["Worker"], bool]] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> AsyncEventContextManager["Worker"]:
         """Page.expect_worker
 
@@ -12492,7 +12587,8 @@ class Page(AsyncContextManager):
 
         return AsyncEventContextManager(
             self._impl_obj.expect_worker(
-                predicate=self._wrap_handler(predicate), timeout=timeout
+                predicate=self._wrap_handler(predicate),
+                timeout=to_milliseconds(timeout),
             ).future
         )
 
@@ -12502,7 +12598,7 @@ class Page(AsyncContextManager):
         checked: bool,
         *,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
@@ -12554,7 +12650,7 @@ class Page(AsyncContextManager):
                 selector=selector,
                 checked=checked,
                 position=position,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 force=force,
                 noWaitAfter=no_wait_after,
                 strict=strict,
@@ -13287,7 +13383,9 @@ class BrowserContext(AsyncContextManager):
         """
         return mapping.from_impl(self._impl_obj.clock)
 
-    def set_default_navigation_timeout(self, timeout: float) -> None:
+    def set_default_navigation_timeout(
+        self, timeout: typing.Union[float, datetime.timedelta]
+    ) -> None:
         """BrowserContext.set_default_navigation_timeout
 
         This setting will change the default maximum navigation time for the following methods and related shortcuts:
@@ -13308,10 +13406,14 @@ class BrowserContext(AsyncContextManager):
         """
 
         return mapping.from_maybe_impl(
-            self._impl_obj.set_default_navigation_timeout(timeout=timeout)
+            self._impl_obj.set_default_navigation_timeout(
+                timeout=to_milliseconds(timeout)
+            )
         )
 
-    def set_default_timeout(self, timeout: float) -> None:
+    def set_default_timeout(
+        self, timeout: typing.Union[float, datetime.timedelta]
+    ) -> None:
         """BrowserContext.set_default_timeout
 
         This setting will change the default maximum time for all the methods accepting `timeout` option.
@@ -13327,7 +13429,7 @@ class BrowserContext(AsyncContextManager):
         """
 
         return mapping.from_maybe_impl(
-            self._impl_obj.set_default_timeout(timeout=timeout)
+            self._impl_obj.set_default_timeout(timeout=to_milliseconds(timeout))
         )
 
     async def new_page(self) -> "Page":
@@ -13969,7 +14071,7 @@ class BrowserContext(AsyncContextManager):
         event: str,
         predicate: typing.Optional[typing.Callable] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> AsyncEventContextManager:
         """BrowserContext.expect_event
 
@@ -14001,7 +14103,9 @@ class BrowserContext(AsyncContextManager):
 
         return AsyncEventContextManager(
             self._impl_obj.expect_event(
-                event=event, predicate=self._wrap_handler(predicate), timeout=timeout
+                event=event,
+                predicate=self._wrap_handler(predicate),
+                timeout=to_milliseconds(timeout),
             ).future
         )
 
@@ -14094,7 +14198,7 @@ class BrowserContext(AsyncContextManager):
         event: str,
         predicate: typing.Optional[typing.Callable] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> typing.Any:
         """BrowserContext.wait_for_event
 
@@ -14121,7 +14225,9 @@ class BrowserContext(AsyncContextManager):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.wait_for_event(
-                event=event, predicate=self._wrap_handler(predicate), timeout=timeout
+                event=event,
+                predicate=self._wrap_handler(predicate),
+                timeout=to_milliseconds(timeout),
             )
         )
 
@@ -14129,7 +14235,7 @@ class BrowserContext(AsyncContextManager):
         self,
         predicate: typing.Optional[typing.Callable[["ConsoleMessage"], bool]] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> AsyncEventContextManager["ConsoleMessage"]:
         """BrowserContext.expect_console_message
 
@@ -14153,7 +14259,8 @@ class BrowserContext(AsyncContextManager):
 
         return AsyncEventContextManager(
             self._impl_obj.expect_console_message(
-                predicate=self._wrap_handler(predicate), timeout=timeout
+                predicate=self._wrap_handler(predicate),
+                timeout=to_milliseconds(timeout),
             ).future
         )
 
@@ -14161,7 +14268,7 @@ class BrowserContext(AsyncContextManager):
         self,
         predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> AsyncEventContextManager["Page"]:
         """BrowserContext.expect_page
 
@@ -14184,7 +14291,8 @@ class BrowserContext(AsyncContextManager):
 
         return AsyncEventContextManager(
             self._impl_obj.expect_page(
-                predicate=self._wrap_handler(predicate), timeout=timeout
+                predicate=self._wrap_handler(predicate),
+                timeout=to_milliseconds(timeout),
             ).future
         )
 
@@ -15085,7 +15193,7 @@ class BrowserType(AsyncBase):
         handle_sigint: typing.Optional[bool] = None,
         handle_sigterm: typing.Optional[bool] = None,
         handle_sighup: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         env: typing.Optional[typing.Dict[str, typing.Union[str, float, bool]]] = None,
         headless: typing.Optional[bool] = None,
         proxy: typing.Optional[ProxySettings] = None,
@@ -15201,7 +15309,7 @@ class BrowserType(AsyncBase):
                 handleSIGINT=handle_sigint,
                 handleSIGTERM=handle_sigterm,
                 handleSIGHUP=handle_sighup,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 env=mapping.to_impl(env),
                 headless=headless,
                 proxy=proxy,
@@ -15227,7 +15335,7 @@ class BrowserType(AsyncBase):
         handle_sigint: typing.Optional[bool] = None,
         handle_sigterm: typing.Optional[bool] = None,
         handle_sighup: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         env: typing.Optional[typing.Dict[str, typing.Union[str, float, bool]]] = None,
         headless: typing.Optional[bool] = None,
         proxy: typing.Optional[ProxySettings] = None,
@@ -15501,7 +15609,7 @@ class BrowserType(AsyncBase):
                 handleSIGINT=handle_sigint,
                 handleSIGTERM=handle_sigterm,
                 handleSIGHUP=handle_sighup,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 env=mapping.to_impl(env),
                 headless=headless,
                 proxy=proxy,
@@ -15551,7 +15659,7 @@ class BrowserType(AsyncBase):
         self,
         endpoint_url: str,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         slow_mo: typing.Optional[float] = None,
         headers: typing.Optional[typing.Dict[str, str]] = None,
         is_local: typing.Optional[bool] = None,
@@ -15601,7 +15709,7 @@ class BrowserType(AsyncBase):
         return mapping.from_impl(
             await self._impl_obj.connect_over_cdp(
                 endpointURL=endpoint_url,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 slowMo=slow_mo,
                 headers=mapping.to_impl(headers),
                 isLocal=is_local,
@@ -15612,7 +15720,7 @@ class BrowserType(AsyncBase):
         self,
         endpoint: str,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         slow_mo: typing.Optional[float] = None,
         headers: typing.Optional[typing.Dict[str, str]] = None,
         expose_network: typing.Optional[str] = None,
@@ -15658,7 +15766,7 @@ class BrowserType(AsyncBase):
         return mapping.from_impl(
             await self._impl_obj.connect(
                 endpoint=endpoint,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 slowMo=slow_mo,
                 headers=mapping.to_impl(headers),
                 exposeNetwork=expose_network,
@@ -16077,7 +16185,9 @@ class Locator(AsyncBase):
         return mapping.from_maybe_impl(self._impl_obj.description)
 
     async def bounding_box(
-        self, *, timeout: typing.Optional[float] = None
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> typing.Optional[FloatRect]:
         """Locator.bounding_box
 
@@ -16116,14 +16226,14 @@ class Locator(AsyncBase):
         """
 
         return mapping.from_impl_nullable(
-            await self._impl_obj.bounding_box(timeout=timeout)
+            await self._impl_obj.bounding_box(timeout=to_milliseconds(timeout))
         )
 
     async def check(
         self,
         *,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
@@ -16174,7 +16284,7 @@ class Locator(AsyncBase):
         return mapping.from_maybe_impl(
             await self._impl_obj.check(
                 position=position,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 force=force,
                 noWaitAfter=no_wait_after,
                 trial=trial,
@@ -16191,7 +16301,7 @@ class Locator(AsyncBase):
         delay: typing.Optional[float] = None,
         button: typing.Optional[Literal["left", "middle", "right"]] = None,
         click_count: typing.Optional[int] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
@@ -16272,7 +16382,7 @@ class Locator(AsyncBase):
                 delay=delay,
                 button=button,
                 clickCount=click_count,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 force=force,
                 noWaitAfter=no_wait_after,
                 trial=trial,
@@ -16289,7 +16399,7 @@ class Locator(AsyncBase):
         position: typing.Optional[Position] = None,
         delay: typing.Optional[float] = None,
         button: typing.Optional[Literal["left", "middle", "right"]] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
@@ -16350,7 +16460,7 @@ class Locator(AsyncBase):
                 position=position,
                 delay=delay,
                 button=button,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 force=force,
                 noWaitAfter=no_wait_after,
                 trial=trial,
@@ -16363,7 +16473,7 @@ class Locator(AsyncBase):
         type: str,
         event_init: typing.Optional[typing.Dict] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """Locator.dispatch_event
 
@@ -16416,7 +16526,9 @@ class Locator(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.dispatch_event(
-                type=type, eventInit=mapping.to_impl(event_init), timeout=timeout
+                type=type,
+                eventInit=mapping.to_impl(event_init),
+                timeout=to_milliseconds(timeout),
             )
         )
 
@@ -16425,7 +16537,7 @@ class Locator(AsyncBase):
         expression: str,
         arg: typing.Optional[typing.Any] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> typing.Any:
         """Locator.evaluate
 
@@ -16467,7 +16579,9 @@ class Locator(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.evaluate(
-                expression=expression, arg=mapping.to_impl(arg), timeout=timeout
+                expression=expression,
+                arg=mapping.to_impl(arg),
+                timeout=to_milliseconds(timeout),
             )
         )
 
@@ -16518,7 +16632,7 @@ class Locator(AsyncBase):
         expression: str,
         arg: typing.Optional[typing.Any] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> "JSHandle":
         """Locator.evaluate_handle
 
@@ -16557,7 +16671,9 @@ class Locator(AsyncBase):
 
         return mapping.from_impl(
             await self._impl_obj.evaluate_handle(
-                expression=expression, arg=mapping.to_impl(arg), timeout=timeout
+                expression=expression,
+                arg=mapping.to_impl(arg),
+                timeout=to_milliseconds(timeout),
             )
         )
 
@@ -16565,7 +16681,7 @@ class Locator(AsyncBase):
         self,
         value: str,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
         force: typing.Optional[bool] = None,
     ) -> None:
@@ -16607,14 +16723,17 @@ class Locator(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.fill(
-                value=value, timeout=timeout, noWaitAfter=no_wait_after, force=force
+                value=value,
+                timeout=to_milliseconds(timeout),
+                noWaitAfter=no_wait_after,
+                force=force,
             )
         )
 
     async def clear(
         self,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
         force: typing.Optional[bool] = None,
     ) -> None:
@@ -16652,7 +16771,7 @@ class Locator(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.clear(
-                timeout=timeout, noWaitAfter=no_wait_after, force=force
+                timeout=to_milliseconds(timeout), noWaitAfter=no_wait_after, force=force
             )
         )
 
@@ -17201,7 +17320,9 @@ class Locator(AsyncBase):
         return mapping.from_impl(self._impl_obj.frame_locator(selector=selector))
 
     async def element_handle(
-        self, *, timeout: typing.Optional[float] = None
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> "ElementHandle":
         """Locator.element_handle
 
@@ -17219,7 +17340,9 @@ class Locator(AsyncBase):
         ElementHandle
         """
 
-        return mapping.from_impl(await self._impl_obj.element_handle(timeout=timeout))
+        return mapping.from_impl(
+            await self._impl_obj.element_handle(timeout=to_milliseconds(timeout))
+        )
 
     async def element_handles(self) -> typing.List["ElementHandle"]:
         """Locator.element_handles
@@ -17410,7 +17533,11 @@ class Locator(AsyncBase):
 
         return mapping.from_impl(self._impl_obj.and_(locator=locator._impl_obj))
 
-    async def focus(self, *, timeout: typing.Optional[float] = None) -> None:
+    async def focus(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> None:
         """Locator.focus
 
         Calls [focus](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus) on the matching element.
@@ -17422,9 +17549,15 @@ class Locator(AsyncBase):
             be changed by using the `browser_context.set_default_timeout()` or `page.set_default_timeout()` methods.
         """
 
-        return mapping.from_maybe_impl(await self._impl_obj.focus(timeout=timeout))
+        return mapping.from_maybe_impl(
+            await self._impl_obj.focus(timeout=to_milliseconds(timeout))
+        )
 
-    async def blur(self, *, timeout: typing.Optional[float] = None) -> None:
+    async def blur(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> None:
         """Locator.blur
 
         Calls [blur](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/blur) on the element.
@@ -17436,7 +17569,9 @@ class Locator(AsyncBase):
             be changed by using the `browser_context.set_default_timeout()` or `page.set_default_timeout()` methods.
         """
 
-        return mapping.from_maybe_impl(await self._impl_obj.blur(timeout=timeout))
+        return mapping.from_maybe_impl(
+            await self._impl_obj.blur(timeout=to_milliseconds(timeout))
+        )
 
     async def all(self) -> typing.List["Locator"]:
         """Locator.all
@@ -17494,7 +17629,7 @@ class Locator(AsyncBase):
         *,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         trial: typing.Optional[bool] = None,
         source_position: typing.Optional[Position] = None,
         target_position: typing.Optional[Position] = None,
@@ -17555,7 +17690,7 @@ class Locator(AsyncBase):
                 target=target._impl_obj,
                 force=force,
                 noWaitAfter=no_wait_after,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 trial=trial,
                 sourcePosition=source_position,
                 targetPosition=target_position,
@@ -17564,7 +17699,10 @@ class Locator(AsyncBase):
         )
 
     async def get_attribute(
-        self, name: str, *, timeout: typing.Optional[float] = None
+        self,
+        name: str,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> typing.Optional[str]:
         """Locator.get_attribute
 
@@ -17587,7 +17725,9 @@ class Locator(AsyncBase):
         """
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.get_attribute(name=name, timeout=timeout)
+            await self._impl_obj.get_attribute(
+                name=name, timeout=to_milliseconds(timeout)
+            )
         )
 
     async def hover(
@@ -17597,7 +17737,7 @@ class Locator(AsyncBase):
             typing.Sequence[Literal["Alt", "Control", "ControlOrMeta", "Meta", "Shift"]]
         ] = None,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
         force: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
@@ -17652,14 +17792,18 @@ class Locator(AsyncBase):
             await self._impl_obj.hover(
                 modifiers=mapping.to_impl(modifiers),
                 position=position,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 noWaitAfter=no_wait_after,
                 force=force,
                 trial=trial,
             )
         )
 
-    async def inner_html(self, *, timeout: typing.Optional[float] = None) -> str:
+    async def inner_html(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> str:
         """Locator.inner_html
 
         Returns the [`element.innerHTML`](https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML).
@@ -17675,9 +17819,15 @@ class Locator(AsyncBase):
         str
         """
 
-        return mapping.from_maybe_impl(await self._impl_obj.inner_html(timeout=timeout))
+        return mapping.from_maybe_impl(
+            await self._impl_obj.inner_html(timeout=to_milliseconds(timeout))
+        )
 
-    async def inner_text(self, *, timeout: typing.Optional[float] = None) -> str:
+    async def inner_text(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> str:
         """Locator.inner_text
 
         Returns the [`element.innerText`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/innerText).
@@ -17696,9 +17846,15 @@ class Locator(AsyncBase):
         str
         """
 
-        return mapping.from_maybe_impl(await self._impl_obj.inner_text(timeout=timeout))
+        return mapping.from_maybe_impl(
+            await self._impl_obj.inner_text(timeout=to_milliseconds(timeout))
+        )
 
-    async def input_value(self, *, timeout: typing.Optional[float] = None) -> str:
+    async def input_value(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> str:
         """Locator.input_value
 
         Returns the value for the matching `<input>` or `<textarea>` or `<select>` element.
@@ -17731,10 +17887,14 @@ class Locator(AsyncBase):
         """
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.input_value(timeout=timeout)
+            await self._impl_obj.input_value(timeout=to_milliseconds(timeout))
         )
 
-    async def is_checked(self, *, timeout: typing.Optional[float] = None) -> bool:
+    async def is_checked(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> bool:
         """Locator.is_checked
 
         Returns whether the element is checked. Throws if the element is not a checkbox or radio input.
@@ -17759,9 +17919,15 @@ class Locator(AsyncBase):
         bool
         """
 
-        return mapping.from_maybe_impl(await self._impl_obj.is_checked(timeout=timeout))
+        return mapping.from_maybe_impl(
+            await self._impl_obj.is_checked(timeout=to_milliseconds(timeout))
+        )
 
-    async def is_disabled(self, *, timeout: typing.Optional[float] = None) -> bool:
+    async def is_disabled(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> bool:
         """Locator.is_disabled
 
         Returns whether the element is disabled, the opposite of [enabled](https://playwright.dev/python/docs/actionability#enabled).
@@ -17787,10 +17953,14 @@ class Locator(AsyncBase):
         """
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.is_disabled(timeout=timeout)
+            await self._impl_obj.is_disabled(timeout=to_milliseconds(timeout))
         )
 
-    async def is_editable(self, *, timeout: typing.Optional[float] = None) -> bool:
+    async def is_editable(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> bool:
         """Locator.is_editable
 
         Returns whether the element is [editable](https://playwright.dev/python/docs/actionability#editable). If the target element is not an `<input>`,
@@ -17818,10 +17988,14 @@ class Locator(AsyncBase):
         """
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.is_editable(timeout=timeout)
+            await self._impl_obj.is_editable(timeout=to_milliseconds(timeout))
         )
 
-    async def is_enabled(self, *, timeout: typing.Optional[float] = None) -> bool:
+    async def is_enabled(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> bool:
         """Locator.is_enabled
 
         Returns whether the element is [enabled](https://playwright.dev/python/docs/actionability#enabled).
@@ -17846,9 +18020,15 @@ class Locator(AsyncBase):
         bool
         """
 
-        return mapping.from_maybe_impl(await self._impl_obj.is_enabled(timeout=timeout))
+        return mapping.from_maybe_impl(
+            await self._impl_obj.is_enabled(timeout=to_milliseconds(timeout))
+        )
 
-    async def is_hidden(self, *, timeout: typing.Optional[float] = None) -> bool:
+    async def is_hidden(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> bool:
         """Locator.is_hidden
 
         Returns whether the element is hidden, the opposite of [visible](https://playwright.dev/python/docs/actionability#visible).
@@ -17872,9 +18052,15 @@ class Locator(AsyncBase):
         bool
         """
 
-        return mapping.from_maybe_impl(await self._impl_obj.is_hidden(timeout=timeout))
+        return mapping.from_maybe_impl(
+            await self._impl_obj.is_hidden(timeout=to_milliseconds(timeout))
+        )
 
-    async def is_visible(self, *, timeout: typing.Optional[float] = None) -> bool:
+    async def is_visible(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> bool:
         """Locator.is_visible
 
         Returns whether the element is [visible](https://playwright.dev/python/docs/actionability#visible).
@@ -17898,14 +18084,16 @@ class Locator(AsyncBase):
         bool
         """
 
-        return mapping.from_maybe_impl(await self._impl_obj.is_visible(timeout=timeout))
+        return mapping.from_maybe_impl(
+            await self._impl_obj.is_visible(timeout=to_milliseconds(timeout))
+        )
 
     async def press(
         self,
         key: str,
         *,
         delay: typing.Optional[float] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
     ) -> None:
         """Locator.press
@@ -17960,14 +18148,17 @@ class Locator(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.press(
-                key=key, delay=delay, timeout=timeout, noWaitAfter=no_wait_after
+                key=key,
+                delay=delay,
+                timeout=to_milliseconds(timeout),
+                noWaitAfter=no_wait_after,
             )
         )
 
     async def screenshot(
         self,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         type: typing.Optional[Literal["jpeg", "png"]] = None,
         path: typing.Optional[typing.Union[pathlib.Path, str]] = None,
         quality: typing.Optional[int] = None,
@@ -18058,7 +18249,7 @@ class Locator(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.screenshot(
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 type=type,
                 path=path,
                 quality=quality,
@@ -18075,7 +18266,7 @@ class Locator(AsyncBase):
     async def aria_snapshot(
         self,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         depth: typing.Optional[int] = None,
         mode: typing.Optional[Literal["ai", "default"]] = None,
     ) -> str:
@@ -18139,7 +18330,9 @@ class Locator(AsyncBase):
         """
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.aria_snapshot(timeout=timeout, depth=depth, mode=mode)
+            await self._impl_obj.aria_snapshot(
+                timeout=to_milliseconds(timeout), depth=depth, mode=mode
+            )
         )
 
     async def normalize(self) -> "Locator":
@@ -18157,7 +18350,9 @@ class Locator(AsyncBase):
         return mapping.from_impl(await self._impl_obj.normalize())
 
     async def scroll_into_view_if_needed(
-        self, *, timeout: typing.Optional[float] = None
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """Locator.scroll_into_view_if_needed
 
@@ -18175,7 +18370,9 @@ class Locator(AsyncBase):
         """
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.scroll_into_view_if_needed(timeout=timeout)
+            await self._impl_obj.scroll_into_view_if_needed(
+                timeout=to_milliseconds(timeout)
+            )
         )
 
     async def select_option(
@@ -18187,7 +18384,7 @@ class Locator(AsyncBase):
         element: typing.Optional[
             typing.Union["ElementHandle", typing.Sequence["ElementHandle"]]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
         force: typing.Optional[bool] = None,
     ) -> typing.List[str]:
@@ -18260,7 +18457,7 @@ class Locator(AsyncBase):
                 index=mapping.to_impl(index),
                 label=mapping.to_impl(label),
                 element=mapping.to_impl(element),
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 noWaitAfter=no_wait_after,
                 force=force,
             )
@@ -18270,7 +18467,7 @@ class Locator(AsyncBase):
         self,
         *,
         force: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """Locator.select_text
 
@@ -18291,7 +18488,9 @@ class Locator(AsyncBase):
         """
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.select_text(force=force, timeout=timeout)
+            await self._impl_obj.select_text(
+                force=force, timeout=to_milliseconds(timeout)
+            )
         )
 
     async def set_input_files(
@@ -18304,7 +18503,7 @@ class Locator(AsyncBase):
             typing.Sequence[FilePayload],
         ],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
     ) -> None:
         """Locator.set_input_files
@@ -18358,7 +18557,9 @@ class Locator(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.set_input_files(
-                files=mapping.to_impl(files), timeout=timeout, noWaitAfter=no_wait_after
+                files=mapping.to_impl(files),
+                timeout=to_milliseconds(timeout),
+                noWaitAfter=no_wait_after,
             )
         )
 
@@ -18369,7 +18570,7 @@ class Locator(AsyncBase):
             typing.Sequence[Literal["Alt", "Control", "ControlOrMeta", "Meta", "Shift"]]
         ] = None,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
@@ -18421,7 +18622,7 @@ class Locator(AsyncBase):
             await self._impl_obj.tap(
                 modifiers=mapping.to_impl(modifiers),
                 position=position,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 force=force,
                 noWaitAfter=no_wait_after,
                 trial=trial,
@@ -18429,7 +18630,9 @@ class Locator(AsyncBase):
         )
 
     async def text_content(
-        self, *, timeout: typing.Optional[float] = None
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> typing.Optional[str]:
         """Locator.text_content
 
@@ -18450,7 +18653,7 @@ class Locator(AsyncBase):
         """
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.text_content(timeout=timeout)
+            await self._impl_obj.text_content(timeout=to_milliseconds(timeout))
         )
 
     async def type(
@@ -18458,7 +18661,7 @@ class Locator(AsyncBase):
         text: str,
         *,
         delay: typing.Optional[float] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
     ) -> None:
         """Locator.type
@@ -18486,7 +18689,10 @@ class Locator(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.type(
-                text=text, delay=delay, timeout=timeout, noWaitAfter=no_wait_after
+                text=text,
+                delay=delay,
+                timeout=to_milliseconds(timeout),
+                noWaitAfter=no_wait_after,
             )
         )
 
@@ -18495,7 +18701,7 @@ class Locator(AsyncBase):
         text: str,
         *,
         delay: typing.Optional[float] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
     ) -> None:
         """Locator.press_sequentially
@@ -18539,7 +18745,10 @@ class Locator(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.press_sequentially(
-                text=text, delay=delay, timeout=timeout, noWaitAfter=no_wait_after
+                text=text,
+                delay=delay,
+                timeout=to_milliseconds(timeout),
+                noWaitAfter=no_wait_after,
             )
         )
 
@@ -18547,7 +18756,7 @@ class Locator(AsyncBase):
         self,
         *,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
@@ -18598,7 +18807,7 @@ class Locator(AsyncBase):
         return mapping.from_maybe_impl(
             await self._impl_obj.uncheck(
                 position=position,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 force=force,
                 noWaitAfter=no_wait_after,
                 trial=trial,
@@ -18650,7 +18859,7 @@ class Locator(AsyncBase):
     async def wait_for(
         self,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         state: typing.Optional[
             Literal["attached", "detached", "hidden", "visible"]
         ] = None,
@@ -18685,7 +18894,7 @@ class Locator(AsyncBase):
         """
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.wait_for(timeout=timeout, state=state)
+            await self._impl_obj.wait_for(timeout=to_milliseconds(timeout), state=state)
         )
 
     async def set_checked(
@@ -18693,7 +18902,7 @@ class Locator(AsyncBase):
         checked: bool,
         *,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
@@ -18746,7 +18955,7 @@ class Locator(AsyncBase):
             await self._impl_obj.set_checked(
                 checked=checked,
                 position=position,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 force=force,
                 noWaitAfter=no_wait_after,
                 trial=trial,
@@ -18921,7 +19130,7 @@ class APIRequestContext(AsyncBase):
         multipart: typing.Optional[
             typing.Dict[str, typing.Union[bytes, bool, float, str, FilePayload]]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         fail_on_status_code: typing.Optional[bool] = None,
         ignore_https_errors: typing.Optional[bool] = None,
         max_redirects: typing.Optional[int] = None,
@@ -18981,7 +19190,7 @@ class APIRequestContext(AsyncBase):
                 data=mapping.to_impl(data),
                 form=mapping.to_impl(form),
                 multipart=mapping.to_impl(multipart),
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 failOnStatusCode=fail_on_status_code,
                 ignoreHTTPSErrors=ignore_https_errors,
                 maxRedirects=max_redirects,
@@ -19002,7 +19211,7 @@ class APIRequestContext(AsyncBase):
         multipart: typing.Optional[
             typing.Dict[str, typing.Union[bytes, bool, float, str, FilePayload]]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         fail_on_status_code: typing.Optional[bool] = None,
         ignore_https_errors: typing.Optional[bool] = None,
         max_redirects: typing.Optional[int] = None,
@@ -19062,7 +19271,7 @@ class APIRequestContext(AsyncBase):
                 data=mapping.to_impl(data),
                 form=mapping.to_impl(form),
                 multipart=mapping.to_impl(multipart),
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 failOnStatusCode=fail_on_status_code,
                 ignoreHTTPSErrors=ignore_https_errors,
                 maxRedirects=max_redirects,
@@ -19083,7 +19292,7 @@ class APIRequestContext(AsyncBase):
         multipart: typing.Optional[
             typing.Dict[str, typing.Union[bytes, bool, float, str, FilePayload]]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         fail_on_status_code: typing.Optional[bool] = None,
         ignore_https_errors: typing.Optional[bool] = None,
         max_redirects: typing.Optional[int] = None,
@@ -19155,7 +19364,7 @@ class APIRequestContext(AsyncBase):
                 data=mapping.to_impl(data),
                 form=mapping.to_impl(form),
                 multipart=mapping.to_impl(multipart),
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 failOnStatusCode=fail_on_status_code,
                 ignoreHTTPSErrors=ignore_https_errors,
                 maxRedirects=max_redirects,
@@ -19176,7 +19385,7 @@ class APIRequestContext(AsyncBase):
         multipart: typing.Optional[
             typing.Dict[str, typing.Union[bytes, bool, float, str, FilePayload]]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         fail_on_status_code: typing.Optional[bool] = None,
         ignore_https_errors: typing.Optional[bool] = None,
         max_redirects: typing.Optional[int] = None,
@@ -19236,7 +19445,7 @@ class APIRequestContext(AsyncBase):
                 data=mapping.to_impl(data),
                 form=mapping.to_impl(form),
                 multipart=mapping.to_impl(multipart),
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 failOnStatusCode=fail_on_status_code,
                 ignoreHTTPSErrors=ignore_https_errors,
                 maxRedirects=max_redirects,
@@ -19257,7 +19466,7 @@ class APIRequestContext(AsyncBase):
         multipart: typing.Optional[
             typing.Dict[str, typing.Union[bytes, bool, float, str, FilePayload]]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         fail_on_status_code: typing.Optional[bool] = None,
         ignore_https_errors: typing.Optional[bool] = None,
         max_redirects: typing.Optional[int] = None,
@@ -19317,7 +19526,7 @@ class APIRequestContext(AsyncBase):
                 data=mapping.to_impl(data),
                 form=mapping.to_impl(form),
                 multipart=mapping.to_impl(multipart),
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 failOnStatusCode=fail_on_status_code,
                 ignoreHTTPSErrors=ignore_https_errors,
                 maxRedirects=max_redirects,
@@ -19338,7 +19547,7 @@ class APIRequestContext(AsyncBase):
         multipart: typing.Optional[
             typing.Dict[str, typing.Union[bytes, bool, float, str, FilePayload]]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         fail_on_status_code: typing.Optional[bool] = None,
         ignore_https_errors: typing.Optional[bool] = None,
         max_redirects: typing.Optional[int] = None,
@@ -19429,7 +19638,7 @@ class APIRequestContext(AsyncBase):
                 data=mapping.to_impl(data),
                 form=mapping.to_impl(form),
                 multipart=mapping.to_impl(multipart),
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 failOnStatusCode=fail_on_status_code,
                 ignoreHTTPSErrors=ignore_https_errors,
                 maxRedirects=max_redirects,
@@ -19451,7 +19660,7 @@ class APIRequestContext(AsyncBase):
         multipart: typing.Optional[
             typing.Dict[str, typing.Union[bytes, bool, float, str, FilePayload]]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         fail_on_status_code: typing.Optional[bool] = None,
         ignore_https_errors: typing.Optional[bool] = None,
         max_redirects: typing.Optional[int] = None,
@@ -19529,7 +19738,7 @@ class APIRequestContext(AsyncBase):
                 data=mapping.to_impl(data),
                 form=mapping.to_impl(form),
                 multipart=mapping.to_impl(multipart),
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 failOnStatusCode=fail_on_status_code,
                 ignoreHTTPSErrors=ignore_https_errors,
                 maxRedirects=max_redirects,
@@ -19580,7 +19789,7 @@ class APIRequest(AsyncBase):
         ignore_https_errors: typing.Optional[bool] = None,
         proxy: typing.Optional[ProxySettings] = None,
         user_agent: typing.Optional[str] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         storage_state: typing.Optional[
             typing.Union[StorageState, str, pathlib.Path]
         ] = None,
@@ -19660,7 +19869,7 @@ class APIRequest(AsyncBase):
                 ignoreHTTPSErrors=ignore_https_errors,
                 proxy=proxy,
                 userAgent=user_agent,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 storageState=storage_state,
                 clientCertificates=client_certificates,
                 failOnStatusCode=fail_on_status_code,
@@ -19678,7 +19887,7 @@ class PageAssertions(AsyncBase):
         self,
         title_or_reg_exp: typing.Union[typing.Pattern[str], str],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """PageAssertions.to_have_title
 
@@ -19705,7 +19914,7 @@ class PageAssertions(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.to_have_title(
-                titleOrRegExp=title_or_reg_exp, timeout=timeout
+                titleOrRegExp=title_or_reg_exp, timeout=to_milliseconds(timeout)
             )
         )
 
@@ -19713,7 +19922,7 @@ class PageAssertions(AsyncBase):
         self,
         title_or_reg_exp: typing.Union[typing.Pattern[str], str],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """PageAssertions.not_to_have_title
 
@@ -19730,7 +19939,7 @@ class PageAssertions(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.not_to_have_title(
-                titleOrRegExp=title_or_reg_exp, timeout=timeout
+                titleOrRegExp=title_or_reg_exp, timeout=to_milliseconds(timeout)
             )
         )
 
@@ -19738,7 +19947,7 @@ class PageAssertions(AsyncBase):
         self,
         url_or_reg_exp: typing.Union[str, typing.Pattern[str]],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         ignore_case: typing.Optional[bool] = None,
     ) -> None:
         """PageAssertions.to_have_url
@@ -19769,7 +19978,9 @@ class PageAssertions(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.to_have_url(
-                urlOrRegExp=url_or_reg_exp, timeout=timeout, ignoreCase=ignore_case
+                urlOrRegExp=url_or_reg_exp,
+                timeout=to_milliseconds(timeout),
+                ignoreCase=ignore_case,
             )
         )
 
@@ -19777,7 +19988,7 @@ class PageAssertions(AsyncBase):
         self,
         url_or_reg_exp: typing.Union[typing.Pattern[str], str],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         ignore_case: typing.Optional[bool] = None,
     ) -> None:
         """PageAssertions.not_to_have_url
@@ -19798,7 +20009,9 @@ class PageAssertions(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.not_to_have_url(
-                urlOrRegExp=url_or_reg_exp, timeout=timeout, ignoreCase=ignore_case
+                urlOrRegExp=url_or_reg_exp,
+                timeout=to_milliseconds(timeout),
+                ignoreCase=ignore_case,
             )
         )
 
@@ -19819,7 +20032,7 @@ class LocatorAssertions(AsyncBase):
         ],
         *,
         use_inner_text: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         ignore_case: typing.Optional[bool] = None,
     ) -> None:
         """LocatorAssertions.to_contain_text
@@ -19895,7 +20108,7 @@ class LocatorAssertions(AsyncBase):
             await self._impl_obj.to_contain_text(
                 expected=mapping.to_impl(expected),
                 useInnerText=use_inner_text,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 ignoreCase=ignore_case,
             )
         )
@@ -19911,7 +20124,7 @@ class LocatorAssertions(AsyncBase):
         ],
         *,
         use_inner_text: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         ignore_case: typing.Optional[bool] = None,
     ) -> None:
         """LocatorAssertions.not_to_contain_text
@@ -19936,7 +20149,7 @@ class LocatorAssertions(AsyncBase):
             await self._impl_obj.not_to_contain_text(
                 expected=mapping.to_impl(expected),
                 useInnerText=use_inner_text,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 ignoreCase=ignore_case,
             )
         )
@@ -19947,7 +20160,7 @@ class LocatorAssertions(AsyncBase):
         value: typing.Union[str, typing.Pattern[str]],
         *,
         ignore_case: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_have_attribute
 
@@ -19978,7 +20191,10 @@ class LocatorAssertions(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.to_have_attribute(
-                name=name, value=value, ignoreCase=ignore_case, timeout=timeout
+                name=name,
+                value=value,
+                ignoreCase=ignore_case,
+                timeout=to_milliseconds(timeout),
             )
         )
 
@@ -19988,7 +20204,7 @@ class LocatorAssertions(AsyncBase):
         value: typing.Union[str, typing.Pattern[str]],
         *,
         ignore_case: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_have_attribute
 
@@ -20010,7 +20226,10 @@ class LocatorAssertions(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.not_to_have_attribute(
-                name=name, value=value, ignoreCase=ignore_case, timeout=timeout
+                name=name,
+                value=value,
+                ignoreCase=ignore_case,
+                timeout=to_milliseconds(timeout),
             )
         )
 
@@ -20024,7 +20243,7 @@ class LocatorAssertions(AsyncBase):
             str,
         ],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_have_class
 
@@ -20067,7 +20286,7 @@ class LocatorAssertions(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.to_have_class(
-                expected=mapping.to_impl(expected), timeout=timeout
+                expected=mapping.to_impl(expected), timeout=to_milliseconds(timeout)
             )
         )
 
@@ -20081,7 +20300,7 @@ class LocatorAssertions(AsyncBase):
             str,
         ],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_have_class
 
@@ -20098,7 +20317,7 @@ class LocatorAssertions(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.not_to_have_class(
-                expected=mapping.to_impl(expected), timeout=timeout
+                expected=mapping.to_impl(expected), timeout=to_milliseconds(timeout)
             )
         )
 
@@ -20106,7 +20325,7 @@ class LocatorAssertions(AsyncBase):
         self,
         expected: typing.Union[typing.Sequence[str], str],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_contain_class
 
@@ -20159,7 +20378,7 @@ class LocatorAssertions(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.to_contain_class(
-                expected=mapping.to_impl(expected), timeout=timeout
+                expected=mapping.to_impl(expected), timeout=to_milliseconds(timeout)
             )
         )
 
@@ -20167,7 +20386,7 @@ class LocatorAssertions(AsyncBase):
         self,
         expected: typing.Union[typing.Sequence[str], str],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_contain_class
 
@@ -20184,12 +20403,15 @@ class LocatorAssertions(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.not_to_contain_class(
-                expected=mapping.to_impl(expected), timeout=timeout
+                expected=mapping.to_impl(expected), timeout=to_milliseconds(timeout)
             )
         )
 
     async def to_have_count(
-        self, count: int, *, timeout: typing.Optional[float] = None
+        self,
+        count: int,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_have_count
 
@@ -20214,11 +20436,16 @@ class LocatorAssertions(AsyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.to_have_count(count=count, timeout=timeout)
+            await self._impl_obj.to_have_count(
+                count=count, timeout=to_milliseconds(timeout)
+            )
         )
 
     async def not_to_have_count(
-        self, count: int, *, timeout: typing.Optional[float] = None
+        self,
+        count: int,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_have_count
 
@@ -20234,7 +20461,9 @@ class LocatorAssertions(AsyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.not_to_have_count(count=count, timeout=timeout)
+            await self._impl_obj.not_to_have_count(
+                count=count, timeout=to_milliseconds(timeout)
+            )
         )
 
     async def to_have_css(
@@ -20242,7 +20471,7 @@ class LocatorAssertions(AsyncBase):
         name: str,
         value: typing.Union[str, typing.Pattern[str]],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_have_css
 
@@ -20269,7 +20498,9 @@ class LocatorAssertions(AsyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.to_have_css(name=name, value=value, timeout=timeout)
+            await self._impl_obj.to_have_css(
+                name=name, value=value, timeout=to_milliseconds(timeout)
+            )
         )
 
     async def not_to_have_css(
@@ -20277,7 +20508,7 @@ class LocatorAssertions(AsyncBase):
         name: str,
         value: typing.Union[str, typing.Pattern[str]],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_have_css
 
@@ -20296,7 +20527,7 @@ class LocatorAssertions(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.not_to_have_css(
-                name=name, value=value, timeout=timeout
+                name=name, value=value, timeout=to_milliseconds(timeout)
             )
         )
 
@@ -20304,7 +20535,7 @@ class LocatorAssertions(AsyncBase):
         self,
         id: typing.Union[str, typing.Pattern[str]],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_have_id
 
@@ -20329,14 +20560,14 @@ class LocatorAssertions(AsyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.to_have_id(id=id, timeout=timeout)
+            await self._impl_obj.to_have_id(id=id, timeout=to_milliseconds(timeout))
         )
 
     async def not_to_have_id(
         self,
         id: typing.Union[str, typing.Pattern[str]],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_have_id
 
@@ -20352,11 +20583,15 @@ class LocatorAssertions(AsyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.not_to_have_id(id=id, timeout=timeout)
+            await self._impl_obj.not_to_have_id(id=id, timeout=to_milliseconds(timeout))
         )
 
     async def to_have_js_property(
-        self, name: str, value: typing.Any, *, timeout: typing.Optional[float] = None
+        self,
+        name: str,
+        value: typing.Any,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_have_js_property
 
@@ -20385,12 +20620,18 @@ class LocatorAssertions(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.to_have_js_property(
-                name=name, value=mapping.to_impl(value), timeout=timeout
+                name=name,
+                value=mapping.to_impl(value),
+                timeout=to_milliseconds(timeout),
             )
         )
 
     async def not_to_have_js_property(
-        self, name: str, value: typing.Any, *, timeout: typing.Optional[float] = None
+        self,
+        name: str,
+        value: typing.Any,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_have_js_property
 
@@ -20409,7 +20650,9 @@ class LocatorAssertions(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.not_to_have_js_property(
-                name=name, value=mapping.to_impl(value), timeout=timeout
+                name=name,
+                value=mapping.to_impl(value),
+                timeout=to_milliseconds(timeout),
             )
         )
 
@@ -20417,7 +20660,7 @@ class LocatorAssertions(AsyncBase):
         self,
         value: typing.Union[str, typing.Pattern[str]],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_have_value
 
@@ -20444,14 +20687,16 @@ class LocatorAssertions(AsyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.to_have_value(value=value, timeout=timeout)
+            await self._impl_obj.to_have_value(
+                value=value, timeout=to_milliseconds(timeout)
+            )
         )
 
     async def not_to_have_value(
         self,
         value: typing.Union[str, typing.Pattern[str]],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_have_value
 
@@ -20467,7 +20712,9 @@ class LocatorAssertions(AsyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.not_to_have_value(value=value, timeout=timeout)
+            await self._impl_obj.not_to_have_value(
+                value=value, timeout=to_milliseconds(timeout)
+            )
         )
 
     async def to_have_values(
@@ -20478,7 +20725,7 @@ class LocatorAssertions(AsyncBase):
             typing.Sequence[typing.Union[typing.Pattern[str], str]],
         ],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_have_values
 
@@ -20517,7 +20764,7 @@ class LocatorAssertions(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.to_have_values(
-                values=mapping.to_impl(values), timeout=timeout
+                values=mapping.to_impl(values), timeout=to_milliseconds(timeout)
             )
         )
 
@@ -20529,7 +20776,7 @@ class LocatorAssertions(AsyncBase):
             typing.Sequence[typing.Union[typing.Pattern[str], str]],
         ],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_have_values
 
@@ -20546,7 +20793,7 @@ class LocatorAssertions(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.not_to_have_values(
-                values=mapping.to_impl(values), timeout=timeout
+                values=mapping.to_impl(values), timeout=to_milliseconds(timeout)
             )
         )
 
@@ -20561,7 +20808,7 @@ class LocatorAssertions(AsyncBase):
         ],
         *,
         use_inner_text: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         ignore_case: typing.Optional[bool] = None,
     ) -> None:
         """LocatorAssertions.to_have_text
@@ -20636,7 +20883,7 @@ class LocatorAssertions(AsyncBase):
             await self._impl_obj.to_have_text(
                 expected=mapping.to_impl(expected),
                 useInnerText=use_inner_text,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 ignoreCase=ignore_case,
             )
         )
@@ -20652,7 +20899,7 @@ class LocatorAssertions(AsyncBase):
         ],
         *,
         use_inner_text: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         ignore_case: typing.Optional[bool] = None,
     ) -> None:
         """LocatorAssertions.not_to_have_text
@@ -20677,7 +20924,7 @@ class LocatorAssertions(AsyncBase):
             await self._impl_obj.not_to_have_text(
                 expected=mapping.to_impl(expected),
                 useInnerText=use_inner_text,
-                timeout=timeout,
+                timeout=to_milliseconds(timeout),
                 ignoreCase=ignore_case,
             )
         )
@@ -20686,7 +20933,7 @@ class LocatorAssertions(AsyncBase):
         self,
         *,
         attached: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_be_attached
 
@@ -20708,13 +20955,15 @@ class LocatorAssertions(AsyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.to_be_attached(attached=attached, timeout=timeout)
+            await self._impl_obj.to_be_attached(
+                attached=attached, timeout=to_milliseconds(timeout)
+            )
         )
 
     async def to_be_checked(
         self,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         checked: typing.Optional[bool] = None,
         indeterminate: typing.Optional[bool] = None,
     ) -> None:
@@ -20746,7 +20995,9 @@ class LocatorAssertions(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.to_be_checked(
-                timeout=timeout, checked=checked, indeterminate=indeterminate
+                timeout=to_milliseconds(timeout),
+                checked=checked,
+                indeterminate=indeterminate,
             )
         )
 
@@ -20754,7 +21005,7 @@ class LocatorAssertions(AsyncBase):
         self,
         *,
         attached: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_be_attached
 
@@ -20769,11 +21020,15 @@ class LocatorAssertions(AsyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.not_to_be_attached(attached=attached, timeout=timeout)
+            await self._impl_obj.not_to_be_attached(
+                attached=attached, timeout=to_milliseconds(timeout)
+            )
         )
 
     async def not_to_be_checked(
-        self, *, timeout: typing.Optional[float] = None
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_be_checked
 
@@ -20787,10 +21042,14 @@ class LocatorAssertions(AsyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.not_to_be_checked(timeout=timeout)
+            await self._impl_obj.not_to_be_checked(timeout=to_milliseconds(timeout))
         )
 
-    async def to_be_disabled(self, *, timeout: typing.Optional[float] = None) -> None:
+    async def to_be_disabled(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> None:
         """LocatorAssertions.to_be_disabled
 
         Ensures the `Locator` points to a disabled element. Element is disabled if it has \"disabled\" attribute or is
@@ -20816,11 +21075,13 @@ class LocatorAssertions(AsyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.to_be_disabled(timeout=timeout)
+            await self._impl_obj.to_be_disabled(timeout=to_milliseconds(timeout))
         )
 
     async def not_to_be_disabled(
-        self, *, timeout: typing.Optional[float] = None
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_be_disabled
 
@@ -20834,14 +21095,14 @@ class LocatorAssertions(AsyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.not_to_be_disabled(timeout=timeout)
+            await self._impl_obj.not_to_be_disabled(timeout=to_milliseconds(timeout))
         )
 
     async def to_be_editable(
         self,
         *,
         editable: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_be_editable
 
@@ -20865,14 +21126,16 @@ class LocatorAssertions(AsyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.to_be_editable(editable=editable, timeout=timeout)
+            await self._impl_obj.to_be_editable(
+                editable=editable, timeout=to_milliseconds(timeout)
+            )
         )
 
     async def not_to_be_editable(
         self,
         *,
         editable: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_be_editable
 
@@ -20887,10 +21150,16 @@ class LocatorAssertions(AsyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.not_to_be_editable(editable=editable, timeout=timeout)
+            await self._impl_obj.not_to_be_editable(
+                editable=editable, timeout=to_milliseconds(timeout)
+            )
         )
 
-    async def to_be_empty(self, *, timeout: typing.Optional[float] = None) -> None:
+    async def to_be_empty(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> None:
         """LocatorAssertions.to_be_empty
 
         Ensures the `Locator` points to an empty editable element or to a DOM node that has no text.
@@ -20912,10 +21181,14 @@ class LocatorAssertions(AsyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.to_be_empty(timeout=timeout)
+            await self._impl_obj.to_be_empty(timeout=to_milliseconds(timeout))
         )
 
-    async def not_to_be_empty(self, *, timeout: typing.Optional[float] = None) -> None:
+    async def not_to_be_empty(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> None:
         """LocatorAssertions.not_to_be_empty
 
         The opposite of `locator_assertions.to_be_empty()`.
@@ -20928,14 +21201,14 @@ class LocatorAssertions(AsyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.not_to_be_empty(timeout=timeout)
+            await self._impl_obj.not_to_be_empty(timeout=to_milliseconds(timeout))
         )
 
     async def to_be_enabled(
         self,
         *,
         enabled: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_be_enabled
 
@@ -20959,14 +21232,16 @@ class LocatorAssertions(AsyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.to_be_enabled(enabled=enabled, timeout=timeout)
+            await self._impl_obj.to_be_enabled(
+                enabled=enabled, timeout=to_milliseconds(timeout)
+            )
         )
 
     async def not_to_be_enabled(
         self,
         *,
         enabled: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_be_enabled
 
@@ -20981,10 +21256,16 @@ class LocatorAssertions(AsyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.not_to_be_enabled(enabled=enabled, timeout=timeout)
+            await self._impl_obj.not_to_be_enabled(
+                enabled=enabled, timeout=to_milliseconds(timeout)
+            )
         )
 
-    async def to_be_hidden(self, *, timeout: typing.Optional[float] = None) -> None:
+    async def to_be_hidden(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> None:
         """LocatorAssertions.to_be_hidden
 
         Ensures that `Locator` either does not resolve to any DOM node, or resolves to a
@@ -21007,10 +21288,14 @@ class LocatorAssertions(AsyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.to_be_hidden(timeout=timeout)
+            await self._impl_obj.to_be_hidden(timeout=to_milliseconds(timeout))
         )
 
-    async def not_to_be_hidden(self, *, timeout: typing.Optional[float] = None) -> None:
+    async def not_to_be_hidden(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> None:
         """LocatorAssertions.not_to_be_hidden
 
         The opposite of `locator_assertions.to_be_hidden()`.
@@ -21023,14 +21308,14 @@ class LocatorAssertions(AsyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.not_to_be_hidden(timeout=timeout)
+            await self._impl_obj.not_to_be_hidden(timeout=to_milliseconds(timeout))
         )
 
     async def to_be_visible(
         self,
         *,
         visible: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_be_visible
 
@@ -21064,14 +21349,16 @@ class LocatorAssertions(AsyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.to_be_visible(visible=visible, timeout=timeout)
+            await self._impl_obj.to_be_visible(
+                visible=visible, timeout=to_milliseconds(timeout)
+            )
         )
 
     async def not_to_be_visible(
         self,
         *,
         visible: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_be_visible
 
@@ -21086,10 +21373,16 @@ class LocatorAssertions(AsyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.not_to_be_visible(visible=visible, timeout=timeout)
+            await self._impl_obj.not_to_be_visible(
+                visible=visible, timeout=to_milliseconds(timeout)
+            )
         )
 
-    async def to_be_focused(self, *, timeout: typing.Optional[float] = None) -> None:
+    async def to_be_focused(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> None:
         """LocatorAssertions.to_be_focused
 
         Ensures the `Locator` points to a focused DOM node.
@@ -21111,11 +21404,13 @@ class LocatorAssertions(AsyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.to_be_focused(timeout=timeout)
+            await self._impl_obj.to_be_focused(timeout=to_milliseconds(timeout))
         )
 
     async def not_to_be_focused(
-        self, *, timeout: typing.Optional[float] = None
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_be_focused
 
@@ -21129,14 +21424,14 @@ class LocatorAssertions(AsyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.not_to_be_focused(timeout=timeout)
+            await self._impl_obj.not_to_be_focused(timeout=to_milliseconds(timeout))
         )
 
     async def to_be_in_viewport(
         self,
         *,
         ratio: typing.Optional[float] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_be_in_viewport
 
@@ -21168,14 +21463,16 @@ class LocatorAssertions(AsyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.to_be_in_viewport(ratio=ratio, timeout=timeout)
+            await self._impl_obj.to_be_in_viewport(
+                ratio=ratio, timeout=to_milliseconds(timeout)
+            )
         )
 
     async def not_to_be_in_viewport(
         self,
         *,
         ratio: typing.Optional[float] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_be_in_viewport
 
@@ -21190,7 +21487,9 @@ class LocatorAssertions(AsyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.not_to_be_in_viewport(ratio=ratio, timeout=timeout)
+            await self._impl_obj.not_to_be_in_viewport(
+                ratio=ratio, timeout=to_milliseconds(timeout)
+            )
         )
 
     async def to_have_accessible_description(
@@ -21198,7 +21497,7 @@ class LocatorAssertions(AsyncBase):
         description: typing.Union[str, typing.Pattern[str]],
         *,
         ignore_case: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_have_accessible_description
 
@@ -21226,7 +21525,9 @@ class LocatorAssertions(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.to_have_accessible_description(
-                description=description, ignoreCase=ignore_case, timeout=timeout
+                description=description,
+                ignoreCase=ignore_case,
+                timeout=to_milliseconds(timeout),
             )
         )
 
@@ -21235,7 +21536,7 @@ class LocatorAssertions(AsyncBase):
         name: typing.Union[str, typing.Pattern[str]],
         *,
         ignore_case: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_have_accessible_description
 
@@ -21255,7 +21556,7 @@ class LocatorAssertions(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.not_to_have_accessible_description(
-                name=name, ignoreCase=ignore_case, timeout=timeout
+                name=name, ignoreCase=ignore_case, timeout=to_milliseconds(timeout)
             )
         )
 
@@ -21264,7 +21565,7 @@ class LocatorAssertions(AsyncBase):
         name: typing.Union[str, typing.Pattern[str]],
         *,
         ignore_case: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_have_accessible_name
 
@@ -21292,7 +21593,7 @@ class LocatorAssertions(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.to_have_accessible_name(
-                name=name, ignoreCase=ignore_case, timeout=timeout
+                name=name, ignoreCase=ignore_case, timeout=to_milliseconds(timeout)
             )
         )
 
@@ -21301,7 +21602,7 @@ class LocatorAssertions(AsyncBase):
         name: typing.Union[str, typing.Pattern[str]],
         *,
         ignore_case: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_have_accessible_name
 
@@ -21321,7 +21622,7 @@ class LocatorAssertions(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.not_to_have_accessible_name(
-                name=name, ignoreCase=ignore_case, timeout=timeout
+                name=name, ignoreCase=ignore_case, timeout=to_milliseconds(timeout)
             )
         )
 
@@ -21412,7 +21713,7 @@ class LocatorAssertions(AsyncBase):
             "treeitem",
         ],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_have_role
 
@@ -21438,7 +21739,9 @@ class LocatorAssertions(AsyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.to_have_role(role=role, timeout=timeout)
+            await self._impl_obj.to_have_role(
+                role=role, timeout=to_milliseconds(timeout)
+            )
         )
 
     async def to_have_accessible_error_message(
@@ -21446,7 +21749,7 @@ class LocatorAssertions(AsyncBase):
         error_message: typing.Union[str, typing.Pattern[str]],
         *,
         ignore_case: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_have_accessible_error_message
 
@@ -21474,7 +21777,9 @@ class LocatorAssertions(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.to_have_accessible_error_message(
-                errorMessage=error_message, ignoreCase=ignore_case, timeout=timeout
+                errorMessage=error_message,
+                ignoreCase=ignore_case,
+                timeout=to_milliseconds(timeout),
             )
         )
 
@@ -21483,7 +21788,7 @@ class LocatorAssertions(AsyncBase):
         error_message: typing.Union[str, typing.Pattern[str]],
         *,
         ignore_case: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_have_accessible_error_message
 
@@ -21503,7 +21808,9 @@ class LocatorAssertions(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.not_to_have_accessible_error_message(
-                errorMessage=error_message, ignoreCase=ignore_case, timeout=timeout
+                errorMessage=error_message,
+                ignoreCase=ignore_case,
+                timeout=to_milliseconds(timeout),
             )
         )
 
@@ -21594,7 +21901,7 @@ class LocatorAssertions(AsyncBase):
             "treeitem",
         ],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_have_role
 
@@ -21610,11 +21917,16 @@ class LocatorAssertions(AsyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.not_to_have_role(role=role, timeout=timeout)
+            await self._impl_obj.not_to_have_role(
+                role=role, timeout=to_milliseconds(timeout)
+            )
         )
 
     async def to_match_aria_snapshot(
-        self, expected: str, *, timeout: typing.Optional[float] = None
+        self,
+        expected: str,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_match_aria_snapshot
 
@@ -21640,12 +21952,15 @@ class LocatorAssertions(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.to_match_aria_snapshot(
-                expected=expected, timeout=timeout
+                expected=expected, timeout=to_milliseconds(timeout)
             )
         )
 
     async def not_to_match_aria_snapshot(
-        self, expected: str, *, timeout: typing.Optional[float] = None
+        self,
+        expected: str,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_match_aria_snapshot
 
@@ -21661,7 +21976,7 @@ class LocatorAssertions(AsyncBase):
 
         return mapping.from_maybe_impl(
             await self._impl_obj.not_to_match_aria_snapshot(
-                expected=expected, timeout=timeout
+                expected=expected, timeout=to_milliseconds(timeout)
             )
         )
 

--- a/playwright/sync_api/_generated.py
+++ b/playwright/sync_api/_generated.py
@@ -65,6 +65,7 @@ from playwright._impl._fetch import APIRequestContext as APIRequestContextImpl
 from playwright._impl._fetch import APIResponse as APIResponseImpl
 from playwright._impl._file_chooser import FileChooser as FileChooserImpl
 from playwright._impl._frame import Frame as FrameImpl
+from playwright._impl._helper import to_milliseconds
 from playwright._impl._input import Keyboard as KeyboardImpl
 from playwright._impl._input import Mouse as MouseImpl
 from playwright._impl._input import Touchscreen as TouchscreenImpl
@@ -801,7 +802,7 @@ class Route(SyncBase):
         post_data: typing.Optional[typing.Union[typing.Any, str, bytes]] = None,
         max_redirects: typing.Optional[int] = None,
         max_retries: typing.Optional[int] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> "APIResponse":
         """Route.fetch
 
@@ -861,7 +862,7 @@ class Route(SyncBase):
                     postData=mapping.to_impl(post_data),
                     maxRedirects=max_redirects,
                     maxRetries=max_retries,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                 )
             )
         )
@@ -1117,7 +1118,7 @@ class WebSocket(SyncBase):
         event: str,
         predicate: typing.Optional[typing.Callable] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> EventContextManager:
         """WebSocket.expect_event
 
@@ -1141,7 +1142,9 @@ class WebSocket(SyncBase):
         return EventContextManager(
             self,
             self._impl_obj.expect_event(
-                event=event, predicate=self._wrap_handler(predicate), timeout=timeout
+                event=event,
+                predicate=self._wrap_handler(predicate),
+                timeout=to_milliseconds(timeout),
             ).future,
         )
 
@@ -1150,7 +1153,7 @@ class WebSocket(SyncBase):
         event: str,
         predicate: typing.Optional[typing.Callable] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> typing.Any:
         """WebSocket.wait_for_event
 
@@ -1180,7 +1183,7 @@ class WebSocket(SyncBase):
                 self._impl_obj.wait_for_event(
                     event=event,
                     predicate=self._wrap_handler(predicate),
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                 )
             )
         )
@@ -2052,7 +2055,9 @@ class ElementHandle(JSHandle):
         )
 
     def scroll_into_view_if_needed(
-        self, *, timeout: typing.Optional[float] = None
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """ElementHandle.scroll_into_view_if_needed
 
@@ -2073,7 +2078,11 @@ class ElementHandle(JSHandle):
         """
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.scroll_into_view_if_needed(timeout=timeout))
+            self._sync(
+                self._impl_obj.scroll_into_view_if_needed(
+                    timeout=to_milliseconds(timeout)
+                )
+            )
         )
 
     def hover(
@@ -2083,7 +2092,7 @@ class ElementHandle(JSHandle):
             typing.Sequence[Literal["Alt", "Control", "ControlOrMeta", "Meta", "Shift"]]
         ] = None,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
         force: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
@@ -2127,7 +2136,7 @@ class ElementHandle(JSHandle):
                 self._impl_obj.hover(
                     modifiers=mapping.to_impl(modifiers),
                     position=position,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     noWaitAfter=no_wait_after,
                     force=force,
                     trial=trial,
@@ -2145,7 +2154,7 @@ class ElementHandle(JSHandle):
         delay: typing.Optional[float] = None,
         button: typing.Optional[Literal["left", "middle", "right"]] = None,
         click_count: typing.Optional[int] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
@@ -2205,7 +2214,7 @@ class ElementHandle(JSHandle):
                     delay=delay,
                     button=button,
                     clickCount=click_count,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     force=force,
                     noWaitAfter=no_wait_after,
                     trial=trial,
@@ -2223,7 +2232,7 @@ class ElementHandle(JSHandle):
         position: typing.Optional[Position] = None,
         delay: typing.Optional[float] = None,
         button: typing.Optional[Literal["left", "middle", "right"]] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
@@ -2279,7 +2288,7 @@ class ElementHandle(JSHandle):
                     position=position,
                     delay=delay,
                     button=button,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     force=force,
                     noWaitAfter=no_wait_after,
                     trial=trial,
@@ -2297,7 +2306,7 @@ class ElementHandle(JSHandle):
         element: typing.Optional[
             typing.Union["ElementHandle", typing.Sequence["ElementHandle"]]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
     ) -> typing.List[str]:
@@ -2359,7 +2368,7 @@ class ElementHandle(JSHandle):
                     index=mapping.to_impl(index),
                     label=mapping.to_impl(label),
                     element=mapping.to_impl(element),
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     force=force,
                     noWaitAfter=no_wait_after,
                 )
@@ -2373,7 +2382,7 @@ class ElementHandle(JSHandle):
             typing.Sequence[Literal["Alt", "Control", "ControlOrMeta", "Meta", "Shift"]]
         ] = None,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
@@ -2419,7 +2428,7 @@ class ElementHandle(JSHandle):
                 self._impl_obj.tap(
                     modifiers=mapping.to_impl(modifiers),
                     position=position,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     force=force,
                     noWaitAfter=no_wait_after,
                     trial=trial,
@@ -2431,7 +2440,7 @@ class ElementHandle(JSHandle):
         self,
         value: str,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
         force: typing.Optional[bool] = None,
     ) -> None:
@@ -2464,7 +2473,10 @@ class ElementHandle(JSHandle):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.fill(
-                    value=value, timeout=timeout, noWaitAfter=no_wait_after, force=force
+                    value=value,
+                    timeout=to_milliseconds(timeout),
+                    noWaitAfter=no_wait_after,
+                    force=force,
                 )
             )
         )
@@ -2473,7 +2485,7 @@ class ElementHandle(JSHandle):
         self,
         *,
         force: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """ElementHandle.select_text
 
@@ -2494,10 +2506,18 @@ class ElementHandle(JSHandle):
         """
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.select_text(force=force, timeout=timeout))
+            self._sync(
+                self._impl_obj.select_text(
+                    force=force, timeout=to_milliseconds(timeout)
+                )
+            )
         )
 
-    def input_value(self, *, timeout: typing.Optional[float] = None) -> str:
+    def input_value(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> str:
         """ElementHandle.input_value
 
         Returns `input.value` for the selected `<input>` or `<textarea>` or `<select>` element.
@@ -2518,7 +2538,7 @@ class ElementHandle(JSHandle):
         """
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.input_value(timeout=timeout))
+            self._sync(self._impl_obj.input_value(timeout=to_milliseconds(timeout)))
         )
 
     def set_input_files(
@@ -2531,7 +2551,7 @@ class ElementHandle(JSHandle):
             typing.Sequence[FilePayload],
         ],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
     ) -> None:
         """ElementHandle.set_input_files
@@ -2560,7 +2580,7 @@ class ElementHandle(JSHandle):
             self._sync(
                 self._impl_obj.set_input_files(
                     files=mapping.to_impl(files),
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     noWaitAfter=no_wait_after,
                 )
             )
@@ -2579,7 +2599,7 @@ class ElementHandle(JSHandle):
         text: str,
         *,
         delay: typing.Optional[float] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
     ) -> None:
         """ElementHandle.type
@@ -2608,7 +2628,10 @@ class ElementHandle(JSHandle):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.type(
-                    text=text, delay=delay, timeout=timeout, noWaitAfter=no_wait_after
+                    text=text,
+                    delay=delay,
+                    timeout=to_milliseconds(timeout),
+                    noWaitAfter=no_wait_after,
                 )
             )
         )
@@ -2618,7 +2641,7 @@ class ElementHandle(JSHandle):
         key: str,
         *,
         delay: typing.Optional[float] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
     ) -> None:
         """ElementHandle.press
@@ -2664,7 +2687,10 @@ class ElementHandle(JSHandle):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.press(
-                    key=key, delay=delay, timeout=timeout, noWaitAfter=no_wait_after
+                    key=key,
+                    delay=delay,
+                    timeout=to_milliseconds(timeout),
+                    noWaitAfter=no_wait_after,
                 )
             )
         )
@@ -2674,7 +2700,7 @@ class ElementHandle(JSHandle):
         checked: bool,
         *,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
@@ -2718,7 +2744,7 @@ class ElementHandle(JSHandle):
                 self._impl_obj.set_checked(
                     checked=checked,
                     position=position,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     force=force,
                     noWaitAfter=no_wait_after,
                     trial=trial,
@@ -2730,7 +2756,7 @@ class ElementHandle(JSHandle):
         self,
         *,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
@@ -2772,7 +2798,7 @@ class ElementHandle(JSHandle):
             self._sync(
                 self._impl_obj.check(
                     position=position,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     force=force,
                     noWaitAfter=no_wait_after,
                     trial=trial,
@@ -2784,7 +2810,7 @@ class ElementHandle(JSHandle):
         self,
         *,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
@@ -2826,7 +2852,7 @@ class ElementHandle(JSHandle):
             self._sync(
                 self._impl_obj.uncheck(
                     position=position,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     force=force,
                     noWaitAfter=no_wait_after,
                     trial=trial,
@@ -2867,7 +2893,7 @@ class ElementHandle(JSHandle):
     def screenshot(
         self,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         type: typing.Optional[Literal["jpeg", "png"]] = None,
         path: typing.Optional[typing.Union[pathlib.Path, str]] = None,
         quality: typing.Optional[int] = None,
@@ -2943,7 +2969,7 @@ class ElementHandle(JSHandle):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.screenshot(
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     type=type,
                     path=path,
                     quality=quality,
@@ -3098,7 +3124,7 @@ class ElementHandle(JSHandle):
             "disabled", "editable", "enabled", "hidden", "stable", "visible"
         ],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """ElementHandle.wait_for_element_state
 
@@ -3128,7 +3154,9 @@ class ElementHandle(JSHandle):
 
         return mapping.from_maybe_impl(
             self._sync(
-                self._impl_obj.wait_for_element_state(state=state, timeout=timeout)
+                self._impl_obj.wait_for_element_state(
+                    state=state, timeout=to_milliseconds(timeout)
+                )
             )
         )
 
@@ -3139,7 +3167,7 @@ class ElementHandle(JSHandle):
         state: typing.Optional[
             Literal["attached", "detached", "hidden", "visible"]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         strict: typing.Optional[bool] = None,
     ) -> typing.Optional["ElementHandle"]:
         """ElementHandle.wait_for_selector
@@ -3190,7 +3218,10 @@ class ElementHandle(JSHandle):
         return mapping.from_impl_nullable(
             self._sync(
                 self._impl_obj.wait_for_selector(
-                    selector=selector, state=state, timeout=timeout, strict=strict
+                    selector=selector,
+                    state=state,
+                    timeout=to_milliseconds(timeout),
+                    strict=strict,
                 )
             )
         )
@@ -3247,7 +3278,7 @@ class FileChooser(SyncBase):
             typing.Sequence[FilePayload],
         ],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
     ) -> None:
         """FileChooser.set_files
@@ -3270,7 +3301,7 @@ class FileChooser(SyncBase):
             self._sync(
                 self._impl_obj.set_files(
                     files=mapping.to_impl(files),
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     noWaitAfter=no_wait_after,
                 )
             )
@@ -3349,7 +3380,7 @@ class Frame(SyncBase):
         self,
         url: str,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         wait_until: typing.Optional[
             Literal["commit", "domcontentloaded", "load", "networkidle"]
         ] = None,
@@ -3406,7 +3437,10 @@ class Frame(SyncBase):
         return mapping.from_impl_nullable(
             self._sync(
                 self._impl_obj.goto(
-                    url=url, timeout=timeout, waitUntil=wait_until, referer=referer
+                    url=url,
+                    timeout=to_milliseconds(timeout),
+                    waitUntil=wait_until,
+                    referer=referer,
                 )
             )
         )
@@ -3420,7 +3454,7 @@ class Frame(SyncBase):
         wait_until: typing.Optional[
             Literal["commit", "domcontentloaded", "load", "networkidle"]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> EventContextManager["Response"]:
         """Frame.expect_navigation
 
@@ -3469,7 +3503,9 @@ class Frame(SyncBase):
         return EventContextManager(
             self,
             self._impl_obj.expect_navigation(
-                url=self._wrap_handler(url), waitUntil=wait_until, timeout=timeout
+                url=self._wrap_handler(url),
+                waitUntil=wait_until,
+                timeout=to_milliseconds(timeout),
             ).future,
         )
 
@@ -3480,7 +3516,7 @@ class Frame(SyncBase):
         wait_until: typing.Optional[
             Literal["commit", "domcontentloaded", "load", "networkidle"]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """Frame.wait_for_url
 
@@ -3517,7 +3553,9 @@ class Frame(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.wait_for_url(
-                    url=self._wrap_handler(url), waitUntil=wait_until, timeout=timeout
+                    url=self._wrap_handler(url),
+                    waitUntil=wait_until,
+                    timeout=to_milliseconds(timeout),
                 )
             )
         )
@@ -3528,7 +3566,7 @@ class Frame(SyncBase):
             Literal["domcontentloaded", "load", "networkidle"]
         ] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """Frame.wait_for_load_state
 
@@ -3565,7 +3603,11 @@ class Frame(SyncBase):
         """
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.wait_for_load_state(state=state, timeout=timeout))
+            self._sync(
+                self._impl_obj.wait_for_load_state(
+                    state=state, timeout=to_milliseconds(timeout)
+                )
+            )
         )
 
     def frame_element(self) -> "ElementHandle":
@@ -3763,7 +3805,7 @@ class Frame(SyncBase):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         state: typing.Optional[
             Literal["attached", "detached", "hidden", "visible"]
         ] = None,
@@ -3828,7 +3870,10 @@ class Frame(SyncBase):
         return mapping.from_impl_nullable(
             self._sync(
                 self._impl_obj.wait_for_selector(
-                    selector=selector, strict=strict, timeout=timeout, state=state
+                    selector=selector,
+                    strict=strict,
+                    timeout=to_milliseconds(timeout),
+                    state=state,
                 )
             )
         )
@@ -3838,7 +3883,7 @@ class Frame(SyncBase):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> bool:
         """Frame.is_checked
 
@@ -3864,7 +3909,7 @@ class Frame(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.is_checked(
-                    selector=selector, strict=strict, timeout=timeout
+                    selector=selector, strict=strict, timeout=to_milliseconds(timeout)
                 )
             )
         )
@@ -3874,7 +3919,7 @@ class Frame(SyncBase):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> bool:
         """Frame.is_disabled
 
@@ -3900,7 +3945,7 @@ class Frame(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.is_disabled(
-                    selector=selector, strict=strict, timeout=timeout
+                    selector=selector, strict=strict, timeout=to_milliseconds(timeout)
                 )
             )
         )
@@ -3910,7 +3955,7 @@ class Frame(SyncBase):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> bool:
         """Frame.is_editable
 
@@ -3936,7 +3981,7 @@ class Frame(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.is_editable(
-                    selector=selector, strict=strict, timeout=timeout
+                    selector=selector, strict=strict, timeout=to_milliseconds(timeout)
                 )
             )
         )
@@ -3946,7 +3991,7 @@ class Frame(SyncBase):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> bool:
         """Frame.is_enabled
 
@@ -3972,7 +4017,7 @@ class Frame(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.is_enabled(
-                    selector=selector, strict=strict, timeout=timeout
+                    selector=selector, strict=strict, timeout=to_milliseconds(timeout)
                 )
             )
         )
@@ -4034,7 +4079,7 @@ class Frame(SyncBase):
         event_init: typing.Optional[typing.Dict] = None,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """Frame.dispatch_event
 
@@ -4095,7 +4140,7 @@ class Frame(SyncBase):
                     type=type,
                     eventInit=mapping.to_impl(event_init),
                     strict=strict,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                 )
             )
         )
@@ -4213,7 +4258,7 @@ class Frame(SyncBase):
         self,
         html: str,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         wait_until: typing.Optional[
             Literal["commit", "domcontentloaded", "load", "networkidle"]
         ] = None,
@@ -4245,7 +4290,7 @@ class Frame(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.set_content(
-                    html=html, timeout=timeout, waitUntil=wait_until
+                    html=html, timeout=to_milliseconds(timeout), waitUntil=wait_until
                 )
             )
         )
@@ -4348,7 +4393,7 @@ class Frame(SyncBase):
         delay: typing.Optional[float] = None,
         button: typing.Optional[Literal["left", "middle", "right"]] = None,
         click_count: typing.Optional[int] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
@@ -4414,7 +4459,7 @@ class Frame(SyncBase):
                     delay=delay,
                     button=button,
                     clickCount=click_count,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     force=force,
                     noWaitAfter=no_wait_after,
                     strict=strict,
@@ -4433,7 +4478,7 @@ class Frame(SyncBase):
         position: typing.Optional[Position] = None,
         delay: typing.Optional[float] = None,
         button: typing.Optional[Literal["left", "middle", "right"]] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
@@ -4496,7 +4541,7 @@ class Frame(SyncBase):
                     position=position,
                     delay=delay,
                     button=button,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     force=force,
                     noWaitAfter=no_wait_after,
                     strict=strict,
@@ -4513,7 +4558,7 @@ class Frame(SyncBase):
             typing.Sequence[Literal["Alt", "Control", "ControlOrMeta", "Meta", "Shift"]]
         ] = None,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
@@ -4569,7 +4614,7 @@ class Frame(SyncBase):
                     selector=selector,
                     modifiers=mapping.to_impl(modifiers),
                     position=position,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     force=force,
                     noWaitAfter=no_wait_after,
                     strict=strict,
@@ -4583,7 +4628,7 @@ class Frame(SyncBase):
         selector: str,
         value: str,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
         force: typing.Optional[bool] = None,
@@ -4626,7 +4671,7 @@ class Frame(SyncBase):
                 self._impl_obj.fill(
                     selector=selector,
                     value=value,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     noWaitAfter=no_wait_after,
                     strict=strict,
                     force=force,
@@ -5189,7 +5234,7 @@ class Frame(SyncBase):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """Frame.focus
 
@@ -5211,7 +5256,9 @@ class Frame(SyncBase):
 
         return mapping.from_maybe_impl(
             self._sync(
-                self._impl_obj.focus(selector=selector, strict=strict, timeout=timeout)
+                self._impl_obj.focus(
+                    selector=selector, strict=strict, timeout=to_milliseconds(timeout)
+                )
             )
         )
 
@@ -5220,7 +5267,7 @@ class Frame(SyncBase):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> typing.Optional[str]:
         """Frame.text_content
 
@@ -5246,7 +5293,7 @@ class Frame(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.text_content(
-                    selector=selector, strict=strict, timeout=timeout
+                    selector=selector, strict=strict, timeout=to_milliseconds(timeout)
                 )
             )
         )
@@ -5256,7 +5303,7 @@ class Frame(SyncBase):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> str:
         """Frame.inner_text
 
@@ -5282,7 +5329,7 @@ class Frame(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.inner_text(
-                    selector=selector, strict=strict, timeout=timeout
+                    selector=selector, strict=strict, timeout=to_milliseconds(timeout)
                 )
             )
         )
@@ -5292,7 +5339,7 @@ class Frame(SyncBase):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> str:
         """Frame.inner_html
 
@@ -5318,7 +5365,7 @@ class Frame(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.inner_html(
-                    selector=selector, strict=strict, timeout=timeout
+                    selector=selector, strict=strict, timeout=to_milliseconds(timeout)
                 )
             )
         )
@@ -5329,7 +5376,7 @@ class Frame(SyncBase):
         name: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> typing.Optional[str]:
         """Frame.get_attribute
 
@@ -5357,7 +5404,10 @@ class Frame(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.get_attribute(
-                    selector=selector, name=name, strict=strict, timeout=timeout
+                    selector=selector,
+                    name=name,
+                    strict=strict,
+                    timeout=to_milliseconds(timeout),
                 )
             )
         )
@@ -5370,7 +5420,7 @@ class Frame(SyncBase):
             typing.Sequence[Literal["Alt", "Control", "ControlOrMeta", "Meta", "Shift"]]
         ] = None,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
         force: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
@@ -5424,7 +5474,7 @@ class Frame(SyncBase):
                     selector=selector,
                     modifiers=mapping.to_impl(modifiers),
                     position=position,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     noWaitAfter=no_wait_after,
                     force=force,
                     strict=strict,
@@ -5443,7 +5493,7 @@ class Frame(SyncBase):
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         trial: typing.Optional[bool] = None,
         steps: typing.Optional[int] = None,
     ) -> None:
@@ -5492,7 +5542,7 @@ class Frame(SyncBase):
                     force=force,
                     noWaitAfter=no_wait_after,
                     strict=strict,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     trial=trial,
                     steps=steps,
                 )
@@ -5509,7 +5559,7 @@ class Frame(SyncBase):
         element: typing.Optional[
             typing.Union["ElementHandle", typing.Sequence["ElementHandle"]]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
         force: typing.Optional[bool] = None,
@@ -5578,7 +5628,7 @@ class Frame(SyncBase):
                     index=mapping.to_impl(index),
                     label=mapping.to_impl(label),
                     element=mapping.to_impl(element),
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     noWaitAfter=no_wait_after,
                     strict=strict,
                     force=force,
@@ -5591,7 +5641,7 @@ class Frame(SyncBase):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> str:
         """Frame.input_value
 
@@ -5621,7 +5671,7 @@ class Frame(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.input_value(
-                    selector=selector, strict=strict, timeout=timeout
+                    selector=selector, strict=strict, timeout=to_milliseconds(timeout)
                 )
             )
         )
@@ -5638,7 +5688,7 @@ class Frame(SyncBase):
         ],
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
     ) -> None:
         """Frame.set_input_files
@@ -5674,7 +5724,7 @@ class Frame(SyncBase):
                     selector=selector,
                     files=mapping.to_impl(files),
                     strict=strict,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     noWaitAfter=no_wait_after,
                 )
             )
@@ -5687,7 +5737,7 @@ class Frame(SyncBase):
         *,
         delay: typing.Optional[float] = None,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
     ) -> None:
         """Frame.type
@@ -5726,7 +5776,7 @@ class Frame(SyncBase):
                     text=text,
                     delay=delay,
                     strict=strict,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     noWaitAfter=no_wait_after,
                 )
             )
@@ -5739,7 +5789,7 @@ class Frame(SyncBase):
         *,
         delay: typing.Optional[float] = None,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
     ) -> None:
         """Frame.press
@@ -5793,7 +5843,7 @@ class Frame(SyncBase):
                     key=key,
                     delay=delay,
                     strict=strict,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     noWaitAfter=no_wait_after,
                 )
             )
@@ -5804,7 +5854,7 @@ class Frame(SyncBase):
         selector: str,
         *,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
@@ -5854,7 +5904,7 @@ class Frame(SyncBase):
                 self._impl_obj.check(
                     selector=selector,
                     position=position,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     force=force,
                     noWaitAfter=no_wait_after,
                     strict=strict,
@@ -5868,7 +5918,7 @@ class Frame(SyncBase):
         selector: str,
         *,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
@@ -5918,7 +5968,7 @@ class Frame(SyncBase):
                 self._impl_obj.uncheck(
                     selector=selector,
                     position=position,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     force=force,
                     noWaitAfter=no_wait_after,
                     strict=strict,
@@ -5927,7 +5977,9 @@ class Frame(SyncBase):
             )
         )
 
-    def wait_for_timeout(self, timeout: float) -> None:
+    def wait_for_timeout(
+        self, timeout: typing.Union[float, datetime.timedelta]
+    ) -> None:
         """Frame.wait_for_timeout
 
         Waits for the given `timeout` in milliseconds.
@@ -5942,7 +5994,9 @@ class Frame(SyncBase):
         """
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.wait_for_timeout(timeout=timeout))
+            self._sync(
+                self._impl_obj.wait_for_timeout(timeout=to_milliseconds(timeout))
+            )
         )
 
     def wait_for_function(
@@ -5950,7 +6004,7 @@ class Frame(SyncBase):
         expression: str,
         *,
         arg: typing.Optional[typing.Any] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         polling: typing.Optional[typing.Union[float, Literal["raf"]]] = None,
     ) -> "JSHandle":
         """Frame.wait_for_function
@@ -6009,7 +6063,7 @@ class Frame(SyncBase):
                 self._impl_obj.wait_for_function(
                     expression=expression,
                     arg=mapping.to_impl(arg),
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     polling=polling,
                 )
             )
@@ -6033,7 +6087,7 @@ class Frame(SyncBase):
         checked: bool,
         *,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
@@ -6086,7 +6140,7 @@ class Frame(SyncBase):
                     selector=selector,
                     checked=checked,
                     position=position,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     force=force,
                     noWaitAfter=no_wait_after,
                     strict=strict,
@@ -6830,7 +6884,7 @@ class Worker(SyncBase):
         event: str,
         predicate: typing.Optional[typing.Callable] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> EventContextManager:
         """Worker.expect_event
 
@@ -6862,7 +6916,9 @@ class Worker(SyncBase):
         return EventContextManager(
             self,
             self._impl_obj.expect_event(
-                event=event, predicate=self._wrap_handler(predicate), timeout=timeout
+                event=event,
+                predicate=self._wrap_handler(predicate),
+                timeout=to_milliseconds(timeout),
             ).future,
         )
 
@@ -8380,7 +8436,9 @@ class Page(SyncContextManager):
             self._impl_obj.frame(name=name, url=self._wrap_handler(url))
         )
 
-    def set_default_navigation_timeout(self, timeout: float) -> None:
+    def set_default_navigation_timeout(
+        self, timeout: typing.Union[float, datetime.timedelta]
+    ) -> None:
         """Page.set_default_navigation_timeout
 
         This setting will change the default maximum navigation time for the following methods and related shortcuts:
@@ -8402,10 +8460,14 @@ class Page(SyncContextManager):
         """
 
         return mapping.from_maybe_impl(
-            self._impl_obj.set_default_navigation_timeout(timeout=timeout)
+            self._impl_obj.set_default_navigation_timeout(
+                timeout=to_milliseconds(timeout)
+            )
         )
 
-    def set_default_timeout(self, timeout: float) -> None:
+    def set_default_timeout(
+        self, timeout: typing.Union[float, datetime.timedelta]
+    ) -> None:
         """Page.set_default_timeout
 
         This setting will change the default maximum time for all the methods accepting `timeout` option.
@@ -8419,7 +8481,7 @@ class Page(SyncContextManager):
         """
 
         return mapping.from_maybe_impl(
-            self._impl_obj.set_default_timeout(timeout=timeout)
+            self._impl_obj.set_default_timeout(timeout=to_milliseconds(timeout))
         )
 
     def query_selector(
@@ -8471,7 +8533,7 @@ class Page(SyncContextManager):
         self,
         selector: str,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         state: typing.Optional[
             Literal["attached", "detached", "hidden", "visible"]
         ] = None,
@@ -8537,7 +8599,10 @@ class Page(SyncContextManager):
         return mapping.from_impl_nullable(
             self._sync(
                 self._impl_obj.wait_for_selector(
-                    selector=selector, timeout=timeout, state=state, strict=strict
+                    selector=selector,
+                    timeout=to_milliseconds(timeout),
+                    state=state,
+                    strict=strict,
                 )
             )
         )
@@ -8547,7 +8612,7 @@ class Page(SyncContextManager):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> bool:
         """Page.is_checked
 
@@ -8573,7 +8638,7 @@ class Page(SyncContextManager):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.is_checked(
-                    selector=selector, strict=strict, timeout=timeout
+                    selector=selector, strict=strict, timeout=to_milliseconds(timeout)
                 )
             )
         )
@@ -8583,7 +8648,7 @@ class Page(SyncContextManager):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> bool:
         """Page.is_disabled
 
@@ -8609,7 +8674,7 @@ class Page(SyncContextManager):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.is_disabled(
-                    selector=selector, strict=strict, timeout=timeout
+                    selector=selector, strict=strict, timeout=to_milliseconds(timeout)
                 )
             )
         )
@@ -8619,7 +8684,7 @@ class Page(SyncContextManager):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> bool:
         """Page.is_editable
 
@@ -8645,7 +8710,7 @@ class Page(SyncContextManager):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.is_editable(
-                    selector=selector, strict=strict, timeout=timeout
+                    selector=selector, strict=strict, timeout=to_milliseconds(timeout)
                 )
             )
         )
@@ -8655,7 +8720,7 @@ class Page(SyncContextManager):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> bool:
         """Page.is_enabled
 
@@ -8681,7 +8746,7 @@ class Page(SyncContextManager):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.is_enabled(
-                    selector=selector, strict=strict, timeout=timeout
+                    selector=selector, strict=strict, timeout=to_milliseconds(timeout)
                 )
             )
         )
@@ -8691,7 +8756,7 @@ class Page(SyncContextManager):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> bool:
         """Page.is_hidden
 
@@ -8717,7 +8782,7 @@ class Page(SyncContextManager):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.is_hidden(
-                    selector=selector, strict=strict, timeout=timeout
+                    selector=selector, strict=strict, timeout=to_milliseconds(timeout)
                 )
             )
         )
@@ -8727,7 +8792,7 @@ class Page(SyncContextManager):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> bool:
         """Page.is_visible
 
@@ -8753,7 +8818,7 @@ class Page(SyncContextManager):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.is_visible(
-                    selector=selector, strict=strict, timeout=timeout
+                    selector=selector, strict=strict, timeout=to_milliseconds(timeout)
                 )
             )
         )
@@ -8764,7 +8829,7 @@ class Page(SyncContextManager):
         type: str,
         event_init: typing.Optional[typing.Dict] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         strict: typing.Optional[bool] = None,
     ) -> None:
         """Page.dispatch_event
@@ -8825,7 +8890,7 @@ class Page(SyncContextManager):
                     selector=selector,
                     type=type,
                     eventInit=mapping.to_impl(event_init),
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     strict=strict,
                 )
             )
@@ -9284,7 +9349,7 @@ class Page(SyncContextManager):
         self,
         html: str,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         wait_until: typing.Optional[
             Literal["commit", "domcontentloaded", "load", "networkidle"]
         ] = None,
@@ -9316,7 +9381,7 @@ class Page(SyncContextManager):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.set_content(
-                    html=html, timeout=timeout, waitUntil=wait_until
+                    html=html, timeout=to_milliseconds(timeout), waitUntil=wait_until
                 )
             )
         )
@@ -9325,7 +9390,7 @@ class Page(SyncContextManager):
         self,
         url: str,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         wait_until: typing.Optional[
             Literal["commit", "domcontentloaded", "load", "networkidle"]
         ] = None,
@@ -9384,7 +9449,10 @@ class Page(SyncContextManager):
         return mapping.from_impl_nullable(
             self._sync(
                 self._impl_obj.goto(
-                    url=url, timeout=timeout, waitUntil=wait_until, referer=referer
+                    url=url,
+                    timeout=to_milliseconds(timeout),
+                    waitUntil=wait_until,
+                    referer=referer,
                 )
             )
         )
@@ -9392,7 +9460,7 @@ class Page(SyncContextManager):
     def reload(
         self,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         wait_until: typing.Optional[
             Literal["commit", "domcontentloaded", "load", "networkidle"]
         ] = None,
@@ -9425,7 +9493,11 @@ class Page(SyncContextManager):
         """
 
         return mapping.from_impl_nullable(
-            self._sync(self._impl_obj.reload(timeout=timeout, waitUntil=wait_until))
+            self._sync(
+                self._impl_obj.reload(
+                    timeout=to_milliseconds(timeout), waitUntil=wait_until
+                )
+            )
         )
 
     def wait_for_load_state(
@@ -9434,7 +9506,7 @@ class Page(SyncContextManager):
             Literal["domcontentloaded", "load", "networkidle"]
         ] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """Page.wait_for_load_state
 
@@ -9480,7 +9552,11 @@ class Page(SyncContextManager):
         """
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.wait_for_load_state(state=state, timeout=timeout))
+            self._sync(
+                self._impl_obj.wait_for_load_state(
+                    state=state, timeout=to_milliseconds(timeout)
+                )
+            )
         )
 
     def wait_for_url(
@@ -9490,7 +9566,7 @@ class Page(SyncContextManager):
         wait_until: typing.Optional[
             Literal["commit", "domcontentloaded", "load", "networkidle"]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """Page.wait_for_url
 
@@ -9527,7 +9603,9 @@ class Page(SyncContextManager):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.wait_for_url(
-                    url=self._wrap_handler(url), waitUntil=wait_until, timeout=timeout
+                    url=self._wrap_handler(url),
+                    waitUntil=wait_until,
+                    timeout=to_milliseconds(timeout),
                 )
             )
         )
@@ -9537,7 +9615,7 @@ class Page(SyncContextManager):
         event: str,
         predicate: typing.Optional[typing.Callable] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> typing.Any:
         """Page.wait_for_event
 
@@ -9567,7 +9645,7 @@ class Page(SyncContextManager):
                 self._impl_obj.wait_for_event(
                     event=event,
                     predicate=self._wrap_handler(predicate),
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                 )
             )
         )
@@ -9575,7 +9653,7 @@ class Page(SyncContextManager):
     def go_back(
         self,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         wait_until: typing.Optional[
             Literal["commit", "domcontentloaded", "load", "networkidle"]
         ] = None,
@@ -9609,13 +9687,17 @@ class Page(SyncContextManager):
         """
 
         return mapping.from_impl_nullable(
-            self._sync(self._impl_obj.go_back(timeout=timeout, waitUntil=wait_until))
+            self._sync(
+                self._impl_obj.go_back(
+                    timeout=to_milliseconds(timeout), waitUntil=wait_until
+                )
+            )
         )
 
     def go_forward(
         self,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         wait_until: typing.Optional[
             Literal["commit", "domcontentloaded", "load", "networkidle"]
         ] = None,
@@ -9649,7 +9731,11 @@ class Page(SyncContextManager):
         """
 
         return mapping.from_impl_nullable(
-            self._sync(self._impl_obj.go_forward(timeout=timeout, waitUntil=wait_until))
+            self._sync(
+                self._impl_obj.go_forward(
+                    timeout=to_milliseconds(timeout), waitUntil=wait_until
+                )
+            )
         )
 
     def request_gc(self) -> None:
@@ -10083,7 +10169,7 @@ class Page(SyncContextManager):
     def screenshot(
         self,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         type: typing.Optional[Literal["jpeg", "png"]] = None,
         path: typing.Optional[typing.Union[pathlib.Path, str]] = None,
         quality: typing.Optional[int] = None,
@@ -10159,7 +10245,7 @@ class Page(SyncContextManager):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.screenshot(
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     type=type,
                     path=path,
                     quality=quality,
@@ -10191,7 +10277,7 @@ class Page(SyncContextManager):
     def aria_snapshot(
         self,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         depth: typing.Optional[int] = None,
         mode: typing.Optional[Literal["ai", "default"]] = None,
     ) -> str:
@@ -10217,7 +10303,9 @@ class Page(SyncContextManager):
 
         return mapping.from_maybe_impl(
             self._sync(
-                self._impl_obj.aria_snapshot(timeout=timeout, depth=depth, mode=mode)
+                self._impl_obj.aria_snapshot(
+                    timeout=to_milliseconds(timeout), depth=depth, mode=mode
+                )
             )
         )
 
@@ -10275,7 +10363,7 @@ class Page(SyncContextManager):
         delay: typing.Optional[float] = None,
         button: typing.Optional[Literal["left", "middle", "right"]] = None,
         click_count: typing.Optional[int] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
@@ -10341,7 +10429,7 @@ class Page(SyncContextManager):
                     delay=delay,
                     button=button,
                     clickCount=click_count,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     force=force,
                     noWaitAfter=no_wait_after,
                     trial=trial,
@@ -10360,7 +10448,7 @@ class Page(SyncContextManager):
         position: typing.Optional[Position] = None,
         delay: typing.Optional[float] = None,
         button: typing.Optional[Literal["left", "middle", "right"]] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
@@ -10422,7 +10510,7 @@ class Page(SyncContextManager):
                     position=position,
                     delay=delay,
                     button=button,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     force=force,
                     noWaitAfter=no_wait_after,
                     strict=strict,
@@ -10439,7 +10527,7 @@ class Page(SyncContextManager):
             typing.Sequence[Literal["Alt", "Control", "ControlOrMeta", "Meta", "Shift"]]
         ] = None,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
@@ -10495,7 +10583,7 @@ class Page(SyncContextManager):
                     selector=selector,
                     modifiers=mapping.to_impl(modifiers),
                     position=position,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     force=force,
                     noWaitAfter=no_wait_after,
                     strict=strict,
@@ -10509,7 +10597,7 @@ class Page(SyncContextManager):
         selector: str,
         value: str,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
         force: typing.Optional[bool] = None,
@@ -10552,7 +10640,7 @@ class Page(SyncContextManager):
                 self._impl_obj.fill(
                     selector=selector,
                     value=value,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     noWaitAfter=no_wait_after,
                     strict=strict,
                     force=force,
@@ -11113,7 +11201,7 @@ class Page(SyncContextManager):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """Page.focus
 
@@ -11135,7 +11223,9 @@ class Page(SyncContextManager):
 
         return mapping.from_maybe_impl(
             self._sync(
-                self._impl_obj.focus(selector=selector, strict=strict, timeout=timeout)
+                self._impl_obj.focus(
+                    selector=selector, strict=strict, timeout=to_milliseconds(timeout)
+                )
             )
         )
 
@@ -11144,7 +11234,7 @@ class Page(SyncContextManager):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> typing.Optional[str]:
         """Page.text_content
 
@@ -11170,7 +11260,7 @@ class Page(SyncContextManager):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.text_content(
-                    selector=selector, strict=strict, timeout=timeout
+                    selector=selector, strict=strict, timeout=to_milliseconds(timeout)
                 )
             )
         )
@@ -11180,7 +11270,7 @@ class Page(SyncContextManager):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> str:
         """Page.inner_text
 
@@ -11206,7 +11296,7 @@ class Page(SyncContextManager):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.inner_text(
-                    selector=selector, strict=strict, timeout=timeout
+                    selector=selector, strict=strict, timeout=to_milliseconds(timeout)
                 )
             )
         )
@@ -11216,7 +11306,7 @@ class Page(SyncContextManager):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> str:
         """Page.inner_html
 
@@ -11242,7 +11332,7 @@ class Page(SyncContextManager):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.inner_html(
-                    selector=selector, strict=strict, timeout=timeout
+                    selector=selector, strict=strict, timeout=to_milliseconds(timeout)
                 )
             )
         )
@@ -11253,7 +11343,7 @@ class Page(SyncContextManager):
         name: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> typing.Optional[str]:
         """Page.get_attribute
 
@@ -11281,7 +11371,10 @@ class Page(SyncContextManager):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.get_attribute(
-                    selector=selector, name=name, strict=strict, timeout=timeout
+                    selector=selector,
+                    name=name,
+                    strict=strict,
+                    timeout=to_milliseconds(timeout),
                 )
             )
         )
@@ -11294,7 +11387,7 @@ class Page(SyncContextManager):
             typing.Sequence[Literal["Alt", "Control", "ControlOrMeta", "Meta", "Shift"]]
         ] = None,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
         force: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
@@ -11348,7 +11441,7 @@ class Page(SyncContextManager):
                     selector=selector,
                     modifiers=mapping.to_impl(modifiers),
                     position=position,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     noWaitAfter=no_wait_after,
                     force=force,
                     strict=strict,
@@ -11366,7 +11459,7 @@ class Page(SyncContextManager):
         target_position: typing.Optional[Position] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         strict: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
         steps: typing.Optional[int] = None,
@@ -11431,7 +11524,7 @@ class Page(SyncContextManager):
                     targetPosition=target_position,
                     force=force,
                     noWaitAfter=no_wait_after,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     strict=strict,
                     trial=trial,
                     steps=steps,
@@ -11449,7 +11542,7 @@ class Page(SyncContextManager):
         element: typing.Optional[
             typing.Union["ElementHandle", typing.Sequence["ElementHandle"]]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
         force: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
@@ -11519,7 +11612,7 @@ class Page(SyncContextManager):
                     index=mapping.to_impl(index),
                     label=mapping.to_impl(label),
                     element=mapping.to_impl(element),
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     noWaitAfter=no_wait_after,
                     force=force,
                     strict=strict,
@@ -11532,7 +11625,7 @@ class Page(SyncContextManager):
         selector: str,
         *,
         strict: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> str:
         """Page.input_value
 
@@ -11562,7 +11655,7 @@ class Page(SyncContextManager):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.input_value(
-                    selector=selector, strict=strict, timeout=timeout
+                    selector=selector, strict=strict, timeout=to_milliseconds(timeout)
                 )
             )
         )
@@ -11578,7 +11671,7 @@ class Page(SyncContextManager):
             typing.Sequence[FilePayload],
         ],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         strict: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
     ) -> None:
@@ -11615,7 +11708,7 @@ class Page(SyncContextManager):
                 self._impl_obj.set_input_files(
                     selector=selector,
                     files=mapping.to_impl(files),
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     strict=strict,
                     noWaitAfter=no_wait_after,
                 )
@@ -11628,7 +11721,7 @@ class Page(SyncContextManager):
         text: str,
         *,
         delay: typing.Optional[float] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
     ) -> None:
@@ -11667,7 +11760,7 @@ class Page(SyncContextManager):
                     selector=selector,
                     text=text,
                     delay=delay,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     noWaitAfter=no_wait_after,
                     strict=strict,
                 )
@@ -11680,7 +11773,7 @@ class Page(SyncContextManager):
         key: str,
         *,
         delay: typing.Optional[float] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
     ) -> None:
@@ -11750,7 +11843,7 @@ class Page(SyncContextManager):
                     selector=selector,
                     key=key,
                     delay=delay,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     noWaitAfter=no_wait_after,
                     strict=strict,
                 )
@@ -11762,7 +11855,7 @@ class Page(SyncContextManager):
         selector: str,
         *,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
@@ -11812,7 +11905,7 @@ class Page(SyncContextManager):
                 self._impl_obj.check(
                     selector=selector,
                     position=position,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     force=force,
                     noWaitAfter=no_wait_after,
                     strict=strict,
@@ -11826,7 +11919,7 @@ class Page(SyncContextManager):
         selector: str,
         *,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
@@ -11876,7 +11969,7 @@ class Page(SyncContextManager):
                 self._impl_obj.uncheck(
                     selector=selector,
                     position=position,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     force=force,
                     noWaitAfter=no_wait_after,
                     strict=strict,
@@ -11885,7 +11978,9 @@ class Page(SyncContextManager):
             )
         )
 
-    def wait_for_timeout(self, timeout: float) -> None:
+    def wait_for_timeout(
+        self, timeout: typing.Union[float, datetime.timedelta]
+    ) -> None:
         """Page.wait_for_timeout
 
         Waits for the given `timeout` in milliseconds.
@@ -11907,7 +12002,9 @@ class Page(SyncContextManager):
         """
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.wait_for_timeout(timeout=timeout))
+            self._sync(
+                self._impl_obj.wait_for_timeout(timeout=to_milliseconds(timeout))
+            )
         )
 
     def wait_for_function(
@@ -11915,7 +12012,7 @@ class Page(SyncContextManager):
         expression: str,
         *,
         arg: typing.Optional[typing.Any] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         polling: typing.Optional[typing.Union[float, Literal["raf"]]] = None,
     ) -> "JSHandle":
         """Page.wait_for_function
@@ -11974,7 +12071,7 @@ class Page(SyncContextManager):
                 self._impl_obj.wait_for_function(
                     expression=expression,
                     arg=mapping.to_impl(arg),
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     polling=polling,
                 )
             )
@@ -12135,7 +12232,7 @@ class Page(SyncContextManager):
         event: str,
         predicate: typing.Optional[typing.Callable] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> EventContextManager:
         """Page.expect_event
 
@@ -12167,7 +12264,9 @@ class Page(SyncContextManager):
         return EventContextManager(
             self,
             self._impl_obj.expect_event(
-                event=event, predicate=self._wrap_handler(predicate), timeout=timeout
+                event=event,
+                predicate=self._wrap_handler(predicate),
+                timeout=to_milliseconds(timeout),
             ).future,
         )
 
@@ -12175,7 +12274,7 @@ class Page(SyncContextManager):
         self,
         predicate: typing.Optional[typing.Callable[["ConsoleMessage"], bool]] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> EventContextManager["ConsoleMessage"]:
         """Page.expect_console_message
 
@@ -12198,7 +12297,8 @@ class Page(SyncContextManager):
         return EventContextManager(
             self,
             self._impl_obj.expect_console_message(
-                predicate=self._wrap_handler(predicate), timeout=timeout
+                predicate=self._wrap_handler(predicate),
+                timeout=to_milliseconds(timeout),
             ).future,
         )
 
@@ -12206,7 +12306,7 @@ class Page(SyncContextManager):
         self,
         predicate: typing.Optional[typing.Callable[["Download"], bool]] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> EventContextManager["Download"]:
         """Page.expect_download
 
@@ -12229,7 +12329,8 @@ class Page(SyncContextManager):
         return EventContextManager(
             self,
             self._impl_obj.expect_download(
-                predicate=self._wrap_handler(predicate), timeout=timeout
+                predicate=self._wrap_handler(predicate),
+                timeout=to_milliseconds(timeout),
             ).future,
         )
 
@@ -12237,7 +12338,7 @@ class Page(SyncContextManager):
         self,
         predicate: typing.Optional[typing.Callable[["FileChooser"], bool]] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> EventContextManager["FileChooser"]:
         """Page.expect_file_chooser
 
@@ -12260,7 +12361,8 @@ class Page(SyncContextManager):
         return EventContextManager(
             self,
             self._impl_obj.expect_file_chooser(
-                predicate=self._wrap_handler(predicate), timeout=timeout
+                predicate=self._wrap_handler(predicate),
+                timeout=to_milliseconds(timeout),
             ).future,
         )
 
@@ -12273,7 +12375,7 @@ class Page(SyncContextManager):
         wait_until: typing.Optional[
             Literal["commit", "domcontentloaded", "load", "networkidle"]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> EventContextManager["Response"]:
         """Page.expect_navigation
 
@@ -12324,7 +12426,9 @@ class Page(SyncContextManager):
         return EventContextManager(
             self,
             self._impl_obj.expect_navigation(
-                url=self._wrap_handler(url), waitUntil=wait_until, timeout=timeout
+                url=self._wrap_handler(url),
+                waitUntil=wait_until,
+                timeout=to_milliseconds(timeout),
             ).future,
         )
 
@@ -12332,7 +12436,7 @@ class Page(SyncContextManager):
         self,
         predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> EventContextManager["Page"]:
         """Page.expect_popup
 
@@ -12355,7 +12459,8 @@ class Page(SyncContextManager):
         return EventContextManager(
             self,
             self._impl_obj.expect_popup(
-                predicate=self._wrap_handler(predicate), timeout=timeout
+                predicate=self._wrap_handler(predicate),
+                timeout=to_milliseconds(timeout),
             ).future,
         )
 
@@ -12365,7 +12470,7 @@ class Page(SyncContextManager):
             str, typing.Pattern[str], typing.Callable[["Request"], bool]
         ],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> EventContextManager["Request"]:
         """Page.expect_request
 
@@ -12402,7 +12507,8 @@ class Page(SyncContextManager):
         return EventContextManager(
             self,
             self._impl_obj.expect_request(
-                urlOrPredicate=self._wrap_handler(url_or_predicate), timeout=timeout
+                urlOrPredicate=self._wrap_handler(url_or_predicate),
+                timeout=to_milliseconds(timeout),
             ).future,
         )
 
@@ -12410,7 +12516,7 @@ class Page(SyncContextManager):
         self,
         predicate: typing.Optional[typing.Callable[["Request"], bool]] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> EventContextManager["Request"]:
         """Page.expect_request_finished
 
@@ -12433,7 +12539,8 @@ class Page(SyncContextManager):
         return EventContextManager(
             self,
             self._impl_obj.expect_request_finished(
-                predicate=self._wrap_handler(predicate), timeout=timeout
+                predicate=self._wrap_handler(predicate),
+                timeout=to_milliseconds(timeout),
             ).future,
         )
 
@@ -12443,7 +12550,7 @@ class Page(SyncContextManager):
             str, typing.Pattern[str], typing.Callable[["Response"], bool]
         ],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> EventContextManager["Response"]:
         """Page.expect_response
 
@@ -12482,7 +12589,8 @@ class Page(SyncContextManager):
         return EventContextManager(
             self,
             self._impl_obj.expect_response(
-                urlOrPredicate=self._wrap_handler(url_or_predicate), timeout=timeout
+                urlOrPredicate=self._wrap_handler(url_or_predicate),
+                timeout=to_milliseconds(timeout),
             ).future,
         )
 
@@ -12490,7 +12598,7 @@ class Page(SyncContextManager):
         self,
         predicate: typing.Optional[typing.Callable[["WebSocket"], bool]] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> EventContextManager["WebSocket"]:
         """Page.expect_websocket
 
@@ -12513,7 +12621,8 @@ class Page(SyncContextManager):
         return EventContextManager(
             self,
             self._impl_obj.expect_websocket(
-                predicate=self._wrap_handler(predicate), timeout=timeout
+                predicate=self._wrap_handler(predicate),
+                timeout=to_milliseconds(timeout),
             ).future,
         )
 
@@ -12521,7 +12630,7 @@ class Page(SyncContextManager):
         self,
         predicate: typing.Optional[typing.Callable[["Worker"], bool]] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> EventContextManager["Worker"]:
         """Page.expect_worker
 
@@ -12544,7 +12653,8 @@ class Page(SyncContextManager):
         return EventContextManager(
             self,
             self._impl_obj.expect_worker(
-                predicate=self._wrap_handler(predicate), timeout=timeout
+                predicate=self._wrap_handler(predicate),
+                timeout=to_milliseconds(timeout),
             ).future,
         )
 
@@ -12554,7 +12664,7 @@ class Page(SyncContextManager):
         checked: bool,
         *,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         strict: typing.Optional[bool] = None,
@@ -12607,7 +12717,7 @@ class Page(SyncContextManager):
                     selector=selector,
                     checked=checked,
                     position=position,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     force=force,
                     noWaitAfter=no_wait_after,
                     strict=strict,
@@ -13281,7 +13391,9 @@ class BrowserContext(SyncContextManager):
         """
         return mapping.from_impl(self._impl_obj.clock)
 
-    def set_default_navigation_timeout(self, timeout: float) -> None:
+    def set_default_navigation_timeout(
+        self, timeout: typing.Union[float, datetime.timedelta]
+    ) -> None:
         """BrowserContext.set_default_navigation_timeout
 
         This setting will change the default maximum navigation time for the following methods and related shortcuts:
@@ -13302,10 +13414,14 @@ class BrowserContext(SyncContextManager):
         """
 
         return mapping.from_maybe_impl(
-            self._impl_obj.set_default_navigation_timeout(timeout=timeout)
+            self._impl_obj.set_default_navigation_timeout(
+                timeout=to_milliseconds(timeout)
+            )
         )
 
-    def set_default_timeout(self, timeout: float) -> None:
+    def set_default_timeout(
+        self, timeout: typing.Union[float, datetime.timedelta]
+    ) -> None:
         """BrowserContext.set_default_timeout
 
         This setting will change the default maximum time for all the methods accepting `timeout` option.
@@ -13321,7 +13437,7 @@ class BrowserContext(SyncContextManager):
         """
 
         return mapping.from_maybe_impl(
-            self._impl_obj.set_default_timeout(timeout=timeout)
+            self._impl_obj.set_default_timeout(timeout=to_milliseconds(timeout))
         )
 
     def new_page(self) -> "Page":
@@ -13972,7 +14088,7 @@ class BrowserContext(SyncContextManager):
         event: str,
         predicate: typing.Optional[typing.Callable] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> EventContextManager:
         """BrowserContext.expect_event
 
@@ -14004,7 +14120,9 @@ class BrowserContext(SyncContextManager):
         return EventContextManager(
             self,
             self._impl_obj.expect_event(
-                event=event, predicate=self._wrap_handler(predicate), timeout=timeout
+                event=event,
+                predicate=self._wrap_handler(predicate),
+                timeout=to_milliseconds(timeout),
             ).future,
         )
 
@@ -14097,7 +14215,7 @@ class BrowserContext(SyncContextManager):
         event: str,
         predicate: typing.Optional[typing.Callable] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> typing.Any:
         """BrowserContext.wait_for_event
 
@@ -14127,7 +14245,7 @@ class BrowserContext(SyncContextManager):
                 self._impl_obj.wait_for_event(
                     event=event,
                     predicate=self._wrap_handler(predicate),
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                 )
             )
         )
@@ -14136,7 +14254,7 @@ class BrowserContext(SyncContextManager):
         self,
         predicate: typing.Optional[typing.Callable[["ConsoleMessage"], bool]] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> EventContextManager["ConsoleMessage"]:
         """BrowserContext.expect_console_message
 
@@ -14160,7 +14278,8 @@ class BrowserContext(SyncContextManager):
         return EventContextManager(
             self,
             self._impl_obj.expect_console_message(
-                predicate=self._wrap_handler(predicate), timeout=timeout
+                predicate=self._wrap_handler(predicate),
+                timeout=to_milliseconds(timeout),
             ).future,
         )
 
@@ -14168,7 +14287,7 @@ class BrowserContext(SyncContextManager):
         self,
         predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> EventContextManager["Page"]:
         """BrowserContext.expect_page
 
@@ -14191,7 +14310,8 @@ class BrowserContext(SyncContextManager):
         return EventContextManager(
             self,
             self._impl_obj.expect_page(
-                predicate=self._wrap_handler(predicate), timeout=timeout
+                predicate=self._wrap_handler(predicate),
+                timeout=to_milliseconds(timeout),
             ).future,
         )
 
@@ -15056,7 +15176,7 @@ class BrowserType(SyncBase):
         handle_sigint: typing.Optional[bool] = None,
         handle_sigterm: typing.Optional[bool] = None,
         handle_sighup: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         env: typing.Optional[typing.Dict[str, typing.Union[str, float, bool]]] = None,
         headless: typing.Optional[bool] = None,
         proxy: typing.Optional[ProxySettings] = None,
@@ -15173,7 +15293,7 @@ class BrowserType(SyncBase):
                     handleSIGINT=handle_sigint,
                     handleSIGTERM=handle_sigterm,
                     handleSIGHUP=handle_sighup,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     env=mapping.to_impl(env),
                     headless=headless,
                     proxy=proxy,
@@ -15200,7 +15320,7 @@ class BrowserType(SyncBase):
         handle_sigint: typing.Optional[bool] = None,
         handle_sigterm: typing.Optional[bool] = None,
         handle_sighup: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         env: typing.Optional[typing.Dict[str, typing.Union[str, float, bool]]] = None,
         headless: typing.Optional[bool] = None,
         proxy: typing.Optional[ProxySettings] = None,
@@ -15475,7 +15595,7 @@ class BrowserType(SyncBase):
                     handleSIGINT=handle_sigint,
                     handleSIGTERM=handle_sigterm,
                     handleSIGHUP=handle_sighup,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     env=mapping.to_impl(env),
                     headless=headless,
                     proxy=proxy,
@@ -15526,7 +15646,7 @@ class BrowserType(SyncBase):
         self,
         endpoint_url: str,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         slow_mo: typing.Optional[float] = None,
         headers: typing.Optional[typing.Dict[str, str]] = None,
         is_local: typing.Optional[bool] = None,
@@ -15577,7 +15697,7 @@ class BrowserType(SyncBase):
             self._sync(
                 self._impl_obj.connect_over_cdp(
                     endpointURL=endpoint_url,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     slowMo=slow_mo,
                     headers=mapping.to_impl(headers),
                     isLocal=is_local,
@@ -15589,7 +15709,7 @@ class BrowserType(SyncBase):
         self,
         endpoint: str,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         slow_mo: typing.Optional[float] = None,
         headers: typing.Optional[typing.Dict[str, str]] = None,
         expose_network: typing.Optional[str] = None,
@@ -15636,7 +15756,7 @@ class BrowserType(SyncBase):
             self._sync(
                 self._impl_obj.connect(
                     endpoint=endpoint,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     slowMo=slow_mo,
                     headers=mapping.to_impl(headers),
                     exposeNetwork=expose_network,
@@ -16055,7 +16175,9 @@ class Locator(SyncBase):
         return mapping.from_maybe_impl(self._impl_obj.description)
 
     def bounding_box(
-        self, *, timeout: typing.Optional[float] = None
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> typing.Optional[FloatRect]:
         """Locator.bounding_box
 
@@ -16094,14 +16216,14 @@ class Locator(SyncBase):
         """
 
         return mapping.from_impl_nullable(
-            self._sync(self._impl_obj.bounding_box(timeout=timeout))
+            self._sync(self._impl_obj.bounding_box(timeout=to_milliseconds(timeout)))
         )
 
     def check(
         self,
         *,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
@@ -16153,7 +16275,7 @@ class Locator(SyncBase):
             self._sync(
                 self._impl_obj.check(
                     position=position,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     force=force,
                     noWaitAfter=no_wait_after,
                     trial=trial,
@@ -16171,7 +16293,7 @@ class Locator(SyncBase):
         delay: typing.Optional[float] = None,
         button: typing.Optional[Literal["left", "middle", "right"]] = None,
         click_count: typing.Optional[int] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
@@ -16253,7 +16375,7 @@ class Locator(SyncBase):
                     delay=delay,
                     button=button,
                     clickCount=click_count,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     force=force,
                     noWaitAfter=no_wait_after,
                     trial=trial,
@@ -16271,7 +16393,7 @@ class Locator(SyncBase):
         position: typing.Optional[Position] = None,
         delay: typing.Optional[float] = None,
         button: typing.Optional[Literal["left", "middle", "right"]] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
@@ -16333,7 +16455,7 @@ class Locator(SyncBase):
                     position=position,
                     delay=delay,
                     button=button,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     force=force,
                     noWaitAfter=no_wait_after,
                     trial=trial,
@@ -16347,7 +16469,7 @@ class Locator(SyncBase):
         type: str,
         event_init: typing.Optional[typing.Dict] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """Locator.dispatch_event
 
@@ -16401,7 +16523,9 @@ class Locator(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.dispatch_event(
-                    type=type, eventInit=mapping.to_impl(event_init), timeout=timeout
+                    type=type,
+                    eventInit=mapping.to_impl(event_init),
+                    timeout=to_milliseconds(timeout),
                 )
             )
         )
@@ -16411,7 +16535,7 @@ class Locator(SyncBase):
         expression: str,
         arg: typing.Optional[typing.Any] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> typing.Any:
         """Locator.evaluate
 
@@ -16454,7 +16578,9 @@ class Locator(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.evaluate(
-                    expression=expression, arg=mapping.to_impl(arg), timeout=timeout
+                    expression=expression,
+                    arg=mapping.to_impl(arg),
+                    timeout=to_milliseconds(timeout),
                 )
             )
         )
@@ -16508,7 +16634,7 @@ class Locator(SyncBase):
         expression: str,
         arg: typing.Optional[typing.Any] = None,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> "JSHandle":
         """Locator.evaluate_handle
 
@@ -16548,7 +16674,9 @@ class Locator(SyncBase):
         return mapping.from_impl(
             self._sync(
                 self._impl_obj.evaluate_handle(
-                    expression=expression, arg=mapping.to_impl(arg), timeout=timeout
+                    expression=expression,
+                    arg=mapping.to_impl(arg),
+                    timeout=to_milliseconds(timeout),
                 )
             )
         )
@@ -16557,7 +16685,7 @@ class Locator(SyncBase):
         self,
         value: str,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
         force: typing.Optional[bool] = None,
     ) -> None:
@@ -16600,7 +16728,10 @@ class Locator(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.fill(
-                    value=value, timeout=timeout, noWaitAfter=no_wait_after, force=force
+                    value=value,
+                    timeout=to_milliseconds(timeout),
+                    noWaitAfter=no_wait_after,
+                    force=force,
                 )
             )
         )
@@ -16608,7 +16739,7 @@ class Locator(SyncBase):
     def clear(
         self,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
         force: typing.Optional[bool] = None,
     ) -> None:
@@ -16647,7 +16778,9 @@ class Locator(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.clear(
-                    timeout=timeout, noWaitAfter=no_wait_after, force=force
+                    timeout=to_milliseconds(timeout),
+                    noWaitAfter=no_wait_after,
+                    force=force,
                 )
             )
         )
@@ -17197,7 +17330,9 @@ class Locator(SyncBase):
         return mapping.from_impl(self._impl_obj.frame_locator(selector=selector))
 
     def element_handle(
-        self, *, timeout: typing.Optional[float] = None
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> "ElementHandle":
         """Locator.element_handle
 
@@ -17216,7 +17351,7 @@ class Locator(SyncBase):
         """
 
         return mapping.from_impl(
-            self._sync(self._impl_obj.element_handle(timeout=timeout))
+            self._sync(self._impl_obj.element_handle(timeout=to_milliseconds(timeout)))
         )
 
     def element_handles(self) -> typing.List["ElementHandle"]:
@@ -17407,7 +17542,11 @@ class Locator(SyncBase):
 
         return mapping.from_impl(self._impl_obj.and_(locator=locator._impl_obj))
 
-    def focus(self, *, timeout: typing.Optional[float] = None) -> None:
+    def focus(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> None:
         """Locator.focus
 
         Calls [focus](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus) on the matching element.
@@ -17420,10 +17559,14 @@ class Locator(SyncBase):
         """
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.focus(timeout=timeout))
+            self._sync(self._impl_obj.focus(timeout=to_milliseconds(timeout)))
         )
 
-    def blur(self, *, timeout: typing.Optional[float] = None) -> None:
+    def blur(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> None:
         """Locator.blur
 
         Calls [blur](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/blur) on the element.
@@ -17435,7 +17578,9 @@ class Locator(SyncBase):
             be changed by using the `browser_context.set_default_timeout()` or `page.set_default_timeout()` methods.
         """
 
-        return mapping.from_maybe_impl(self._sync(self._impl_obj.blur(timeout=timeout)))
+        return mapping.from_maybe_impl(
+            self._sync(self._impl_obj.blur(timeout=to_milliseconds(timeout)))
+        )
 
     def all(self) -> typing.List["Locator"]:
         """Locator.all
@@ -17493,7 +17638,7 @@ class Locator(SyncBase):
         *,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         trial: typing.Optional[bool] = None,
         source_position: typing.Optional[Position] = None,
         target_position: typing.Optional[Position] = None,
@@ -17555,7 +17700,7 @@ class Locator(SyncBase):
                     target=target._impl_obj,
                     force=force,
                     noWaitAfter=no_wait_after,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     trial=trial,
                     sourcePosition=source_position,
                     targetPosition=target_position,
@@ -17565,7 +17710,10 @@ class Locator(SyncBase):
         )
 
     def get_attribute(
-        self, name: str, *, timeout: typing.Optional[float] = None
+        self,
+        name: str,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> typing.Optional[str]:
         """Locator.get_attribute
 
@@ -17588,7 +17736,11 @@ class Locator(SyncBase):
         """
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.get_attribute(name=name, timeout=timeout))
+            self._sync(
+                self._impl_obj.get_attribute(
+                    name=name, timeout=to_milliseconds(timeout)
+                )
+            )
         )
 
     def hover(
@@ -17598,7 +17750,7 @@ class Locator(SyncBase):
             typing.Sequence[Literal["Alt", "Control", "ControlOrMeta", "Meta", "Shift"]]
         ] = None,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
         force: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
@@ -17654,7 +17806,7 @@ class Locator(SyncBase):
                 self._impl_obj.hover(
                     modifiers=mapping.to_impl(modifiers),
                     position=position,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     noWaitAfter=no_wait_after,
                     force=force,
                     trial=trial,
@@ -17662,7 +17814,11 @@ class Locator(SyncBase):
             )
         )
 
-    def inner_html(self, *, timeout: typing.Optional[float] = None) -> str:
+    def inner_html(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> str:
         """Locator.inner_html
 
         Returns the [`element.innerHTML`](https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML).
@@ -17679,10 +17835,14 @@ class Locator(SyncBase):
         """
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.inner_html(timeout=timeout))
+            self._sync(self._impl_obj.inner_html(timeout=to_milliseconds(timeout)))
         )
 
-    def inner_text(self, *, timeout: typing.Optional[float] = None) -> str:
+    def inner_text(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> str:
         """Locator.inner_text
 
         Returns the [`element.innerText`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/innerText).
@@ -17702,10 +17862,14 @@ class Locator(SyncBase):
         """
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.inner_text(timeout=timeout))
+            self._sync(self._impl_obj.inner_text(timeout=to_milliseconds(timeout)))
         )
 
-    def input_value(self, *, timeout: typing.Optional[float] = None) -> str:
+    def input_value(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> str:
         """Locator.input_value
 
         Returns the value for the matching `<input>` or `<textarea>` or `<select>` element.
@@ -17738,10 +17902,14 @@ class Locator(SyncBase):
         """
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.input_value(timeout=timeout))
+            self._sync(self._impl_obj.input_value(timeout=to_milliseconds(timeout)))
         )
 
-    def is_checked(self, *, timeout: typing.Optional[float] = None) -> bool:
+    def is_checked(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> bool:
         """Locator.is_checked
 
         Returns whether the element is checked. Throws if the element is not a checkbox or radio input.
@@ -17767,10 +17935,14 @@ class Locator(SyncBase):
         """
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.is_checked(timeout=timeout))
+            self._sync(self._impl_obj.is_checked(timeout=to_milliseconds(timeout)))
         )
 
-    def is_disabled(self, *, timeout: typing.Optional[float] = None) -> bool:
+    def is_disabled(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> bool:
         """Locator.is_disabled
 
         Returns whether the element is disabled, the opposite of [enabled](https://playwright.dev/python/docs/actionability#enabled).
@@ -17796,10 +17968,14 @@ class Locator(SyncBase):
         """
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.is_disabled(timeout=timeout))
+            self._sync(self._impl_obj.is_disabled(timeout=to_milliseconds(timeout)))
         )
 
-    def is_editable(self, *, timeout: typing.Optional[float] = None) -> bool:
+    def is_editable(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> bool:
         """Locator.is_editable
 
         Returns whether the element is [editable](https://playwright.dev/python/docs/actionability#editable). If the target element is not an `<input>`,
@@ -17827,10 +18003,14 @@ class Locator(SyncBase):
         """
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.is_editable(timeout=timeout))
+            self._sync(self._impl_obj.is_editable(timeout=to_milliseconds(timeout)))
         )
 
-    def is_enabled(self, *, timeout: typing.Optional[float] = None) -> bool:
+    def is_enabled(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> bool:
         """Locator.is_enabled
 
         Returns whether the element is [enabled](https://playwright.dev/python/docs/actionability#enabled).
@@ -17856,10 +18036,14 @@ class Locator(SyncBase):
         """
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.is_enabled(timeout=timeout))
+            self._sync(self._impl_obj.is_enabled(timeout=to_milliseconds(timeout)))
         )
 
-    def is_hidden(self, *, timeout: typing.Optional[float] = None) -> bool:
+    def is_hidden(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> bool:
         """Locator.is_hidden
 
         Returns whether the element is hidden, the opposite of [visible](https://playwright.dev/python/docs/actionability#visible).
@@ -17884,10 +18068,14 @@ class Locator(SyncBase):
         """
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.is_hidden(timeout=timeout))
+            self._sync(self._impl_obj.is_hidden(timeout=to_milliseconds(timeout)))
         )
 
-    def is_visible(self, *, timeout: typing.Optional[float] = None) -> bool:
+    def is_visible(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> bool:
         """Locator.is_visible
 
         Returns whether the element is [visible](https://playwright.dev/python/docs/actionability#visible).
@@ -17912,7 +18100,7 @@ class Locator(SyncBase):
         """
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.is_visible(timeout=timeout))
+            self._sync(self._impl_obj.is_visible(timeout=to_milliseconds(timeout)))
         )
 
     def press(
@@ -17920,7 +18108,7 @@ class Locator(SyncBase):
         key: str,
         *,
         delay: typing.Optional[float] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
     ) -> None:
         """Locator.press
@@ -17976,7 +18164,10 @@ class Locator(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.press(
-                    key=key, delay=delay, timeout=timeout, noWaitAfter=no_wait_after
+                    key=key,
+                    delay=delay,
+                    timeout=to_milliseconds(timeout),
+                    noWaitAfter=no_wait_after,
                 )
             )
         )
@@ -17984,7 +18175,7 @@ class Locator(SyncBase):
     def screenshot(
         self,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         type: typing.Optional[Literal["jpeg", "png"]] = None,
         path: typing.Optional[typing.Union[pathlib.Path, str]] = None,
         quality: typing.Optional[int] = None,
@@ -18076,7 +18267,7 @@ class Locator(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.screenshot(
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     type=type,
                     path=path,
                     quality=quality,
@@ -18094,7 +18285,7 @@ class Locator(SyncBase):
     def aria_snapshot(
         self,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         depth: typing.Optional[int] = None,
         mode: typing.Optional[Literal["ai", "default"]] = None,
     ) -> str:
@@ -18159,7 +18350,9 @@ class Locator(SyncBase):
 
         return mapping.from_maybe_impl(
             self._sync(
-                self._impl_obj.aria_snapshot(timeout=timeout, depth=depth, mode=mode)
+                self._impl_obj.aria_snapshot(
+                    timeout=to_milliseconds(timeout), depth=depth, mode=mode
+                )
             )
         )
 
@@ -18178,7 +18371,9 @@ class Locator(SyncBase):
         return mapping.from_impl(self._sync(self._impl_obj.normalize()))
 
     def scroll_into_view_if_needed(
-        self, *, timeout: typing.Optional[float] = None
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """Locator.scroll_into_view_if_needed
 
@@ -18196,7 +18391,11 @@ class Locator(SyncBase):
         """
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.scroll_into_view_if_needed(timeout=timeout))
+            self._sync(
+                self._impl_obj.scroll_into_view_if_needed(
+                    timeout=to_milliseconds(timeout)
+                )
+            )
         )
 
     def select_option(
@@ -18208,7 +18407,7 @@ class Locator(SyncBase):
         element: typing.Optional[
             typing.Union["ElementHandle", typing.Sequence["ElementHandle"]]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
         force: typing.Optional[bool] = None,
     ) -> typing.List[str]:
@@ -18282,7 +18481,7 @@ class Locator(SyncBase):
                     index=mapping.to_impl(index),
                     label=mapping.to_impl(label),
                     element=mapping.to_impl(element),
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     noWaitAfter=no_wait_after,
                     force=force,
                 )
@@ -18293,7 +18492,7 @@ class Locator(SyncBase):
         self,
         *,
         force: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """Locator.select_text
 
@@ -18314,7 +18513,11 @@ class Locator(SyncBase):
         """
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.select_text(force=force, timeout=timeout))
+            self._sync(
+                self._impl_obj.select_text(
+                    force=force, timeout=to_milliseconds(timeout)
+                )
+            )
         )
 
     def set_input_files(
@@ -18327,7 +18530,7 @@ class Locator(SyncBase):
             typing.Sequence[FilePayload],
         ],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
     ) -> None:
         """Locator.set_input_files
@@ -18383,7 +18586,7 @@ class Locator(SyncBase):
             self._sync(
                 self._impl_obj.set_input_files(
                     files=mapping.to_impl(files),
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     noWaitAfter=no_wait_after,
                 )
             )
@@ -18396,7 +18599,7 @@ class Locator(SyncBase):
             typing.Sequence[Literal["Alt", "Control", "ControlOrMeta", "Meta", "Shift"]]
         ] = None,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
@@ -18449,7 +18652,7 @@ class Locator(SyncBase):
                 self._impl_obj.tap(
                     modifiers=mapping.to_impl(modifiers),
                     position=position,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     force=force,
                     noWaitAfter=no_wait_after,
                     trial=trial,
@@ -18458,7 +18661,9 @@ class Locator(SyncBase):
         )
 
     def text_content(
-        self, *, timeout: typing.Optional[float] = None
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> typing.Optional[str]:
         """Locator.text_content
 
@@ -18479,7 +18684,7 @@ class Locator(SyncBase):
         """
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.text_content(timeout=timeout))
+            self._sync(self._impl_obj.text_content(timeout=to_milliseconds(timeout)))
         )
 
     def type(
@@ -18487,7 +18692,7 @@ class Locator(SyncBase):
         text: str,
         *,
         delay: typing.Optional[float] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
     ) -> None:
         """Locator.type
@@ -18516,7 +18721,10 @@ class Locator(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.type(
-                    text=text, delay=delay, timeout=timeout, noWaitAfter=no_wait_after
+                    text=text,
+                    delay=delay,
+                    timeout=to_milliseconds(timeout),
+                    noWaitAfter=no_wait_after,
                 )
             )
         )
@@ -18526,7 +18734,7 @@ class Locator(SyncBase):
         text: str,
         *,
         delay: typing.Optional[float] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         no_wait_after: typing.Optional[bool] = None,
     ) -> None:
         """Locator.press_sequentially
@@ -18571,7 +18779,10 @@ class Locator(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.press_sequentially(
-                    text=text, delay=delay, timeout=timeout, noWaitAfter=no_wait_after
+                    text=text,
+                    delay=delay,
+                    timeout=to_milliseconds(timeout),
+                    noWaitAfter=no_wait_after,
                 )
             )
         )
@@ -18580,7 +18791,7 @@ class Locator(SyncBase):
         self,
         *,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
@@ -18632,7 +18843,7 @@ class Locator(SyncBase):
             self._sync(
                 self._impl_obj.uncheck(
                     position=position,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     force=force,
                     noWaitAfter=no_wait_after,
                     trial=trial,
@@ -18685,7 +18896,7 @@ class Locator(SyncBase):
     def wait_for(
         self,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         state: typing.Optional[
             Literal["attached", "detached", "hidden", "visible"]
         ] = None,
@@ -18720,7 +18931,9 @@ class Locator(SyncBase):
         """
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.wait_for(timeout=timeout, state=state))
+            self._sync(
+                self._impl_obj.wait_for(timeout=to_milliseconds(timeout), state=state)
+            )
         )
 
     def set_checked(
@@ -18728,7 +18941,7 @@ class Locator(SyncBase):
         checked: bool,
         *,
         position: typing.Optional[Position] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         force: typing.Optional[bool] = None,
         no_wait_after: typing.Optional[bool] = None,
         trial: typing.Optional[bool] = None,
@@ -18782,7 +18995,7 @@ class Locator(SyncBase):
                 self._impl_obj.set_checked(
                     checked=checked,
                     position=position,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     force=force,
                     noWaitAfter=no_wait_after,
                     trial=trial,
@@ -18960,7 +19173,7 @@ class APIRequestContext(SyncBase):
         multipart: typing.Optional[
             typing.Dict[str, typing.Union[bytes, bool, float, str, FilePayload]]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         fail_on_status_code: typing.Optional[bool] = None,
         ignore_https_errors: typing.Optional[bool] = None,
         max_redirects: typing.Optional[int] = None,
@@ -19021,7 +19234,7 @@ class APIRequestContext(SyncBase):
                     data=mapping.to_impl(data),
                     form=mapping.to_impl(form),
                     multipart=mapping.to_impl(multipart),
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     failOnStatusCode=fail_on_status_code,
                     ignoreHTTPSErrors=ignore_https_errors,
                     maxRedirects=max_redirects,
@@ -19043,7 +19256,7 @@ class APIRequestContext(SyncBase):
         multipart: typing.Optional[
             typing.Dict[str, typing.Union[bytes, bool, float, str, FilePayload]]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         fail_on_status_code: typing.Optional[bool] = None,
         ignore_https_errors: typing.Optional[bool] = None,
         max_redirects: typing.Optional[int] = None,
@@ -19104,7 +19317,7 @@ class APIRequestContext(SyncBase):
                     data=mapping.to_impl(data),
                     form=mapping.to_impl(form),
                     multipart=mapping.to_impl(multipart),
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     failOnStatusCode=fail_on_status_code,
                     ignoreHTTPSErrors=ignore_https_errors,
                     maxRedirects=max_redirects,
@@ -19126,7 +19339,7 @@ class APIRequestContext(SyncBase):
         multipart: typing.Optional[
             typing.Dict[str, typing.Union[bytes, bool, float, str, FilePayload]]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         fail_on_status_code: typing.Optional[bool] = None,
         ignore_https_errors: typing.Optional[bool] = None,
         max_redirects: typing.Optional[int] = None,
@@ -19199,7 +19412,7 @@ class APIRequestContext(SyncBase):
                     data=mapping.to_impl(data),
                     form=mapping.to_impl(form),
                     multipart=mapping.to_impl(multipart),
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     failOnStatusCode=fail_on_status_code,
                     ignoreHTTPSErrors=ignore_https_errors,
                     maxRedirects=max_redirects,
@@ -19221,7 +19434,7 @@ class APIRequestContext(SyncBase):
         multipart: typing.Optional[
             typing.Dict[str, typing.Union[bytes, bool, float, str, FilePayload]]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         fail_on_status_code: typing.Optional[bool] = None,
         ignore_https_errors: typing.Optional[bool] = None,
         max_redirects: typing.Optional[int] = None,
@@ -19282,7 +19495,7 @@ class APIRequestContext(SyncBase):
                     data=mapping.to_impl(data),
                     form=mapping.to_impl(form),
                     multipart=mapping.to_impl(multipart),
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     failOnStatusCode=fail_on_status_code,
                     ignoreHTTPSErrors=ignore_https_errors,
                     maxRedirects=max_redirects,
@@ -19304,7 +19517,7 @@ class APIRequestContext(SyncBase):
         multipart: typing.Optional[
             typing.Dict[str, typing.Union[bytes, bool, float, str, FilePayload]]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         fail_on_status_code: typing.Optional[bool] = None,
         ignore_https_errors: typing.Optional[bool] = None,
         max_redirects: typing.Optional[int] = None,
@@ -19365,7 +19578,7 @@ class APIRequestContext(SyncBase):
                     data=mapping.to_impl(data),
                     form=mapping.to_impl(form),
                     multipart=mapping.to_impl(multipart),
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     failOnStatusCode=fail_on_status_code,
                     ignoreHTTPSErrors=ignore_https_errors,
                     maxRedirects=max_redirects,
@@ -19387,7 +19600,7 @@ class APIRequestContext(SyncBase):
         multipart: typing.Optional[
             typing.Dict[str, typing.Union[bytes, bool, float, str, FilePayload]]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         fail_on_status_code: typing.Optional[bool] = None,
         ignore_https_errors: typing.Optional[bool] = None,
         max_redirects: typing.Optional[int] = None,
@@ -19479,7 +19692,7 @@ class APIRequestContext(SyncBase):
                     data=mapping.to_impl(data),
                     form=mapping.to_impl(form),
                     multipart=mapping.to_impl(multipart),
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     failOnStatusCode=fail_on_status_code,
                     ignoreHTTPSErrors=ignore_https_errors,
                     maxRedirects=max_redirects,
@@ -19502,7 +19715,7 @@ class APIRequestContext(SyncBase):
         multipart: typing.Optional[
             typing.Dict[str, typing.Union[bytes, bool, float, str, FilePayload]]
         ] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         fail_on_status_code: typing.Optional[bool] = None,
         ignore_https_errors: typing.Optional[bool] = None,
         max_redirects: typing.Optional[int] = None,
@@ -19585,7 +19798,7 @@ class APIRequestContext(SyncBase):
                     data=mapping.to_impl(data),
                     form=mapping.to_impl(form),
                     multipart=mapping.to_impl(multipart),
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     failOnStatusCode=fail_on_status_code,
                     ignoreHTTPSErrors=ignore_https_errors,
                     maxRedirects=max_redirects,
@@ -19637,7 +19850,7 @@ class APIRequest(SyncBase):
         ignore_https_errors: typing.Optional[bool] = None,
         proxy: typing.Optional[ProxySettings] = None,
         user_agent: typing.Optional[str] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         storage_state: typing.Optional[
             typing.Union[StorageState, str, pathlib.Path]
         ] = None,
@@ -19718,7 +19931,7 @@ class APIRequest(SyncBase):
                     ignoreHTTPSErrors=ignore_https_errors,
                     proxy=proxy,
                     userAgent=user_agent,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     storageState=storage_state,
                     clientCertificates=client_certificates,
                     failOnStatusCode=fail_on_status_code,
@@ -19737,7 +19950,7 @@ class PageAssertions(SyncBase):
         self,
         title_or_reg_exp: typing.Union[typing.Pattern[str], str],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """PageAssertions.to_have_title
 
@@ -19765,7 +19978,7 @@ class PageAssertions(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.to_have_title(
-                    titleOrRegExp=title_or_reg_exp, timeout=timeout
+                    titleOrRegExp=title_or_reg_exp, timeout=to_milliseconds(timeout)
                 )
             )
         )
@@ -19774,7 +19987,7 @@ class PageAssertions(SyncBase):
         self,
         title_or_reg_exp: typing.Union[typing.Pattern[str], str],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """PageAssertions.not_to_have_title
 
@@ -19792,7 +20005,7 @@ class PageAssertions(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.not_to_have_title(
-                    titleOrRegExp=title_or_reg_exp, timeout=timeout
+                    titleOrRegExp=title_or_reg_exp, timeout=to_milliseconds(timeout)
                 )
             )
         )
@@ -19801,7 +20014,7 @@ class PageAssertions(SyncBase):
         self,
         url_or_reg_exp: typing.Union[str, typing.Pattern[str]],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         ignore_case: typing.Optional[bool] = None,
     ) -> None:
         """PageAssertions.to_have_url
@@ -19833,7 +20046,9 @@ class PageAssertions(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.to_have_url(
-                    urlOrRegExp=url_or_reg_exp, timeout=timeout, ignoreCase=ignore_case
+                    urlOrRegExp=url_or_reg_exp,
+                    timeout=to_milliseconds(timeout),
+                    ignoreCase=ignore_case,
                 )
             )
         )
@@ -19842,7 +20057,7 @@ class PageAssertions(SyncBase):
         self,
         url_or_reg_exp: typing.Union[typing.Pattern[str], str],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         ignore_case: typing.Optional[bool] = None,
     ) -> None:
         """PageAssertions.not_to_have_url
@@ -19864,7 +20079,9 @@ class PageAssertions(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.not_to_have_url(
-                    urlOrRegExp=url_or_reg_exp, timeout=timeout, ignoreCase=ignore_case
+                    urlOrRegExp=url_or_reg_exp,
+                    timeout=to_milliseconds(timeout),
+                    ignoreCase=ignore_case,
                 )
             )
         )
@@ -19886,7 +20103,7 @@ class LocatorAssertions(SyncBase):
         ],
         *,
         use_inner_text: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         ignore_case: typing.Optional[bool] = None,
     ) -> None:
         """LocatorAssertions.to_contain_text
@@ -19963,7 +20180,7 @@ class LocatorAssertions(SyncBase):
                 self._impl_obj.to_contain_text(
                     expected=mapping.to_impl(expected),
                     useInnerText=use_inner_text,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     ignoreCase=ignore_case,
                 )
             )
@@ -19980,7 +20197,7 @@ class LocatorAssertions(SyncBase):
         ],
         *,
         use_inner_text: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         ignore_case: typing.Optional[bool] = None,
     ) -> None:
         """LocatorAssertions.not_to_contain_text
@@ -20006,7 +20223,7 @@ class LocatorAssertions(SyncBase):
                 self._impl_obj.not_to_contain_text(
                     expected=mapping.to_impl(expected),
                     useInnerText=use_inner_text,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     ignoreCase=ignore_case,
                 )
             )
@@ -20018,7 +20235,7 @@ class LocatorAssertions(SyncBase):
         value: typing.Union[str, typing.Pattern[str]],
         *,
         ignore_case: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_have_attribute
 
@@ -20050,7 +20267,10 @@ class LocatorAssertions(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.to_have_attribute(
-                    name=name, value=value, ignoreCase=ignore_case, timeout=timeout
+                    name=name,
+                    value=value,
+                    ignoreCase=ignore_case,
+                    timeout=to_milliseconds(timeout),
                 )
             )
         )
@@ -20061,7 +20281,7 @@ class LocatorAssertions(SyncBase):
         value: typing.Union[str, typing.Pattern[str]],
         *,
         ignore_case: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_have_attribute
 
@@ -20084,7 +20304,10 @@ class LocatorAssertions(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.not_to_have_attribute(
-                    name=name, value=value, ignoreCase=ignore_case, timeout=timeout
+                    name=name,
+                    value=value,
+                    ignoreCase=ignore_case,
+                    timeout=to_milliseconds(timeout),
                 )
             )
         )
@@ -20099,7 +20322,7 @@ class LocatorAssertions(SyncBase):
             str,
         ],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_have_class
 
@@ -20143,7 +20366,7 @@ class LocatorAssertions(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.to_have_class(
-                    expected=mapping.to_impl(expected), timeout=timeout
+                    expected=mapping.to_impl(expected), timeout=to_milliseconds(timeout)
                 )
             )
         )
@@ -20158,7 +20381,7 @@ class LocatorAssertions(SyncBase):
             str,
         ],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_have_class
 
@@ -20176,7 +20399,7 @@ class LocatorAssertions(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.not_to_have_class(
-                    expected=mapping.to_impl(expected), timeout=timeout
+                    expected=mapping.to_impl(expected), timeout=to_milliseconds(timeout)
                 )
             )
         )
@@ -20185,7 +20408,7 @@ class LocatorAssertions(SyncBase):
         self,
         expected: typing.Union[typing.Sequence[str], str],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_contain_class
 
@@ -20239,7 +20462,7 @@ class LocatorAssertions(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.to_contain_class(
-                    expected=mapping.to_impl(expected), timeout=timeout
+                    expected=mapping.to_impl(expected), timeout=to_milliseconds(timeout)
                 )
             )
         )
@@ -20248,7 +20471,7 @@ class LocatorAssertions(SyncBase):
         self,
         expected: typing.Union[typing.Sequence[str], str],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_contain_class
 
@@ -20266,13 +20489,16 @@ class LocatorAssertions(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.not_to_contain_class(
-                    expected=mapping.to_impl(expected), timeout=timeout
+                    expected=mapping.to_impl(expected), timeout=to_milliseconds(timeout)
                 )
             )
         )
 
     def to_have_count(
-        self, count: int, *, timeout: typing.Optional[float] = None
+        self,
+        count: int,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_have_count
 
@@ -20297,11 +20523,18 @@ class LocatorAssertions(SyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.to_have_count(count=count, timeout=timeout))
+            self._sync(
+                self._impl_obj.to_have_count(
+                    count=count, timeout=to_milliseconds(timeout)
+                )
+            )
         )
 
     def not_to_have_count(
-        self, count: int, *, timeout: typing.Optional[float] = None
+        self,
+        count: int,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_have_count
 
@@ -20317,7 +20550,11 @@ class LocatorAssertions(SyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.not_to_have_count(count=count, timeout=timeout))
+            self._sync(
+                self._impl_obj.not_to_have_count(
+                    count=count, timeout=to_milliseconds(timeout)
+                )
+            )
         )
 
     def to_have_css(
@@ -20325,7 +20562,7 @@ class LocatorAssertions(SyncBase):
         name: str,
         value: typing.Union[str, typing.Pattern[str]],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_have_css
 
@@ -20353,7 +20590,9 @@ class LocatorAssertions(SyncBase):
 
         return mapping.from_maybe_impl(
             self._sync(
-                self._impl_obj.to_have_css(name=name, value=value, timeout=timeout)
+                self._impl_obj.to_have_css(
+                    name=name, value=value, timeout=to_milliseconds(timeout)
+                )
             )
         )
 
@@ -20362,7 +20601,7 @@ class LocatorAssertions(SyncBase):
         name: str,
         value: typing.Union[str, typing.Pattern[str]],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_have_css
 
@@ -20381,7 +20620,9 @@ class LocatorAssertions(SyncBase):
 
         return mapping.from_maybe_impl(
             self._sync(
-                self._impl_obj.not_to_have_css(name=name, value=value, timeout=timeout)
+                self._impl_obj.not_to_have_css(
+                    name=name, value=value, timeout=to_milliseconds(timeout)
+                )
             )
         )
 
@@ -20389,7 +20630,7 @@ class LocatorAssertions(SyncBase):
         self,
         id: typing.Union[str, typing.Pattern[str]],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_have_id
 
@@ -20414,14 +20655,16 @@ class LocatorAssertions(SyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.to_have_id(id=id, timeout=timeout))
+            self._sync(
+                self._impl_obj.to_have_id(id=id, timeout=to_milliseconds(timeout))
+            )
         )
 
     def not_to_have_id(
         self,
         id: typing.Union[str, typing.Pattern[str]],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_have_id
 
@@ -20437,11 +20680,17 @@ class LocatorAssertions(SyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.not_to_have_id(id=id, timeout=timeout))
+            self._sync(
+                self._impl_obj.not_to_have_id(id=id, timeout=to_milliseconds(timeout))
+            )
         )
 
     def to_have_js_property(
-        self, name: str, value: typing.Any, *, timeout: typing.Optional[float] = None
+        self,
+        name: str,
+        value: typing.Any,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_have_js_property
 
@@ -20471,13 +20720,19 @@ class LocatorAssertions(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.to_have_js_property(
-                    name=name, value=mapping.to_impl(value), timeout=timeout
+                    name=name,
+                    value=mapping.to_impl(value),
+                    timeout=to_milliseconds(timeout),
                 )
             )
         )
 
     def not_to_have_js_property(
-        self, name: str, value: typing.Any, *, timeout: typing.Optional[float] = None
+        self,
+        name: str,
+        value: typing.Any,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_have_js_property
 
@@ -20497,7 +20752,9 @@ class LocatorAssertions(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.not_to_have_js_property(
-                    name=name, value=mapping.to_impl(value), timeout=timeout
+                    name=name,
+                    value=mapping.to_impl(value),
+                    timeout=to_milliseconds(timeout),
                 )
             )
         )
@@ -20506,7 +20763,7 @@ class LocatorAssertions(SyncBase):
         self,
         value: typing.Union[str, typing.Pattern[str]],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_have_value
 
@@ -20533,14 +20790,18 @@ class LocatorAssertions(SyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.to_have_value(value=value, timeout=timeout))
+            self._sync(
+                self._impl_obj.to_have_value(
+                    value=value, timeout=to_milliseconds(timeout)
+                )
+            )
         )
 
     def not_to_have_value(
         self,
         value: typing.Union[str, typing.Pattern[str]],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_have_value
 
@@ -20556,7 +20817,11 @@ class LocatorAssertions(SyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.not_to_have_value(value=value, timeout=timeout))
+            self._sync(
+                self._impl_obj.not_to_have_value(
+                    value=value, timeout=to_milliseconds(timeout)
+                )
+            )
         )
 
     def to_have_values(
@@ -20567,7 +20832,7 @@ class LocatorAssertions(SyncBase):
             typing.Sequence[typing.Union[typing.Pattern[str], str]],
         ],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_have_values
 
@@ -20607,7 +20872,7 @@ class LocatorAssertions(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.to_have_values(
-                    values=mapping.to_impl(values), timeout=timeout
+                    values=mapping.to_impl(values), timeout=to_milliseconds(timeout)
                 )
             )
         )
@@ -20620,7 +20885,7 @@ class LocatorAssertions(SyncBase):
             typing.Sequence[typing.Union[typing.Pattern[str], str]],
         ],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_have_values
 
@@ -20638,7 +20903,7 @@ class LocatorAssertions(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.not_to_have_values(
-                    values=mapping.to_impl(values), timeout=timeout
+                    values=mapping.to_impl(values), timeout=to_milliseconds(timeout)
                 )
             )
         )
@@ -20654,7 +20919,7 @@ class LocatorAssertions(SyncBase):
         ],
         *,
         use_inner_text: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         ignore_case: typing.Optional[bool] = None,
     ) -> None:
         """LocatorAssertions.to_have_text
@@ -20730,7 +20995,7 @@ class LocatorAssertions(SyncBase):
                 self._impl_obj.to_have_text(
                     expected=mapping.to_impl(expected),
                     useInnerText=use_inner_text,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     ignoreCase=ignore_case,
                 )
             )
@@ -20747,7 +21012,7 @@ class LocatorAssertions(SyncBase):
         ],
         *,
         use_inner_text: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         ignore_case: typing.Optional[bool] = None,
     ) -> None:
         """LocatorAssertions.not_to_have_text
@@ -20773,7 +21038,7 @@ class LocatorAssertions(SyncBase):
                 self._impl_obj.not_to_have_text(
                     expected=mapping.to_impl(expected),
                     useInnerText=use_inner_text,
-                    timeout=timeout,
+                    timeout=to_milliseconds(timeout),
                     ignoreCase=ignore_case,
                 )
             )
@@ -20783,7 +21048,7 @@ class LocatorAssertions(SyncBase):
         self,
         *,
         attached: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_be_attached
 
@@ -20806,14 +21071,16 @@ class LocatorAssertions(SyncBase):
 
         return mapping.from_maybe_impl(
             self._sync(
-                self._impl_obj.to_be_attached(attached=attached, timeout=timeout)
+                self._impl_obj.to_be_attached(
+                    attached=attached, timeout=to_milliseconds(timeout)
+                )
             )
         )
 
     def to_be_checked(
         self,
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
         checked: typing.Optional[bool] = None,
         indeterminate: typing.Optional[bool] = None,
     ) -> None:
@@ -20846,7 +21113,9 @@ class LocatorAssertions(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.to_be_checked(
-                    timeout=timeout, checked=checked, indeterminate=indeterminate
+                    timeout=to_milliseconds(timeout),
+                    checked=checked,
+                    indeterminate=indeterminate,
                 )
             )
         )
@@ -20855,7 +21124,7 @@ class LocatorAssertions(SyncBase):
         self,
         *,
         attached: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_be_attached
 
@@ -20871,11 +21140,17 @@ class LocatorAssertions(SyncBase):
 
         return mapping.from_maybe_impl(
             self._sync(
-                self._impl_obj.not_to_be_attached(attached=attached, timeout=timeout)
+                self._impl_obj.not_to_be_attached(
+                    attached=attached, timeout=to_milliseconds(timeout)
+                )
             )
         )
 
-    def not_to_be_checked(self, *, timeout: typing.Optional[float] = None) -> None:
+    def not_to_be_checked(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> None:
         """LocatorAssertions.not_to_be_checked
 
         The opposite of `locator_assertions.to_be_checked()`.
@@ -20888,10 +21163,16 @@ class LocatorAssertions(SyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.not_to_be_checked(timeout=timeout))
+            self._sync(
+                self._impl_obj.not_to_be_checked(timeout=to_milliseconds(timeout))
+            )
         )
 
-    def to_be_disabled(self, *, timeout: typing.Optional[float] = None) -> None:
+    def to_be_disabled(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> None:
         """LocatorAssertions.to_be_disabled
 
         Ensures the `Locator` points to a disabled element. Element is disabled if it has \"disabled\" attribute or is
@@ -20917,10 +21198,14 @@ class LocatorAssertions(SyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.to_be_disabled(timeout=timeout))
+            self._sync(self._impl_obj.to_be_disabled(timeout=to_milliseconds(timeout)))
         )
 
-    def not_to_be_disabled(self, *, timeout: typing.Optional[float] = None) -> None:
+    def not_to_be_disabled(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> None:
         """LocatorAssertions.not_to_be_disabled
 
         The opposite of `locator_assertions.to_be_disabled()`.
@@ -20933,14 +21218,16 @@ class LocatorAssertions(SyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.not_to_be_disabled(timeout=timeout))
+            self._sync(
+                self._impl_obj.not_to_be_disabled(timeout=to_milliseconds(timeout))
+            )
         )
 
     def to_be_editable(
         self,
         *,
         editable: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_be_editable
 
@@ -20965,7 +21252,9 @@ class LocatorAssertions(SyncBase):
 
         return mapping.from_maybe_impl(
             self._sync(
-                self._impl_obj.to_be_editable(editable=editable, timeout=timeout)
+                self._impl_obj.to_be_editable(
+                    editable=editable, timeout=to_milliseconds(timeout)
+                )
             )
         )
 
@@ -20973,7 +21262,7 @@ class LocatorAssertions(SyncBase):
         self,
         *,
         editable: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_be_editable
 
@@ -20989,11 +21278,17 @@ class LocatorAssertions(SyncBase):
 
         return mapping.from_maybe_impl(
             self._sync(
-                self._impl_obj.not_to_be_editable(editable=editable, timeout=timeout)
+                self._impl_obj.not_to_be_editable(
+                    editable=editable, timeout=to_milliseconds(timeout)
+                )
             )
         )
 
-    def to_be_empty(self, *, timeout: typing.Optional[float] = None) -> None:
+    def to_be_empty(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> None:
         """LocatorAssertions.to_be_empty
 
         Ensures the `Locator` points to an empty editable element or to a DOM node that has no text.
@@ -21015,10 +21310,14 @@ class LocatorAssertions(SyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.to_be_empty(timeout=timeout))
+            self._sync(self._impl_obj.to_be_empty(timeout=to_milliseconds(timeout)))
         )
 
-    def not_to_be_empty(self, *, timeout: typing.Optional[float] = None) -> None:
+    def not_to_be_empty(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> None:
         """LocatorAssertions.not_to_be_empty
 
         The opposite of `locator_assertions.to_be_empty()`.
@@ -21031,14 +21330,14 @@ class LocatorAssertions(SyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.not_to_be_empty(timeout=timeout))
+            self._sync(self._impl_obj.not_to_be_empty(timeout=to_milliseconds(timeout)))
         )
 
     def to_be_enabled(
         self,
         *,
         enabled: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_be_enabled
 
@@ -21062,14 +21361,18 @@ class LocatorAssertions(SyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.to_be_enabled(enabled=enabled, timeout=timeout))
+            self._sync(
+                self._impl_obj.to_be_enabled(
+                    enabled=enabled, timeout=to_milliseconds(timeout)
+                )
+            )
         )
 
     def not_to_be_enabled(
         self,
         *,
         enabled: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_be_enabled
 
@@ -21085,11 +21388,17 @@ class LocatorAssertions(SyncBase):
 
         return mapping.from_maybe_impl(
             self._sync(
-                self._impl_obj.not_to_be_enabled(enabled=enabled, timeout=timeout)
+                self._impl_obj.not_to_be_enabled(
+                    enabled=enabled, timeout=to_milliseconds(timeout)
+                )
             )
         )
 
-    def to_be_hidden(self, *, timeout: typing.Optional[float] = None) -> None:
+    def to_be_hidden(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> None:
         """LocatorAssertions.to_be_hidden
 
         Ensures that `Locator` either does not resolve to any DOM node, or resolves to a
@@ -21112,10 +21421,14 @@ class LocatorAssertions(SyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.to_be_hidden(timeout=timeout))
+            self._sync(self._impl_obj.to_be_hidden(timeout=to_milliseconds(timeout)))
         )
 
-    def not_to_be_hidden(self, *, timeout: typing.Optional[float] = None) -> None:
+    def not_to_be_hidden(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> None:
         """LocatorAssertions.not_to_be_hidden
 
         The opposite of `locator_assertions.to_be_hidden()`.
@@ -21128,14 +21441,16 @@ class LocatorAssertions(SyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.not_to_be_hidden(timeout=timeout))
+            self._sync(
+                self._impl_obj.not_to_be_hidden(timeout=to_milliseconds(timeout))
+            )
         )
 
     def to_be_visible(
         self,
         *,
         visible: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_be_visible
 
@@ -21169,14 +21484,18 @@ class LocatorAssertions(SyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.to_be_visible(visible=visible, timeout=timeout))
+            self._sync(
+                self._impl_obj.to_be_visible(
+                    visible=visible, timeout=to_milliseconds(timeout)
+                )
+            )
         )
 
     def not_to_be_visible(
         self,
         *,
         visible: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_be_visible
 
@@ -21192,11 +21511,17 @@ class LocatorAssertions(SyncBase):
 
         return mapping.from_maybe_impl(
             self._sync(
-                self._impl_obj.not_to_be_visible(visible=visible, timeout=timeout)
+                self._impl_obj.not_to_be_visible(
+                    visible=visible, timeout=to_milliseconds(timeout)
+                )
             )
         )
 
-    def to_be_focused(self, *, timeout: typing.Optional[float] = None) -> None:
+    def to_be_focused(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> None:
         """LocatorAssertions.to_be_focused
 
         Ensures the `Locator` points to a focused DOM node.
@@ -21218,10 +21543,14 @@ class LocatorAssertions(SyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.to_be_focused(timeout=timeout))
+            self._sync(self._impl_obj.to_be_focused(timeout=to_milliseconds(timeout)))
         )
 
-    def not_to_be_focused(self, *, timeout: typing.Optional[float] = None) -> None:
+    def not_to_be_focused(
+        self,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
+    ) -> None:
         """LocatorAssertions.not_to_be_focused
 
         The opposite of `locator_assertions.to_be_focused()`.
@@ -21234,14 +21563,16 @@ class LocatorAssertions(SyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.not_to_be_focused(timeout=timeout))
+            self._sync(
+                self._impl_obj.not_to_be_focused(timeout=to_milliseconds(timeout))
+            )
         )
 
     def to_be_in_viewport(
         self,
         *,
         ratio: typing.Optional[float] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_be_in_viewport
 
@@ -21273,14 +21604,18 @@ class LocatorAssertions(SyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.to_be_in_viewport(ratio=ratio, timeout=timeout))
+            self._sync(
+                self._impl_obj.to_be_in_viewport(
+                    ratio=ratio, timeout=to_milliseconds(timeout)
+                )
+            )
         )
 
     def not_to_be_in_viewport(
         self,
         *,
         ratio: typing.Optional[float] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_be_in_viewport
 
@@ -21296,7 +21631,9 @@ class LocatorAssertions(SyncBase):
 
         return mapping.from_maybe_impl(
             self._sync(
-                self._impl_obj.not_to_be_in_viewport(ratio=ratio, timeout=timeout)
+                self._impl_obj.not_to_be_in_viewport(
+                    ratio=ratio, timeout=to_milliseconds(timeout)
+                )
             )
         )
 
@@ -21305,7 +21642,7 @@ class LocatorAssertions(SyncBase):
         description: typing.Union[str, typing.Pattern[str]],
         *,
         ignore_case: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_have_accessible_description
 
@@ -21334,7 +21671,9 @@ class LocatorAssertions(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.to_have_accessible_description(
-                    description=description, ignoreCase=ignore_case, timeout=timeout
+                    description=description,
+                    ignoreCase=ignore_case,
+                    timeout=to_milliseconds(timeout),
                 )
             )
         )
@@ -21344,7 +21683,7 @@ class LocatorAssertions(SyncBase):
         name: typing.Union[str, typing.Pattern[str]],
         *,
         ignore_case: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_have_accessible_description
 
@@ -21365,7 +21704,7 @@ class LocatorAssertions(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.not_to_have_accessible_description(
-                    name=name, ignoreCase=ignore_case, timeout=timeout
+                    name=name, ignoreCase=ignore_case, timeout=to_milliseconds(timeout)
                 )
             )
         )
@@ -21375,7 +21714,7 @@ class LocatorAssertions(SyncBase):
         name: typing.Union[str, typing.Pattern[str]],
         *,
         ignore_case: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_have_accessible_name
 
@@ -21404,7 +21743,7 @@ class LocatorAssertions(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.to_have_accessible_name(
-                    name=name, ignoreCase=ignore_case, timeout=timeout
+                    name=name, ignoreCase=ignore_case, timeout=to_milliseconds(timeout)
                 )
             )
         )
@@ -21414,7 +21753,7 @@ class LocatorAssertions(SyncBase):
         name: typing.Union[str, typing.Pattern[str]],
         *,
         ignore_case: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_have_accessible_name
 
@@ -21435,7 +21774,7 @@ class LocatorAssertions(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.not_to_have_accessible_name(
-                    name=name, ignoreCase=ignore_case, timeout=timeout
+                    name=name, ignoreCase=ignore_case, timeout=to_milliseconds(timeout)
                 )
             )
         )
@@ -21527,7 +21866,7 @@ class LocatorAssertions(SyncBase):
             "treeitem",
         ],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_have_role
 
@@ -21553,7 +21892,9 @@ class LocatorAssertions(SyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.to_have_role(role=role, timeout=timeout))
+            self._sync(
+                self._impl_obj.to_have_role(role=role, timeout=to_milliseconds(timeout))
+            )
         )
 
     def to_have_accessible_error_message(
@@ -21561,7 +21902,7 @@ class LocatorAssertions(SyncBase):
         error_message: typing.Union[str, typing.Pattern[str]],
         *,
         ignore_case: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_have_accessible_error_message
 
@@ -21590,7 +21931,9 @@ class LocatorAssertions(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.to_have_accessible_error_message(
-                    errorMessage=error_message, ignoreCase=ignore_case, timeout=timeout
+                    errorMessage=error_message,
+                    ignoreCase=ignore_case,
+                    timeout=to_milliseconds(timeout),
                 )
             )
         )
@@ -21600,7 +21943,7 @@ class LocatorAssertions(SyncBase):
         error_message: typing.Union[str, typing.Pattern[str]],
         *,
         ignore_case: typing.Optional[bool] = None,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_have_accessible_error_message
 
@@ -21621,7 +21964,9 @@ class LocatorAssertions(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.not_to_have_accessible_error_message(
-                    errorMessage=error_message, ignoreCase=ignore_case, timeout=timeout
+                    errorMessage=error_message,
+                    ignoreCase=ignore_case,
+                    timeout=to_milliseconds(timeout),
                 )
             )
         )
@@ -21713,7 +22058,7 @@ class LocatorAssertions(SyncBase):
             "treeitem",
         ],
         *,
-        timeout: typing.Optional[float] = None,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_have_role
 
@@ -21729,11 +22074,18 @@ class LocatorAssertions(SyncBase):
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            self._sync(self._impl_obj.not_to_have_role(role=role, timeout=timeout))
+            self._sync(
+                self._impl_obj.not_to_have_role(
+                    role=role, timeout=to_milliseconds(timeout)
+                )
+            )
         )
 
     def to_match_aria_snapshot(
-        self, expected: str, *, timeout: typing.Optional[float] = None
+        self,
+        expected: str,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.to_match_aria_snapshot
 
@@ -21760,13 +22112,16 @@ class LocatorAssertions(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.to_match_aria_snapshot(
-                    expected=expected, timeout=timeout
+                    expected=expected, timeout=to_milliseconds(timeout)
                 )
             )
         )
 
     def not_to_match_aria_snapshot(
-        self, expected: str, *, timeout: typing.Optional[float] = None
+        self,
+        expected: str,
+        *,
+        timeout: typing.Optional[typing.Union[float, datetime.timedelta]] = None,
     ) -> None:
         """LocatorAssertions.not_to_match_aria_snapshot
 
@@ -21783,7 +22138,7 @@ class LocatorAssertions(SyncBase):
         return mapping.from_maybe_impl(
             self._sync(
                 self._impl_obj.not_to_match_aria_snapshot(
-                    expected=expected, timeout=timeout
+                    expected=expected, timeout=to_milliseconds(timeout)
                 )
             )
         )

--- a/scripts/generate_api.py
+++ b/scripts/generate_api.py
@@ -135,6 +135,12 @@ def signature(func: FunctionType, indent: int) -> str:
                 + f"{func.__name__}.{name}"
             )
         processed = process_type(value, True)
+        if name == "timeout":
+            processed = re.sub(
+                r"\bfloat\b",
+                "typing.Union[float, datetime.timedelta]",
+                processed,
+            )
         if (
             not positional_exception
             and not saw_optional
@@ -159,6 +165,8 @@ def arguments(func: FunctionType, indent: int) -> str:
         ), f"Underscore in impl classes is not allowed, use camel case, func={func}, name={name}"
         if "Callable" in value_str:
             tokens.append(f"{name}=self._wrap_handler({to_snake_case(name)})")
+        elif name == "timeout" and "float" in value_str:
+            tokens.append(f"{name}=to_milliseconds({to_snake_case(name)})")
         elif (
             "typing.Any" in value_str
             or "typing.Dict" in value_str
@@ -264,6 +272,7 @@ from playwright._impl._video import Video as VideoImpl
 from playwright._impl._tracing import Tracing as TracingImpl
 from playwright._impl._locator import Locator as LocatorImpl, FrameLocator as FrameLocatorImpl
 from playwright._impl._errors import Error
+from playwright._impl._helper import to_milliseconds
 from playwright._impl._fetch import APIRequest as APIRequestImpl, APIResponse as APIResponseImpl, APIRequestContext as APIRequestContextImpl
 from playwright._impl._assertions import PageAssertions as PageAssertionsImpl, LocatorAssertions as LocatorAssertionsImpl, APIResponseAssertions as APIResponseAssertionsImpl
 """

--- a/tests/async/test_click.py
+++ b/tests/async/test_click.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+from datetime import timedelta
 from typing import Optional
 
 import pytest
@@ -1139,3 +1140,8 @@ async def test_click_with_tweened_mouse_movement(page: Page, browser_name: str) 
         [180, 260],
         [200, 300],
     ]
+
+
+async def test_click_should_accept_timedelta_for_timeout(page: Page) -> None:
+    with pytest.raises(TimeoutError, match="Timeout 1ms exceeded"):
+        await page.click("does-not-exist", timeout=timedelta(milliseconds=1))

--- a/tests/sync/test_sync.py
+++ b/tests/sync/test_sync.py
@@ -14,6 +14,7 @@
 
 import multiprocessing
 import os
+from datetime import timedelta
 from typing import Any, Callable, Dict
 
 import pytest
@@ -358,3 +359,8 @@ def test_should_return_proper_api_name_on_error(page: Page) -> None:
     except Exception as error:
         # Each browser returns slightly different error messages, but they should all start with "Page.evaluate:", because that was the Playwright method where the error originated
         assert str(error).startswith("Page.evaluate:")
+
+
+def test_click_should_accept_timedelta_for_timeout(page: Page) -> None:
+    with pytest.raises(TimeoutError, match="Timeout 1ms exceeded"):
+        page.click("does-not-exist", timeout=timedelta(milliseconds=1))


### PR DESCRIPTION
Closes #2600.

Lets users pass `datetime.timedelta` to any function with a `timeout` parameter, in addition to a plain float (milliseconds):

```py
from datetime import timedelta

page.click("div", timeout=timedelta(minutes=5))
```

The codegen widens every `timeout: float` parameter on the generated public API to `Union[float, datetime.timedelta]` and converts via a new `to_milliseconds` helper at the boundary to the impl layer (which keeps using `float`, so the doc validator stays happy against the JS `number` type).

The bulk of the diff is regenerated code from `./scripts/update_api.sh`.