### PR TITLE
fix(typing): typed overloads for expect_event and wait_for_event

### DIFF
--- a/playwright/async_api/_generated.py
+++ b/playwright/async_api/_generated.py
@@ -1120,6 +1120,55 @@ class WebSocket(AsyncBase):
         """
         return mapping.from_maybe_impl(self._impl_obj.url)
 
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["close"],
+        predicate: typing.Optional[typing.Callable[["WebSocket"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["WebSocket"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["framereceived"],
+        predicate: typing.Optional[
+            typing.Callable[["typing.Union[bytes, str]"], bool]
+        ] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["typing.Union[bytes, str]"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["framesent"],
+        predicate: typing.Optional[
+            typing.Callable[["typing.Union[bytes, str]"], bool]
+        ] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["typing.Union[bytes, str]"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["socketerror"],
+        predicate: typing.Optional[typing.Callable[["str"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["str"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: str,
+        predicate: typing.Optional[typing.Callable[..., bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager[typing.Any]: ...
+
     def expect_event(
         self,
         event: str,
@@ -1152,6 +1201,55 @@ class WebSocket(AsyncBase):
                 event=event, predicate=self._wrap_handler(predicate), timeout=timeout
             ).future
         )
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["close"],
+        predicate: typing.Optional[typing.Callable[["WebSocket"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "WebSocket": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["framereceived"],
+        predicate: typing.Optional[
+            typing.Callable[["typing.Union[bytes, str]"], bool]
+        ] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "typing.Union[bytes, str]": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["framesent"],
+        predicate: typing.Optional[
+            typing.Callable[["typing.Union[bytes, str]"], bool]
+        ] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "typing.Union[bytes, str]": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["socketerror"],
+        predicate: typing.Optional[typing.Callable[["str"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "str": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: str,
+        predicate: typing.Optional[typing.Callable[..., bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> typing.Any: ...
 
     async def wait_for_event(
         self,
@@ -6737,6 +6835,33 @@ class Worker(AsyncBase):
             )
         )
 
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["close"],
+        predicate: typing.Optional[typing.Callable[["Worker"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["Worker"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["console"],
+        predicate: typing.Optional[typing.Callable[["ConsoleMessage"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["ConsoleMessage"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: str,
+        predicate: typing.Optional[typing.Callable[..., bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager[typing.Any]: ...
+
     def expect_event(
         self,
         event: str,
@@ -9531,6 +9656,186 @@ class Page(AsyncContextManager):
             )
         )
 
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["close"],
+        predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Page": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["console"],
+        predicate: typing.Optional[typing.Callable[["ConsoleMessage"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "ConsoleMessage": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["crash"],
+        predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Page": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["dialog"],
+        predicate: typing.Optional[typing.Callable[["Dialog"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Dialog": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["domcontentloaded"],
+        predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Page": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["download"],
+        predicate: typing.Optional[typing.Callable[["Download"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Download": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["filechooser"],
+        predicate: typing.Optional[typing.Callable[["FileChooser"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "FileChooser": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["frameattached"],
+        predicate: typing.Optional[typing.Callable[["Frame"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Frame": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["framedetached"],
+        predicate: typing.Optional[typing.Callable[["Frame"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Frame": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["framenavigated"],
+        predicate: typing.Optional[typing.Callable[["Frame"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Frame": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["load"],
+        predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Page": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["pageerror"],
+        predicate: typing.Optional[typing.Callable[["Error"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Error": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["popup"],
+        predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Page": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["request"],
+        predicate: typing.Optional[typing.Callable[["Request"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Request": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["requestfailed"],
+        predicate: typing.Optional[typing.Callable[["Request"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Request": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["requestfinished"],
+        predicate: typing.Optional[typing.Callable[["Request"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Request": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["response"],
+        predicate: typing.Optional[typing.Callable[["Response"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Response": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["websocket"],
+        predicate: typing.Optional[typing.Callable[["WebSocket"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "WebSocket": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["worker"],
+        predicate: typing.Optional[typing.Callable[["Worker"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Worker": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: str,
+        predicate: typing.Optional[typing.Callable[..., bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> typing.Any: ...
+
     async def wait_for_event(
         self,
         event: str,
@@ -12074,6 +12379,186 @@ class Page(AsyncContextManager):
             )
         )
 
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["close"],
+        predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["Page"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["console"],
+        predicate: typing.Optional[typing.Callable[["ConsoleMessage"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["ConsoleMessage"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["crash"],
+        predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["Page"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["dialog"],
+        predicate: typing.Optional[typing.Callable[["Dialog"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["Dialog"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["domcontentloaded"],
+        predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["Page"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["download"],
+        predicate: typing.Optional[typing.Callable[["Download"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["Download"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["filechooser"],
+        predicate: typing.Optional[typing.Callable[["FileChooser"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["FileChooser"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["frameattached"],
+        predicate: typing.Optional[typing.Callable[["Frame"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["Frame"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["framedetached"],
+        predicate: typing.Optional[typing.Callable[["Frame"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["Frame"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["framenavigated"],
+        predicate: typing.Optional[typing.Callable[["Frame"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["Frame"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["load"],
+        predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["Page"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["pageerror"],
+        predicate: typing.Optional[typing.Callable[["Error"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["Error"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["popup"],
+        predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["Page"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["request"],
+        predicate: typing.Optional[typing.Callable[["Request"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["Request"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["requestfailed"],
+        predicate: typing.Optional[typing.Callable[["Request"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["Request"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["requestfinished"],
+        predicate: typing.Optional[typing.Callable[["Request"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["Request"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["response"],
+        predicate: typing.Optional[typing.Callable[["Response"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["Response"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["websocket"],
+        predicate: typing.Optional[typing.Callable[["WebSocket"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["WebSocket"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["worker"],
+        predicate: typing.Optional[typing.Callable[["Worker"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["Worker"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: str,
+        predicate: typing.Optional[typing.Callable[..., bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager[typing.Any]: ...
+
     def expect_event(
         self,
         event: str,
@@ -13964,6 +14449,114 @@ class BrowserContext(AsyncContextManager):
             )
         )
 
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["backgroundpage"],
+        predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["Page"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["close"],
+        predicate: typing.Optional[typing.Callable[["BrowserContext"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["BrowserContext"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["console"],
+        predicate: typing.Optional[typing.Callable[["ConsoleMessage"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["ConsoleMessage"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["dialog"],
+        predicate: typing.Optional[typing.Callable[["Dialog"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["Dialog"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["page"],
+        predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["Page"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["weberror"],
+        predicate: typing.Optional[typing.Callable[["WebError"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["WebError"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["request"],
+        predicate: typing.Optional[typing.Callable[["Request"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["Request"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["requestfailed"],
+        predicate: typing.Optional[typing.Callable[["Request"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["Request"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["requestfinished"],
+        predicate: typing.Optional[typing.Callable[["Request"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["Request"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["response"],
+        predicate: typing.Optional[typing.Callable[["Response"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["Response"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["serviceworker"],
+        predicate: typing.Optional[typing.Callable[["Worker"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager["Worker"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: str,
+        predicate: typing.Optional[typing.Callable[..., bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncEventContextManager[typing.Any]: ...
+
     def expect_event(
         self,
         event: str,
@@ -14088,6 +14681,114 @@ class BrowserContext(AsyncContextManager):
         return mapping.from_maybe_impl(
             await self._impl_obj.set_storage_state(storageState=storage_state)
         )
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["backgroundpage"],
+        predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Page": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["close"],
+        predicate: typing.Optional[typing.Callable[["BrowserContext"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "BrowserContext": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["console"],
+        predicate: typing.Optional[typing.Callable[["ConsoleMessage"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "ConsoleMessage": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["dialog"],
+        predicate: typing.Optional[typing.Callable[["Dialog"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Dialog": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["page"],
+        predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Page": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["weberror"],
+        predicate: typing.Optional[typing.Callable[["WebError"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "WebError": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["request"],
+        predicate: typing.Optional[typing.Callable[["Request"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Request": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["requestfailed"],
+        predicate: typing.Optional[typing.Callable[["Request"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Request": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["requestfinished"],
+        predicate: typing.Optional[typing.Callable[["Request"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Request": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["response"],
+        predicate: typing.Optional[typing.Callable[["Response"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Response": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: typing.Literal["serviceworker"],
+        predicate: typing.Optional[typing.Callable[["Worker"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Worker": ...
+
+    @typing.overload
+    async def wait_for_event(
+        self,
+        event: str,
+        predicate: typing.Optional[typing.Callable[..., bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> typing.Any: ...
 
     async def wait_for_event(
         self,

--- a/playwright/sync_api/_generated.py
+++ b/playwright/sync_api/_generated.py
@@ -1112,6 +1112,55 @@ class WebSocket(SyncBase):
         """
         return mapping.from_maybe_impl(self._impl_obj.url)
 
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["close"],
+        predicate: typing.Optional[typing.Callable[["WebSocket"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["WebSocket"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["framereceived"],
+        predicate: typing.Optional[
+            typing.Callable[["typing.Union[bytes, str]"], bool]
+        ] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["typing.Union[bytes, str]"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["framesent"],
+        predicate: typing.Optional[
+            typing.Callable[["typing.Union[bytes, str]"], bool]
+        ] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["typing.Union[bytes, str]"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["socketerror"],
+        predicate: typing.Optional[typing.Callable[["str"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["str"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: str,
+        predicate: typing.Optional[typing.Callable[..., bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager[typing.Any]: ...
+
     def expect_event(
         self,
         event: str,
@@ -1144,6 +1193,55 @@ class WebSocket(SyncBase):
                 event=event, predicate=self._wrap_handler(predicate), timeout=timeout
             ).future,
         )
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["close"],
+        predicate: typing.Optional[typing.Callable[["WebSocket"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "WebSocket": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["framereceived"],
+        predicate: typing.Optional[
+            typing.Callable[["typing.Union[bytes, str]"], bool]
+        ] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "typing.Union[bytes, str]": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["framesent"],
+        predicate: typing.Optional[
+            typing.Callable[["typing.Union[bytes, str]"], bool]
+        ] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "typing.Union[bytes, str]": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["socketerror"],
+        predicate: typing.Optional[typing.Callable[["str"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "str": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: str,
+        predicate: typing.Optional[typing.Callable[..., bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> typing.Any: ...
 
     def wait_for_event(
         self,
@@ -6825,6 +6923,33 @@ class Worker(SyncBase):
             )
         )
 
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["close"],
+        predicate: typing.Optional[typing.Callable[["Worker"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["Worker"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["console"],
+        predicate: typing.Optional[typing.Callable[["ConsoleMessage"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["ConsoleMessage"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: str,
+        predicate: typing.Optional[typing.Callable[..., bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager[typing.Any]: ...
+
     def expect_event(
         self,
         event: str,
@@ -9532,6 +9657,186 @@ class Page(SyncContextManager):
             )
         )
 
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["close"],
+        predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Page": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["console"],
+        predicate: typing.Optional[typing.Callable[["ConsoleMessage"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "ConsoleMessage": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["crash"],
+        predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Page": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["dialog"],
+        predicate: typing.Optional[typing.Callable[["Dialog"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Dialog": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["domcontentloaded"],
+        predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Page": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["download"],
+        predicate: typing.Optional[typing.Callable[["Download"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Download": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["filechooser"],
+        predicate: typing.Optional[typing.Callable[["FileChooser"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "FileChooser": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["frameattached"],
+        predicate: typing.Optional[typing.Callable[["Frame"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Frame": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["framedetached"],
+        predicate: typing.Optional[typing.Callable[["Frame"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Frame": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["framenavigated"],
+        predicate: typing.Optional[typing.Callable[["Frame"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Frame": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["load"],
+        predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Page": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["pageerror"],
+        predicate: typing.Optional[typing.Callable[["Error"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Error": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["popup"],
+        predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Page": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["request"],
+        predicate: typing.Optional[typing.Callable[["Request"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Request": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["requestfailed"],
+        predicate: typing.Optional[typing.Callable[["Request"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Request": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["requestfinished"],
+        predicate: typing.Optional[typing.Callable[["Request"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Request": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["response"],
+        predicate: typing.Optional[typing.Callable[["Response"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Response": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["websocket"],
+        predicate: typing.Optional[typing.Callable[["WebSocket"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "WebSocket": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["worker"],
+        predicate: typing.Optional[typing.Callable[["Worker"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Worker": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: str,
+        predicate: typing.Optional[typing.Callable[..., bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> typing.Any: ...
+
     def wait_for_event(
         self,
         event: str,
@@ -12130,6 +12435,186 @@ class Page(SyncContextManager):
             )
         )
 
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["close"],
+        predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["Page"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["console"],
+        predicate: typing.Optional[typing.Callable[["ConsoleMessage"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["ConsoleMessage"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["crash"],
+        predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["Page"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["dialog"],
+        predicate: typing.Optional[typing.Callable[["Dialog"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["Dialog"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["domcontentloaded"],
+        predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["Page"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["download"],
+        predicate: typing.Optional[typing.Callable[["Download"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["Download"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["filechooser"],
+        predicate: typing.Optional[typing.Callable[["FileChooser"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["FileChooser"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["frameattached"],
+        predicate: typing.Optional[typing.Callable[["Frame"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["Frame"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["framedetached"],
+        predicate: typing.Optional[typing.Callable[["Frame"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["Frame"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["framenavigated"],
+        predicate: typing.Optional[typing.Callable[["Frame"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["Frame"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["load"],
+        predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["Page"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["pageerror"],
+        predicate: typing.Optional[typing.Callable[["Error"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["Error"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["popup"],
+        predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["Page"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["request"],
+        predicate: typing.Optional[typing.Callable[["Request"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["Request"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["requestfailed"],
+        predicate: typing.Optional[typing.Callable[["Request"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["Request"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["requestfinished"],
+        predicate: typing.Optional[typing.Callable[["Request"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["Request"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["response"],
+        predicate: typing.Optional[typing.Callable[["Response"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["Response"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["websocket"],
+        predicate: typing.Optional[typing.Callable[["WebSocket"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["WebSocket"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["worker"],
+        predicate: typing.Optional[typing.Callable[["Worker"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["Worker"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: str,
+        predicate: typing.Optional[typing.Callable[..., bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager[typing.Any]: ...
+
     def expect_event(
         self,
         event: str,
@@ -13967,6 +14452,114 @@ class BrowserContext(SyncContextManager):
             )
         )
 
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["backgroundpage"],
+        predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["Page"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["close"],
+        predicate: typing.Optional[typing.Callable[["BrowserContext"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["BrowserContext"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["console"],
+        predicate: typing.Optional[typing.Callable[["ConsoleMessage"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["ConsoleMessage"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["dialog"],
+        predicate: typing.Optional[typing.Callable[["Dialog"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["Dialog"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["page"],
+        predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["Page"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["weberror"],
+        predicate: typing.Optional[typing.Callable[["WebError"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["WebError"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["request"],
+        predicate: typing.Optional[typing.Callable[["Request"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["Request"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["requestfailed"],
+        predicate: typing.Optional[typing.Callable[["Request"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["Request"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["requestfinished"],
+        predicate: typing.Optional[typing.Callable[["Request"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["Request"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["response"],
+        predicate: typing.Optional[typing.Callable[["Response"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["Response"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: typing.Literal["serviceworker"],
+        predicate: typing.Optional[typing.Callable[["Worker"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager["Worker"]: ...
+
+    @typing.overload
+    def expect_event(
+        self,
+        event: str,
+        predicate: typing.Optional[typing.Callable[..., bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> EventContextManager[typing.Any]: ...
+
     def expect_event(
         self,
         event: str,
@@ -14091,6 +14684,114 @@ class BrowserContext(SyncContextManager):
         return mapping.from_maybe_impl(
             self._sync(self._impl_obj.set_storage_state(storageState=storage_state))
         )
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["backgroundpage"],
+        predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Page": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["close"],
+        predicate: typing.Optional[typing.Callable[["BrowserContext"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "BrowserContext": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["console"],
+        predicate: typing.Optional[typing.Callable[["ConsoleMessage"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "ConsoleMessage": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["dialog"],
+        predicate: typing.Optional[typing.Callable[["Dialog"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Dialog": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["page"],
+        predicate: typing.Optional[typing.Callable[["Page"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Page": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["weberror"],
+        predicate: typing.Optional[typing.Callable[["WebError"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "WebError": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["request"],
+        predicate: typing.Optional[typing.Callable[["Request"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Request": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["requestfailed"],
+        predicate: typing.Optional[typing.Callable[["Request"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Request": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["requestfinished"],
+        predicate: typing.Optional[typing.Callable[["Request"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Request": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["response"],
+        predicate: typing.Optional[typing.Callable[["Response"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Response": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: typing.Literal["serviceworker"],
+        predicate: typing.Optional[typing.Callable[["Worker"], bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> "Worker": ...
+
+    @typing.overload
+    def wait_for_event(
+        self,
+        event: str,
+        predicate: typing.Optional[typing.Callable[..., bool]] = None,
+        *,
+        timeout: typing.Optional[float] = None,
+    ) -> typing.Any: ...
 
     def wait_for_event(
         self,

--- a/scripts/documentation_provider.py
+++ b/scripts/documentation_provider.py
@@ -243,6 +243,55 @@ class DocumentationProvider:
                 doc.append(f"        return super().{event_type}(event=event,f=f)")
             print("\n".join(doc))
 
+    def print_event_overloads(self, class_name: str, method_name: str) -> None:
+        """Emit ``@typing.overload`` stubs for ``expect_event`` / ``wait_for_event``
+        keyed on ``Literal`` event names with their payload types from api.json,
+        so pyright/mypy can narrow the return type at call sites.
+        Must be called right before the implementation signature is emitted.
+        """
+        if class_name not in self.classes:
+            return
+        events = self.classes[class_name].get("events") or []
+        if not events:
+            return
+        is_expect = method_name == "expect_event"
+        async_prefix = "async " if not is_expect and self.is_async else ""
+        if is_expect:
+            ctx_mgr = (
+                "AsyncEventContextManager" if self.is_async else "EventContextManager"
+            )
+        for event in events:
+            payload = self.serialize_doc_type(event["type"], "")
+            if payload.startswith("{"):
+                payload = "typing.Dict"
+            if "Union[" in payload:
+                payload = payload.replace("Union[", "typing.Union[")
+            return_type = f'{ctx_mgr}["{payload}"]' if is_expect else f'"{payload}"'
+            event_literal = event["name"].lower()
+            print("    @typing.overload")
+            print(f"    {async_prefix}def {method_name}(")
+            print("        self,")
+            print(f'        event: typing.Literal["{event_literal}"],')
+            print(
+                f'        predicate: typing.Optional[typing.Callable[["{payload}"], bool]] = None,'
+            )
+            print("        *,")
+            print("        timeout: typing.Optional[float] = None,")
+            print(f"    ) -> {return_type}: ...")
+            print("")
+        # Catch-all overload for non-literal event names — keeps pyright happy
+        # with `event: str` callers without falling through to `Unknown`.
+        catchall_return = f"{ctx_mgr}[typing.Any]" if is_expect else "typing.Any"
+        print("    @typing.overload")
+        print(f"    {async_prefix}def {method_name}(")
+        print("        self,")
+        print("        event: str,")
+        print("        predicate: typing.Optional[typing.Callable[..., bool]] = None,")
+        print("        *,")
+        print("        timeout: typing.Optional[float] = None,")
+        print(f"    ) -> {catchall_return}: ...")
+        print("")
+
     def indent_paragraph(self, p: str, indent: str) -> str:
         lines = p.split("\n")
         result = [lines[0]]

--- a/scripts/generate_async_api.py
+++ b/scripts/generate_async_api.py
@@ -92,6 +92,8 @@ def generate(t: Any) -> None:
                 '"Disposable"', '"AsyncContextManager"'
             ).replace('"DisposableStub"', '"AsyncContextManager"')
             print("")
+            if name in ("expect_event", "wait_for_event"):
+                documentation_provider.print_event_overloads(class_name, name)
             async_prefix = "async " if is_async else ""
             print(
                 f"    {async_prefix}def {name}({signature(value, len(name) + 9)}) -> {return_type_value}:"

--- a/scripts/generate_sync_api.py
+++ b/scripts/generate_sync_api.py
@@ -93,6 +93,8 @@ def generate(t: Any) -> None:
                 '"Disposable"', '"SyncContextManager"'
             ).replace('"DisposableStub"', '"SyncContextManager"')
             print("")
+            if name in ("expect_event", "wait_for_event"):
+                documentation_provider.print_event_overloads(class_name, name)
             print(
                 f"    def {name}({signature(value, len(name) + 9)}) -> {return_type_value}:"
             )

--- a/tests/async/test_browsercontext_events.py
+++ b/tests/async/test_browsercontext_events.py
@@ -197,7 +197,7 @@ async def test_page_error_event_should_work(page: Page) -> None:
         await page.set_content('<script>throw new Error("boom")</script>')
     page_error = await page_error_info.value
     assert page_error.page == page
-    assert "boom" in page_error.error.stack
+    assert page_error.error.stack and "boom" in page_error.error.stack
 
 
 async def test_weberror_event_should_work(context: BrowserContext, page: Page) -> None:

--- a/tests/async/test_page_request_intercept.py
+++ b/tests/async/test_page_request_intercept.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import asyncio
-from typing import cast
 
 import pytest
 
@@ -98,4 +97,4 @@ async def test_should_fulfill_popup_main_request_using_alias(
     [popup, _] = await asyncio.gather(
         page.wait_for_event("popup"), page.get_by_text("click me").click()
     )
-    await expect(cast(Page, popup).locator("body")).to_have_text("hello")
+    await expect(popup.locator("body")).to_have_text("hello")

--- a/tests/async/test_resource_timing.py
+++ b/tests/async/test_resource_timing.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict
 
 import pytest
 
-from playwright.async_api import Browser, Page
+from playwright.async_api import Browser, Page, ResourceTiming
 from tests.server import Server
 
 
@@ -95,7 +94,7 @@ def verify_timing_value(value: float, previous: float) -> None:
     assert value == -1 or value > 0 and value >= previous
 
 
-def verify_connections_timing_consistency(timing: Dict) -> None:
+def verify_connections_timing_consistency(timing: ResourceTiming) -> None:
     verify_timing_value(timing["domainLookupStart"], -1)
     verify_timing_value(timing["domainLookupEnd"], timing["domainLookupStart"])
     verify_timing_value(timing["connectStart"], timing["domainLookupEnd"])

--- a/tests/sync/test_resource_timing.py
+++ b/tests/sync/test_resource_timing.py
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict
-
 import pytest
 
-from playwright.sync_api import Browser, Page
+from playwright.sync_api import Browser, Page, ResourceTiming
 from tests.server import Server
 
 
@@ -99,7 +97,7 @@ def verify_timing_value(value: float, previous: float) -> None:
     assert value == -1 or value > 0 and value >= previous
 
 
-def verify_connections_timing_consistency(timing: Dict) -> None:
+def verify_connections_timing_consistency(timing: ResourceTiming) -> None:
     verify_timing_value(timing["domainLookupStart"], -1)
     verify_timing_value(timing["domainLookupEnd"], timing["domainLookupStart"])
     verify_timing_value(timing["connectStart"], timing["domainLookupEnd"])


### PR DESCRIPTION
## Summary
- Codegen now emits `@typing.overload` stubs for `expect_event` / `wait_for_event` keyed on `Literal["event_name"]` with the payload type from `api.json`, plus a catch-all `event: str` overload returning `EventContextManager[Any]` / `Any`.
- `info.value` now narrows to the correct payload type (e.g. `Request` for `expect_event("requestfinished")`) instead of `Any`/`Unknown` under strict pyright.
- Fixes a couple of latent test-side type slips that the new precise types exposed (`ResourceTiming` vs `Dict`, optional `Error.stack`).

Fixes https://github.com/microsoft/playwright-python/issues/3047