### PR TITLE
chore: roll to 1.60.0-beta-1778142790000

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Playwright is a Python library to automate [Chromium](https://www.chromium.org/H
 |   :---   | :---: | :---: | :---:   |
 | Chromium <!-- GEN:chromium-version -->148.0.7778.96<!-- GEN:stop --> | ✅ | ✅ | ✅ |
 | WebKit <!-- GEN:webkit-version -->26.4<!-- GEN:stop --> | ✅ | ✅ | ✅ |
-| Firefox <!-- GEN:firefox-version -->150.0.1<!-- GEN:stop --> | ✅ | ✅ | ✅ |
+| Firefox <!-- GEN:firefox-version -->150.0.2<!-- GEN:stop --> | ✅ | ✅ | ✅ |
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Playwright is a Python library to automate [Chromium](https://www.chromium.org/H
 
 |          | Linux | macOS | Windows |
 |   :---   | :---: | :---: | :---:   |
-| Chromium <!-- GEN:chromium-version -->147.0.7727.15<!-- GEN:stop --> | ✅ | ✅ | ✅ |
+| Chromium <!-- GEN:chromium-version -->148.0.7778.96<!-- GEN:stop --> | ✅ | ✅ | ✅ |
 | WebKit <!-- GEN:webkit-version -->26.4<!-- GEN:stop --> | ✅ | ✅ | ✅ |
-| Firefox <!-- GEN:firefox-version -->148.0.2<!-- GEN:stop --> | ✅ | ✅ | ✅ |
+| Firefox <!-- GEN:firefox-version -->150.0.1<!-- GEN:stop --> | ✅ | ✅ | ✅ |
 
 ## Documentation
 

--- a/playwright/_impl/_api_structures.py
+++ b/playwright/_impl/_api_structures.py
@@ -151,14 +151,29 @@ class ViewportSize(TypedDict):
 
 class SourceLocation(TypedDict):
     url: str
+    line: int
+    column: int
     lineNumber: int
     columnNumber: int
+
+
+class WebErrorLocation(TypedDict):
+    url: str
+    line: int
+    column: int
 
 
 class FilePayload(TypedDict):
     name: str
     mimeType: str
     buffer: bytes
+
+
+class DropPayload(TypedDict, total=False):
+    files: Optional[
+        Union[str, Path, FilePayload, Sequence[Union[str, Path]], Sequence[FilePayload]]
+    ]
+    data: Optional[Dict[str, str]]
 
 
 class RemoteAddr(TypedDict):
@@ -216,6 +231,7 @@ class FrameExpectOptions(TypedDict, total=False):
     useInnerText: Optional[bool]
     isNot: bool
     timeout: Optional[float]
+    pseudo: Optional[str]
 
 
 class FrameExpectResult(TypedDict):
@@ -330,3 +346,5 @@ class DebuggerPausedDetails(TypedDict):
 
 class ScreencastFrame(TypedDict):
     data: bytes
+    viewportWidth: int
+    viewportHeight: int

--- a/playwright/_impl/_assertions.py
+++ b/playwright/_impl/_assertions.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import collections.abc
-from typing import Any, List, Optional, Pattern, Sequence, Union
+from typing import Any, List, Literal, Optional, Pattern, Sequence, Union
 from urllib.parse import urljoin
 
 from playwright._impl._api_structures import (
@@ -26,6 +26,7 @@ from playwright._impl._connection import format_call_log
 from playwright._impl._errors import Error
 from playwright._impl._fetch import APIResponse
 from playwright._impl._helper import is_textual_mime_type
+from playwright._impl._js_handle import parse_value
 from playwright._impl._locator import Locator
 from playwright._impl._page import Page
 from playwright._impl._str_utils import escape_regex_flags
@@ -71,7 +72,14 @@ class AssertionsBase:
             del expect_options["useInnerText"]
         result = await self._call_expect(expression, expect_options, title)
         if result["matches"] == self._is_not:
-            actual = result.get("received")
+            received = result.get("received") or {}
+            if isinstance(received, dict):
+                if "value" in received and received["value"] is not None:
+                    actual = parse_value(received["value"])
+                else:
+                    actual = received.get("ariaSnapshot")
+            else:
+                actual = received
             if self._custom_message:
                 out_message = self._custom_message
                 if expected is not None:
@@ -160,6 +168,24 @@ class PageAssertions(AssertionsBase):
     ) -> None:
         __tracebackhide__ = True
         await self._not.to_have_url(urlOrRegExp, timeout, ignoreCase)
+
+    async def to_match_aria_snapshot(
+        self, expected: str, timeout: float = None
+    ) -> None:
+        __tracebackhide__ = True
+        await self._expect_impl(
+            "to.match.aria",
+            FrameExpectOptions(expectedValue=expected, timeout=timeout),
+            expected,
+            "Page expected to match Aria snapshot",
+            'Expect "to_match_aria_snapshot"',
+        )
+
+    async def not_to_match_aria_snapshot(
+        self, expected: str, timeout: float = None
+    ) -> None:
+        __tracebackhide__ = True
+        await self._not.to_match_aria_snapshot(expected, timeout)
 
 
 class LocatorAssertions(AssertionsBase):
@@ -400,13 +426,17 @@ class LocatorAssertions(AssertionsBase):
         name: str,
         value: Union[str, Pattern[str]],
         timeout: float = None,
+        pseudo: Literal["after", "before"] = None,
     ) -> None:
         __tracebackhide__ = True
         expected_text = to_expected_text_values([value])
         await self._expect_impl(
             "to.have.css",
             FrameExpectOptions(
-                expressionArg=name, expectedText=expected_text, timeout=timeout
+                expressionArg=name,
+                expectedText=expected_text,
+                timeout=timeout,
+                pseudo=pseudo,
             ),
             value,
             "Locator expected to have CSS",

--- a/playwright/_impl/_browser.py
+++ b/playwright/_impl/_browser.py
@@ -59,6 +59,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 class Browser(ChannelOwner):
     Events = SimpleNamespace(
+        Context="context",
         Disconnected="disconnected",
     )
 
@@ -104,6 +105,7 @@ class Browser(ChannelOwner):
         # and will be configured later in `ConnectToBrowserType`.
         if self._browser_type:
             self._setup_browser_context(context)
+        self.emit(Browser.Events.Context, context)
 
     def _setup_browser_context(self, context: BrowserContext) -> None:
         context._tracing._traces_dir = self._traces_dir

--- a/playwright/_impl/_browser_context.py
+++ b/playwright/_impl/_browser_context.py
@@ -36,8 +36,8 @@ from playwright._impl._api_structures import (
     Geolocation,
     SetCookieParam,
     StorageState,
+    WebErrorLocation,
 )
-from playwright._impl._artifact import Artifact
 from playwright._impl._cdp_session import CDPSession
 from playwright._impl._clock import Clock
 from playwright._impl._connection import (
@@ -57,7 +57,6 @@ from playwright._impl._har_router import HarRouter
 from playwright._impl._helper import (
     HarContentPolicy,
     HarMode,
-    HarRecordingMetadata,
     RouteFromHarNotFoundPolicy,
     RouteHandler,
     RouteHandlerCallback,
@@ -95,7 +94,13 @@ class BrowserContext(ChannelOwner):
         Close="close",
         Console="console",
         Dialog="dialog",
+        Download="download",
+        FrameAttached="frameattached",
+        FrameDetached="framedetached",
+        FrameNavigated="framenavigated",
         Page="page",
+        PageClose="pageclose",
+        PageLoad="pageload",
         WebError="weberror",
         ServiceWorker="serviceworker",
         Request="request",
@@ -125,7 +130,6 @@ class BrowserContext(ChannelOwner):
         self._videos_dir: Optional[str] = self._options.get("recordVideo")
         self._tracing = cast(Tracing, from_channel(initializer["tracing"]))
         self._debugger: Debugger = cast(Debugger, from_channel(initializer["debugger"]))
-        self._har_recorders: Dict[str, HarRecordingMetadata] = {}
         self._request: APIRequestContext = from_channel(initializer["requestContext"])
         self._request._timeout_settings = self._timeout_settings
         self._clock = Clock(self)
@@ -171,6 +175,10 @@ class BrowserContext(ChannelOwner):
             lambda params: self._on_page_error(
                 parse_error(params["error"]["error"]),
                 from_nullable_channel(params["page"]),
+                cast(
+                    WebErrorLocation,
+                    params.get("location") or {"url": "", "line": 0, "column": 0},
+                ),
             ),
         )
         self._channel.on(
@@ -321,7 +329,7 @@ class BrowserContext(ChannelOwner):
         content_policy: HarContentPolicy = record_har_content or (
             "omit" if record_har_omit_content is True else default_policy
         )
-        await self._record_into_har(
+        await self._tracing._record_into_har(
             har=record_har_path,
             page=None,
             url=record_har_url_filter,
@@ -404,9 +412,7 @@ class BrowserContext(ChannelOwner):
             await self._channel.send("addInitScript", None, dict(source=script))
         )
 
-    async def expose_binding(
-        self, name: str, callback: Callable, handle: bool = None
-    ) -> Disposable:
+    async def expose_binding(self, name: str, callback: Callable) -> Disposable:
         for page in self._pages:
             if name in page._bindings:
                 raise Error(
@@ -416,9 +422,7 @@ class BrowserContext(ChannelOwner):
             raise Error(f'Function "{name}" has been already registered')
         self._bindings[name] = callback
         return from_channel(
-            await self._channel.send(
-                "exposeBinding", None, dict(name=name, needsHandle=handle or False)
-            )
+            await self._channel.send("exposeBinding", None, dict(name=name))
         )
 
     async def expose_function(self, name: str, callback: Callable) -> Disposable:
@@ -483,35 +487,6 @@ class BrowserContext(ChannelOwner):
         await self._unroute_internal(self._routes, [], behavior)
         self._dispose_har_routers()
 
-    async def _record_into_har(
-        self,
-        har: Union[Path, str],
-        page: Optional[Page] = None,
-        url: Union[Pattern[str], str] = None,
-        update_content: HarContentPolicy = None,
-        update_mode: HarMode = None,
-    ) -> None:
-        update_content = update_content or "attach"
-        params: Dict[str, Any] = {
-            "options": {
-                "zip": str(har).endswith(".zip"),
-                "content": update_content,
-                "urlGlob": url if isinstance(url, str) else None,
-                "urlRegexSource": url.pattern if isinstance(url, Pattern) else None,
-                "urlRegexFlags": (
-                    escape_regex_flags(url) if isinstance(url, Pattern) else None
-                ),
-                "mode": update_mode or "minimal",
-            }
-        }
-        if page:
-            params["page"] = page._channel
-        har_id = await self._channel.send("harStart", None, params)
-        self._har_recorders[har_id] = {
-            "path": str(har),
-            "content": update_content,
-        }
-
     async def route_from_har(
         self,
         har: Union[Path, str],
@@ -522,7 +497,7 @@ class BrowserContext(ChannelOwner):
         updateMode: HarMode = None,
     ) -> None:
         if update:
-            await self._record_into_har(
+            await self._tracing._record_into_har(
                 har=har,
                 page=None,
                 url=url,
@@ -602,27 +577,7 @@ class BrowserContext(ChannelOwner):
         await self.request.dispose(reason=reason)
 
         async def _inner_close() -> None:
-            for har_id, params in self._har_recorders.items():
-                har = cast(
-                    Artifact,
-                    from_channel(
-                        await self._channel.send("harExport", None, {"harId": har_id})
-                    ),
-                )
-                # Server side will compress artifact if content is attach or if file is .zip.
-                is_compressed = params.get("content") == "attach" or params[
-                    "path"
-                ].endswith(".zip")
-                need_compressed = params["path"].endswith(".zip")
-                if is_compressed and not need_compressed:
-                    tmp_path = params["path"] + ".tmp"
-                    await har.save_as(tmp_path)
-                    await self._connection.local_utils.har_unzip(
-                        zipFile=tmp_path, harFile=params["path"]
-                    )
-                else:
-                    await har.save_as(params["path"])
-                await har.delete()
+            await self._tracing._export_all_hars()
 
         await self._channel._connection.wrap_api_call(_inner_close, True)
         await self._channel.send("close", None, {"reason": reason})
@@ -732,10 +687,12 @@ class BrowserContext(ChannelOwner):
             else:
                 asyncio.create_task(dialog.dismiss())
 
-    def _on_page_error(self, error: Error, page: Optional[Page]) -> None:
+    def _on_page_error(
+        self, error: Error, page: Optional[Page], location: WebErrorLocation
+    ) -> None:
         self.emit(
             BrowserContext.Events.WebError,
-            WebError(self._loop, self._dispatcher_fiber, page, error),
+            WebError(self._loop, self._dispatcher_fiber, page, error, location),
         )
         if page:
             page.emit(Page.Events.PageError, error)

--- a/playwright/_impl/_browser_type.py
+++ b/playwright/_impl/_browser_type.py
@@ -201,6 +201,7 @@ class BrowserType(ChannelOwner):
         slowMo: float = None,
         headers: Dict[str, str] = None,
         isLocal: bool = None,
+        noDefaults: bool = None,
     ) -> Browser:
         params = locals_to_params(locals())
         if params.get("headers"):

--- a/playwright/_impl/_console_message.py
+++ b/playwright/_impl/_console_message.py
@@ -74,7 +74,16 @@ class ConsoleMessage:
 
     @property
     def location(self) -> SourceLocation:
-        return self._event["location"]
+        # Wire format uses `lineNumber`/`columnNumber`; docs expose both `line`/`column`
+        # (legacy) and `lineNumber`/`columnNumber` (added upstream in 1.60).
+        loc = self._event["location"]
+        return {
+            "url": loc["url"],
+            "line": loc["lineNumber"],
+            "column": loc["columnNumber"],
+            "lineNumber": loc["lineNumber"],
+            "columnNumber": loc["columnNumber"],
+        }
 
     @property
     def timestamp(self) -> float:

--- a/playwright/_impl/_fetch.py
+++ b/playwright/_impl/_fetch.py
@@ -110,6 +110,7 @@ class APIRequestContext(ChannelOwner):
 
     async def dispose(self, reason: str = None) -> None:
         self._close_reason = reason
+        await self._tracing._export_all_hars()
         try:
             await self._channel.send("dispose", None, {"reason": reason})
         except Error as e:
@@ -117,6 +118,10 @@ class APIRequestContext(ChannelOwner):
                 return
             raise e
         self._tracing._reset_stack_counter()
+
+    @property
+    def tracing(self) -> Tracing:
+        return self._tracing
 
     async def delete(
         self,

--- a/playwright/_impl/_frame.py
+++ b/playwright/_impl/_frame.py
@@ -32,6 +32,7 @@ from pyee import EventEmitter
 
 from playwright._impl._api_structures import (
     AriaRole,
+    DropPayload,
     FilePayload,
     FrameExpectOptions,
     FrameExpectResult,
@@ -122,6 +123,7 @@ class Frame(ChannelOwner):
             self._load_states.remove(remove)
         if not self._parent_frame and add == "load" and self._page:
             self._page.emit("load", self._page)
+            self._page.context.emit("pageload", self._page)
         if not self._parent_frame and add == "domcontentloaded" and self._page:
             self._page.emit("domcontentloaded", self._page)
 
@@ -131,6 +133,7 @@ class Frame(ChannelOwner):
         self._event_emitter.emit("navigated", event)
         if "error" not in event and self._page:
             self._page.emit("framenavigated", self)
+            self._page.context.emit("framenavigated", self)
 
     async def _query_count(self, selector: str) -> int:
         return await self._channel.send("queryCount", None, {"selector": selector})
@@ -662,6 +665,7 @@ class Frame(ChannelOwner):
         pressed: bool = None,
         selected: bool = None,
         exact: bool = None,
+        description: Union[str, Pattern[str]] = None,
     ) -> "Locator":
         return self.locator(
             get_by_role_selector(
@@ -675,6 +679,7 @@ class Frame(ChannelOwner):
                 pressed=pressed,
                 selected=selected,
                 exact=exact,
+                description=description,
             )
         )
 
@@ -812,6 +817,33 @@ class Frame(ChannelOwner):
             },
         )
 
+    async def _drop(
+        self,
+        selector: str,
+        payload: "DropPayload",
+        strict: bool = None,
+        position: Position = None,
+        timeout: float = None,
+    ) -> None:
+        params: Dict[str, Any] = {
+            "selector": selector,
+            "strict": strict,
+            "position": position,
+            "timeout": self._timeout(timeout),
+        }
+        files = payload.get("files") if payload else None
+        if files is not None:
+            converted = await convert_input_files(files, self.page.context)
+            if "directoryStream" in converted or "directoryLocalPath" in converted:
+                raise Error(
+                    "Dropping a directory is not supported, pass individual files instead."
+                )
+            params.update(converted)
+        data = payload.get("data") if payload else None
+        if data is not None:
+            params["data"] = [{"mimeType": k, "value": v} for k, v in data.items()]
+        await self._channel.send("drop", self._timeout, params)
+
     async def type(
         self,
         selector: str,
@@ -911,5 +943,10 @@ class Frame(ChannelOwner):
                 trial=trial,
             )
 
-    async def _highlight(self, selector: str) -> None:
-        await self._channel.send("highlight", None, {"selector": selector})
+    async def _highlight(self, selector: str, style: str = None) -> None:
+        await self._channel.send(
+            "highlight", None, {"selector": selector, "style": style}
+        )
+
+    async def _hide_highlight(self, selector: str) -> None:
+        await self._channel.send("hideHighlight", None, {"selector": selector})

--- a/playwright/_impl/_locator.py
+++ b/playwright/_impl/_locator.py
@@ -33,6 +33,7 @@ from typing import (
 
 from playwright._impl._api_structures import (
     AriaRole,
+    DropPayload,
     FilePayload,
     FloatRect,
     FrameExpectOptions,
@@ -279,6 +280,7 @@ class Locator:
         pressed: bool = None,
         selected: bool = None,
         exact: bool = None,
+        description: Union[str, Pattern[str]] = None,
     ) -> "Locator":
         return self.locator(
             get_by_role_selector(
@@ -292,6 +294,7 @@ class Locator:
                 pressed=pressed,
                 selected=selected,
                 exact=exact,
+                description=description,
             )
         )
 
@@ -439,6 +442,20 @@ class Locator:
             self._selector, target._selector, strict=True, **params
         )
 
+    async def drop(
+        self,
+        payload: DropPayload,
+        position: Position = None,
+        timeout: float = None,
+    ) -> None:
+        await self._frame._drop(
+            self._selector,
+            payload,
+            strict=True,
+            position=position,
+            timeout=timeout,
+        )
+
     async def get_attribute(self, name: str, timeout: float = None) -> Optional[str]:
         params = locals_to_params(locals())
         return await self._frame.get_attribute(
@@ -569,6 +586,7 @@ class Locator:
         timeout: float = None,
         depth: int = None,
         mode: Literal["ai", "default"] = None,
+        boxes: bool = None,
     ) -> str:
         return await self._frame._channel.send(
             "ariaSnapshot",
@@ -756,8 +774,11 @@ class Locator:
     ) -> FrameExpectResult:
         return await self._frame._expect(self._selector, expression, options, title)
 
-    async def highlight(self) -> None:
-        await self._frame._highlight(self._selector)
+    async def highlight(self, style: str = None) -> None:
+        await self._frame._highlight(self._selector, style)
+
+    async def hide_highlight(self) -> None:
+        await self._frame._hide_highlight(self._selector)
 
 
 class FrameLocator:
@@ -823,6 +844,7 @@ class FrameLocator:
         pressed: bool = None,
         selected: bool = None,
         exact: bool = None,
+        description: Union[str, Pattern[str]] = None,
     ) -> "Locator":
         return self.locator(
             get_by_role_selector(
@@ -836,6 +858,7 @@ class FrameLocator:
                 pressed=pressed,
                 selected=selected,
                 exact=exact,
+                description=description,
             )
         )
 
@@ -938,6 +961,7 @@ def get_by_role_selector(
     pressed: bool = None,
     selected: bool = None,
     exact: bool = None,
+    description: Union[str, Pattern[str]] = None,
 ) -> str:
     props: List[Tuple[str, str]] = []
     if checked is not None:
@@ -957,6 +981,13 @@ def get_by_role_selector(
             (
                 "name",
                 escape_for_attribute_selector(name, exact=exact),
+            )
+        )
+    if description is not None:
+        props.append(
+            (
+                "description",
+                escape_for_attribute_selector(description, exact=exact),
             )
         )
     if pressed is not None:

--- a/playwright/_impl/_network.py
+++ b/playwright/_impl/_network.py
@@ -596,6 +596,10 @@ class ServerWebSocketRoute:
     def url(self) -> str:
         return self._ws._initializer["url"]
 
+    @property
+    def protocols(self) -> List[str]:
+        return list(self._ws._initializer.get("protocols", []))
+
     def close(self, code: int = None, reason: str = None) -> None:
         _create_task_and_ignore_exception(
             self._ws._loop,
@@ -693,6 +697,10 @@ class WebSocketRoute(ChannelOwner):
     @property
     def url(self) -> str:
         return self._initializer["url"]
+
+    @property
+    def protocols(self) -> List[str]:
+        return list(self._initializer.get("protocols", []))
 
     async def close(self, code: int = None, reason: str = None) -> None:
         try:

--- a/playwright/_impl/_page.py
+++ b/playwright/_impl/_page.py
@@ -280,11 +280,13 @@ class Page(ChannelOwner):
         frame._page = self
         self._frames.append(frame)
         self.emit(Page.Events.FrameAttached, frame)
+        self._browser_context.emit("frameattached", frame)
 
     def _on_frame_detached(self, frame: Frame) -> None:
         self._frames.remove(frame)
         frame._detached = True
         self.emit(Page.Events.FrameDetached, frame)
+        self._browser_context.emit("framedetached", frame)
 
     async def _on_route(self, route: Route) -> None:
         route._context = self.context
@@ -350,6 +352,7 @@ class Page(ChannelOwner):
             self._browser_context._pages.remove(self)
         self._dispose_har_routers()
         self.emit(Page.Events.Close, self)
+        self._browser_context.emit("pageclose", self)
 
     def _on_crash(self) -> None:
         self.emit(Page.Events.Crash, self)
@@ -358,9 +361,9 @@ class Page(ChannelOwner):
         url = params["url"]
         suggested_filename = params["suggestedFilename"]
         artifact = cast(Artifact, from_channel(params["artifact"]))
-        self.emit(
-            Page.Events.Download, Download(self, url, suggested_filename, artifact)
-        )
+        download = Download(self, url, suggested_filename, artifact)
+        self.emit(Page.Events.Download, download)
+        self._browser_context.emit("download", download)
 
     def _on_viewport_size_changed(self, params: Any) -> None:
         self._viewport_size = params["viewportSize"]
@@ -506,9 +509,7 @@ class Page(ChannelOwner):
     async def expose_function(self, name: str, callback: Callable) -> Disposable:
         return await self.expose_binding(name, lambda source, *args: callback(*args))
 
-    async def expose_binding(
-        self, name: str, callback: Callable, handle: bool = None
-    ) -> Disposable:
+    async def expose_binding(self, name: str, callback: Callable) -> Disposable:
         if name in self._bindings:
             raise Error(f'Function "{name}" has been already registered')
         if name in self._browser_context._bindings:
@@ -520,7 +521,7 @@ class Page(ChannelOwner):
             await self._channel.send(
                 "exposeBinding",
                 None,
-                dict(name=name, needsHandle=handle or False),
+                dict(name=name),
             )
         )
 
@@ -663,6 +664,9 @@ class Page(ChannelOwner):
     async def bring_to_front(self) -> None:
         await self._channel.send("bringToFront", None)
 
+    async def hide_highlight(self) -> None:
+        await self._channel.send("hideHighlight", None)
+
     async def add_init_script(
         self, script: str = None, path: Union[str, Path] = None
     ) -> Disposable:
@@ -750,7 +754,7 @@ class Page(ChannelOwner):
         updateMode: HarMode = None,
     ) -> None:
         if update:
-            await self._browser_context._record_into_har(
+            await self._browser_context._tracing._record_into_har(
                 har=har,
                 page=self,
                 url=url,
@@ -835,6 +839,7 @@ class Page(ChannelOwner):
         timeout: float = None,
         depth: int = None,
         mode: Literal["ai", "default"] = None,
+        boxes: bool = None,
     ) -> str:
         return await self._main_frame._channel.send(
             "ariaSnapshot",
@@ -954,6 +959,7 @@ class Page(ChannelOwner):
         pressed: bool = None,
         selected: bool = None,
         exact: bool = None,
+        description: Union[str, Pattern[str]] = None,
     ) -> "Locator":
         return self._main_frame.get_by_role(
             role,
@@ -966,6 +972,7 @@ class Page(ChannelOwner):
             pressed=pressed,
             selected=selected,
             exact=exact,
+            description=description,
         )
 
     def get_by_test_id(self, testId: Union[str, Pattern[str]]) -> "Locator":

--- a/playwright/_impl/_screencast.py
+++ b/playwright/_impl/_screencast.py
@@ -55,7 +55,13 @@ class Screencast:
         data = params["data"]
         if isinstance(data, str):
             data = base64.b64decode(data)
-        result = self._on_frame({"data": data})
+        result = self._on_frame(
+            {
+                "data": data,
+                "viewportWidth": params["viewportWidth"],
+                "viewportHeight": params["viewportHeight"],
+            }
+        )
         if hasattr(result, "__await__"):
             self._page._loop.create_task(result)
 

--- a/playwright/_impl/_tracing.py
+++ b/playwright/_impl/_tracing.py
@@ -13,13 +13,17 @@
 # limitations under the License.
 
 import pathlib
-from typing import Dict, Optional, Union, cast
+from typing import Any, Dict, Literal, Optional, Pattern, Union, cast
 
 from playwright._impl._api_structures import TracingGroupLocation
 from playwright._impl._artifact import Artifact
-from playwright._impl._connection import ChannelOwner, from_nullable_channel
+from playwright._impl._connection import (
+    ChannelOwner,
+    from_channel,
+    from_nullable_channel,
+)
 from playwright._impl._disposable import DisposableStub
-from playwright._impl._helper import locals_to_params
+from playwright._impl._helper import Error, locals_to_params
 
 
 class Tracing(ChannelOwner):
@@ -32,6 +36,8 @@ class Tracing(ChannelOwner):
         self._stacks_id: Optional[str] = None
         self._is_tracing: bool = False
         self._traces_dir: Optional[str] = None
+        self._har_id: Optional[str] = None
+        self._har_recorders: Dict[str, Dict[str, str]] = {}
 
     async def start(
         self,
@@ -160,3 +166,116 @@ class Tracing(ChannelOwner):
             "tracingGroupEnd",
             None,
         )
+
+    async def start_har(
+        self,
+        path: Union[pathlib.Path, str],
+        content: Literal["attach", "embed", "omit"] = None,
+        mode: Literal["full", "minimal"] = None,
+        urlFilter: Union[str, Pattern[str]] = None,
+    ) -> DisposableStub:
+        if self._har_id:
+            raise Error("HAR recording has already been started")
+        is_zip = str(path).endswith(".zip")
+        default_content: Literal["attach", "embed", "omit"] = (
+            "attach" if is_zip else "embed"
+        )
+        self._har_id = await self._record_into_har(
+            har=path,
+            page=None,
+            url=urlFilter,
+            update_content=content or default_content,
+            update_mode=mode or "full",
+        )
+        return DisposableStub(lambda: self.stop_har(), self)
+
+    async def _record_into_har(
+        self,
+        har: Union[pathlib.Path, str],
+        page: Optional[ChannelOwner],
+        url: Union[str, Pattern[str]] = None,
+        update_content: Literal["attach", "embed", "omit"] = None,
+        update_mode: Literal["full", "minimal"] = None,
+        resourcesDir: Optional[str] = None,
+    ) -> str:
+        is_zip = str(har).endswith(".zip")
+        url_glob: Optional[str] = None
+        url_regex_source: Optional[str] = None
+        url_regex_flags: Optional[str] = None
+        if isinstance(url, str):
+            url_glob = url
+        elif url is not None:
+            url_regex_source = url.pattern
+            url_regex_flags = "".join(
+                flag
+                for flag, mask in (("i", 2), ("m", 8), ("s", 16))
+                if url.flags & mask
+            )
+        options: Dict[str, object] = {
+            "content": update_content or "attach",
+            "mode": update_mode or "minimal",
+            "harPath": None if is_zip else str(har),
+        }
+        if url_glob is not None:
+            options["urlGlob"] = url_glob
+        if url_regex_source is not None:
+            options["urlRegexSource"] = url_regex_source
+        if url_regex_flags is not None:
+            options["urlRegexFlags"] = url_regex_flags
+        if resourcesDir is not None:
+            options["resourcesDir"] = resourcesDir
+        params: Dict[str, Any] = {"options": options}
+        if page is not None:
+            params["page"] = page._channel
+        result = await self._channel.send_return_as_dict("harStart", None, params)
+        har_id = result["harId"]
+        self._har_recorders[har_id] = {"path": str(har)}
+        return har_id
+
+    async def _export_all_hars(self) -> None:
+        for har_id in list(self._har_recorders.keys()):
+            await self._export_har(har_id)
+        self._har_id = None
+
+    async def stop_har(self) -> None:
+        har_id = self._har_id
+        if not har_id:
+            return
+        self._har_id = None
+        await self._export_har(har_id)
+
+    async def _export_har(self, har_id: str) -> None:
+        params = self._har_recorders.pop(har_id, None)
+        if not params:
+            return
+        is_local = not self._connection.is_remote
+        is_zip = params["path"].endswith(".zip")
+
+        if is_local:
+            result = await self._channel.send_return_as_dict(
+                "harExport", None, {"harId": har_id, "mode": "entries"}
+            )
+            if not is_zip:
+                # Server wrote HAR and resources to the user's chosen paths.
+                return
+            await self._connection.local_utils.zip(
+                {
+                    "zipFile": params["path"],
+                    "entries": result["entries"],
+                    "mode": "write",
+                    "includeSources": False,
+                }
+            )
+            return
+
+        result = await self._channel.send_return_as_dict(
+            "harExport", None, {"harId": har_id, "mode": "archive"}
+        )
+        artifact = cast(Artifact, from_channel(result["artifact"]))
+        if is_zip:
+            await artifact.save_as(params["path"])
+            await artifact.delete()
+            return
+        # Uncompressed har is not supported in thin clients
+        await artifact.save_as(params["path"] + ".tmp")
+        await artifact.delete()

--- a/playwright/_impl/_web_error.py
+++ b/playwright/_impl/_web_error.py
@@ -15,6 +15,7 @@
 from asyncio import AbstractEventLoop
 from typing import Any, Optional
 
+from playwright._impl._api_structures import WebErrorLocation
 from playwright._impl._helper import Error
 from playwright._impl._page import Page
 
@@ -26,11 +27,13 @@ class WebError:
         dispatcher_fiber: Any,
         page: Optional[Page],
         error: Error,
+        location: WebErrorLocation,
     ) -> None:
         self._loop = loop
         self._dispatcher_fiber = dispatcher_fiber
         self._page = page
         self._error = error
+        self._location = location
 
     @property
     def page(self) -> Optional[Page]:
@@ -39,3 +42,7 @@ class WebError:
     @property
     def error(self) -> Error:
         return self._error
+
+    @property
+    def location(self) -> WebErrorLocation:
+        return self._location

--- a/playwright/async_api/_generated.py
+++ b/playwright/async_api/_generated.py
@@ -24,6 +24,7 @@ from playwright._impl._api_structures import (
     Cookie,
     DebuggerLocation,
     DebuggerPausedDetails,
+    DropPayload,
     FilePayload,
     FloatRect,
     Geolocation,
@@ -42,6 +43,7 @@ from playwright._impl._api_structures import (
     StorageState,
     TracingGroupLocation,
     ViewportSize,
+    WebErrorLocation,
 )
 from playwright._impl._assertions import (
     APIResponseAssertions as APIResponseAssertionsImpl,
@@ -1218,6 +1220,34 @@ class WebSocketRoute(AsyncBase):
         str
         """
         return mapping.from_maybe_impl(self._impl_obj.url)
+
+    @property
+    def protocols(self) -> typing.List[str]:
+        """WebSocketRoute.protocols
+
+        The list of WebSocket subprotocols requested by the page, as passed via the second argument to the
+        [`WebSocket` constructor](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/WebSocket). Corresponds to the
+        `Sec-WebSocket-Protocol` request header.
+
+        Returns an empty array if no protocols were specified.
+
+        **Usage**
+
+        ```py
+        async def handler(ws: WebSocketRoute):
+          if \"chat.v2\" in ws.protocols:
+            ws.on_message(lambda message: ws.send(f\"v2:{message}\"))
+          else:
+            await ws.close(code=1002, reason=\"Unsupported protocol\")
+
+        await page.route_web_socket(\"wss://example.com/ws\", handler)
+        ```
+
+        Returns
+        -------
+        List[str]
+        """
+        return mapping.from_maybe_impl(self._impl_obj.protocols)
 
     async def close(
         self, *, code: typing.Optional[int] = None, reason: typing.Optional[str] = None
@@ -4831,6 +4861,7 @@ class Frame(AsyncBase):
         pressed: typing.Optional[bool] = None,
         selected: typing.Optional[bool] = None,
         exact: typing.Optional[bool] = None,
+        description: typing.Optional[typing.Union[typing.Pattern[str], str]] = None,
     ) -> "Locator":
         """Frame.get_by_role
 
@@ -4913,8 +4944,13 @@ class Frame(AsyncBase):
 
             Learn more about [`aria-selected`](https://www.w3.org/TR/wai-aria-1.2/#aria-selected).
         exact : Union[bool, None]
-            Whether `name` is matched exactly: case-sensitive and whole-string. Defaults to false. Ignored when `name` is a
-            regular expression. Note that exact match still trims whitespace.
+            Whether `name` and `description` are matched exactly: case-sensitive and whole-string. Defaults to false. Ignored
+            when the value is a regular expression. Note that exact match still trims whitespace.
+        description : Union[Pattern[str], str, None]
+            Option to match the [accessible description](https://w3c.github.io/accname/#dfn-accessible-description). By
+            default, matching is case-insensitive and searches for a substring, use `exact` to control this behavior.
+
+            Learn more about [accessible description](https://w3c.github.io/accname/#dfn-accessible-description).
 
         Returns
         -------
@@ -4933,6 +4969,7 @@ class Frame(AsyncBase):
                 pressed=pressed,
                 selected=selected,
                 exact=exact,
+                description=description,
             )
         )
 
@@ -6318,6 +6355,7 @@ class FrameLocator(AsyncBase):
         pressed: typing.Optional[bool] = None,
         selected: typing.Optional[bool] = None,
         exact: typing.Optional[bool] = None,
+        description: typing.Optional[typing.Union[typing.Pattern[str], str]] = None,
     ) -> "Locator":
         """FrameLocator.get_by_role
 
@@ -6400,8 +6438,13 @@ class FrameLocator(AsyncBase):
 
             Learn more about [`aria-selected`](https://www.w3.org/TR/wai-aria-1.2/#aria-selected).
         exact : Union[bool, None]
-            Whether `name` is matched exactly: case-sensitive and whole-string. Defaults to false. Ignored when `name` is a
-            regular expression. Note that exact match still trims whitespace.
+            Whether `name` and `description` are matched exactly: case-sensitive and whole-string. Defaults to false. Ignored
+            when the value is a regular expression. Note that exact match still trims whitespace.
+        description : Union[Pattern[str], str, None]
+            Option to match the [accessible description](https://w3c.github.io/accname/#dfn-accessible-description). By
+            default, matching is case-insensitive and searches for a substring, use `exact` to control this behavior.
+
+            Learn more about [accessible description](https://w3c.github.io/accname/#dfn-accessible-description).
 
         Returns
         -------
@@ -6420,6 +6463,7 @@ class FrameLocator(AsyncBase):
                 pressed=pressed,
                 selected=selected,
                 exact=exact,
+                description=description,
             )
         )
 
@@ -7119,7 +7163,7 @@ class ConsoleMessage(AsyncBase):
 
         Returns
         -------
-        {url: str, lineNumber: int, columnNumber: int}
+        {url: str, line: int, column: int, lineNumber: int, columnNumber: int}
         """
         return mapping.from_impl(self._impl_obj.location)
 
@@ -7480,8 +7524,8 @@ class Screencast(AsyncBase):
 
         Parameters
         ----------
-        on_frame : Union[Callable[[{data: bytes}], Any], None]
-            Callback that receives JPEG-encoded frame data.
+        on_frame : Union[Callable[[{data: bytes, viewportWidth: int, viewportHeight: int}], Any], None]
+            Callback that receives JPEG-encoded frame data along with the page viewport size at the time of capture.
         path : Union[pathlib.Path, str, None]
             Path where the video should be saved when the screencast is stopped. When provided, video recording is started.
         quality : Union[int, None]
@@ -9182,11 +9226,7 @@ class Page(AsyncContextManager):
         )
 
     async def expose_binding(
-        self,
-        name: str,
-        callback: typing.Callable,
-        *,
-        handle: typing.Optional[bool] = None,
+        self, name: str, callback: typing.Callable
     ) -> "AsyncContextManager":
         """Page.expose_binding
 
@@ -9238,10 +9278,6 @@ class Page(AsyncContextManager):
             Name of the function on the window object.
         callback : Callable
             Callback function that will be called in the Playwright's context.
-        handle : Union[bool, None]
-            Whether to pass the argument as a handle, instead of passing by value. When passing a handle, only one argument is
-            supported. When passing by value, multiple arguments are supported.
-            Deprecated: This option will be removed in the future.
 
         Returns
         -------
@@ -9250,7 +9286,7 @@ class Page(AsyncContextManager):
 
         return mapping.from_impl(
             await self._impl_obj.expose_binding(
-                name=name, callback=self._wrap_handler(callback), handle=handle
+                name=name, callback=self._wrap_handler(callback)
             )
         )
 
@@ -9778,6 +9814,14 @@ class Page(AsyncContextManager):
 
         return mapping.from_maybe_impl(await self._impl_obj.bring_to_front())
 
+    async def hide_highlight(self) -> None:
+        """Page.hide_highlight
+
+        Hide all locator highlight overlays previously added by `locator.highlight()` on this page.
+        """
+
+        return mapping.from_maybe_impl(await self._impl_obj.hide_highlight())
+
     async def add_init_script(
         self,
         script: typing.Optional[str] = None,
@@ -10177,6 +10221,7 @@ class Page(AsyncContextManager):
         timeout: typing.Optional[float] = None,
         depth: typing.Optional[int] = None,
         mode: typing.Optional[Literal["ai", "default"]] = None,
+        boxes: typing.Optional[bool] = None,
     ) -> str:
         """Page.aria_snapshot
 
@@ -10192,6 +10237,11 @@ class Page(AsyncContextManager):
         mode : Union["ai", "default", None]
             When set to `"ai"`, returns a snapshot optimized for AI consumption: including element references like `[ref=e2]`
             and snapshots of `<iframe>`s. Defaults to `"default"`.
+        boxes : Union[bool, None]
+            When `true`, appends each element's bounding box as `[box=x,y,width,height]` to the snapshot. Coordinates are
+            relative to the viewport, in CSS pixels, as returned by
+            [`Element.getBoundingClientRect()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect).
+            Defaults to `false`.
 
         Returns
         -------
@@ -10199,7 +10249,9 @@ class Page(AsyncContextManager):
         """
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.aria_snapshot(timeout=timeout, depth=depth, mode=mode)
+            await self._impl_obj.aria_snapshot(
+                timeout=timeout, depth=depth, mode=mode, boxes=boxes
+            )
         )
 
     async def close(
@@ -10805,6 +10857,7 @@ class Page(AsyncContextManager):
         pressed: typing.Optional[bool] = None,
         selected: typing.Optional[bool] = None,
         exact: typing.Optional[bool] = None,
+        description: typing.Optional[typing.Union[typing.Pattern[str], str]] = None,
     ) -> "Locator":
         """Page.get_by_role
 
@@ -10887,8 +10940,13 @@ class Page(AsyncContextManager):
 
             Learn more about [`aria-selected`](https://www.w3.org/TR/wai-aria-1.2/#aria-selected).
         exact : Union[bool, None]
-            Whether `name` is matched exactly: case-sensitive and whole-string. Defaults to false. Ignored when `name` is a
-            regular expression. Note that exact match still trims whitespace.
+            Whether `name` and `description` are matched exactly: case-sensitive and whole-string. Defaults to false. Ignored
+            when the value is a regular expression. Note that exact match still trims whitespace.
+        description : Union[Pattern[str], str, None]
+            Option to match the [accessible description](https://w3c.github.io/accname/#dfn-accessible-description). By
+            default, matching is case-insensitive and searches for a substring, use `exact` to control this behavior.
+
+            Learn more about [accessible description](https://w3c.github.io/accname/#dfn-accessible-description).
 
         Returns
         -------
@@ -10907,6 +10965,7 @@ class Page(AsyncContextManager):
                 pressed=pressed,
                 selected=selected,
                 exact=exact,
+                description=description,
             )
         )
 
@@ -12836,6 +12895,16 @@ class WebError(AsyncBase):
         """
         return mapping.from_impl(self._impl_obj.error)
 
+    @property
+    def location(self) -> WebErrorLocation:
+        """WebError.location
+
+        Returns
+        -------
+        {url: str, line: int, column: int}
+        """
+        return mapping.from_impl(self._impl_obj.location)
+
 
 mapping.register(WebErrorImpl, WebError)
 
@@ -12915,6 +12984,48 @@ class BrowserContext(AsyncContextManager):
     @typing.overload
     def on(
         self,
+        event: Literal["download"],
+        f: typing.Callable[["Download"], "typing.Union[typing.Awaitable[None], None]"],
+    ) -> None:
+        """
+        Emitted when attachment download started in any page belonging to this context. User can access basic file
+        operations on downloaded content via the passed `Download` instance. See also `page.on('download')` to receive
+        events about a specific page."""
+
+    @typing.overload
+    def on(
+        self,
+        event: Literal["frameattached"],
+        f: typing.Callable[["Frame"], "typing.Union[typing.Awaitable[None], None]"],
+    ) -> None:
+        """
+        Emitted when a frame is attached in any page belonging to this context. See also `page.on('frame_attached')` to
+        receive events about a specific page."""
+
+    @typing.overload
+    def on(
+        self,
+        event: Literal["framedetached"],
+        f: typing.Callable[["Frame"], "typing.Union[typing.Awaitable[None], None]"],
+    ) -> None:
+        """
+        Emitted when a frame is detached in any page belonging to this context. See also `page.on('frame_detached')` to
+        receive events about a specific page."""
+
+    @typing.overload
+    def on(
+        self,
+        event: Literal["framenavigated"],
+        f: typing.Callable[["Frame"], "typing.Union[typing.Awaitable[None], None]"],
+    ) -> None:
+        """
+        Emitted when a frame is navigated to a new url in any page belonging to this context. See also
+        `page.on('frame_navigated')` to receive events about navigations in a specific page.
+        """
+
+    @typing.overload
+    def on(
+        self,
         event: Literal["page"],
         f: typing.Callable[["Page"], "typing.Union[typing.Awaitable[None], None]"],
     ) -> None:
@@ -12938,6 +13049,27 @@ class BrowserContext(AsyncContextManager):
 
         **NOTE** Use `page.wait_for_load_state()` to wait until the page gets to a particular state (you should not
         need it in most cases)."""
+
+    @typing.overload
+    def on(
+        self,
+        event: Literal["pageclose"],
+        f: typing.Callable[["Page"], "typing.Union[typing.Awaitable[None], None]"],
+    ) -> None:
+        """
+        Emitted when a page in this context is closed. See also `page.on('close')` to receive events about a specific
+        page."""
+
+    @typing.overload
+    def on(
+        self,
+        event: Literal["pageload"],
+        f: typing.Callable[["Page"], "typing.Union[typing.Awaitable[None], None]"],
+    ) -> None:
+        """
+        Emitted when the JavaScript [`load`](https://developer.mozilla.org/en-US/docs/Web/Events/load) event is dispatched
+        in any page belonging to this context. See also `page.on('load')` to receive events about a specific page.
+        """
 
     @typing.overload
     def on(
@@ -13089,6 +13221,48 @@ class BrowserContext(AsyncContextManager):
     @typing.overload
     def once(
         self,
+        event: Literal["download"],
+        f: typing.Callable[["Download"], "typing.Union[typing.Awaitable[None], None]"],
+    ) -> None:
+        """
+        Emitted when attachment download started in any page belonging to this context. User can access basic file
+        operations on downloaded content via the passed `Download` instance. See also `page.on('download')` to receive
+        events about a specific page."""
+
+    @typing.overload
+    def once(
+        self,
+        event: Literal["frameattached"],
+        f: typing.Callable[["Frame"], "typing.Union[typing.Awaitable[None], None]"],
+    ) -> None:
+        """
+        Emitted when a frame is attached in any page belonging to this context. See also `page.on('frame_attached')` to
+        receive events about a specific page."""
+
+    @typing.overload
+    def once(
+        self,
+        event: Literal["framedetached"],
+        f: typing.Callable[["Frame"], "typing.Union[typing.Awaitable[None], None]"],
+    ) -> None:
+        """
+        Emitted when a frame is detached in any page belonging to this context. See also `page.on('frame_detached')` to
+        receive events about a specific page."""
+
+    @typing.overload
+    def once(
+        self,
+        event: Literal["framenavigated"],
+        f: typing.Callable[["Frame"], "typing.Union[typing.Awaitable[None], None]"],
+    ) -> None:
+        """
+        Emitted when a frame is navigated to a new url in any page belonging to this context. See also
+        `page.on('frame_navigated')` to receive events about navigations in a specific page.
+        """
+
+    @typing.overload
+    def once(
+        self,
         event: Literal["page"],
         f: typing.Callable[["Page"], "typing.Union[typing.Awaitable[None], None]"],
     ) -> None:
@@ -13112,6 +13286,27 @@ class BrowserContext(AsyncContextManager):
 
         **NOTE** Use `page.wait_for_load_state()` to wait until the page gets to a particular state (you should not
         need it in most cases)."""
+
+    @typing.overload
+    def once(
+        self,
+        event: Literal["pageclose"],
+        f: typing.Callable[["Page"], "typing.Union[typing.Awaitable[None], None]"],
+    ) -> None:
+        """
+        Emitted when a page in this context is closed. See also `page.on('close')` to receive events about a specific
+        page."""
+
+    @typing.overload
+    def once(
+        self,
+        event: Literal["pageload"],
+        f: typing.Callable[["Page"], "typing.Union[typing.Awaitable[None], None]"],
+    ) -> None:
+        """
+        Emitted when the JavaScript [`load`](https://developer.mozilla.org/en-US/docs/Web/Events/load) event is dispatched
+        in any page belonging to this context. See also `page.on('load')` to receive events about a specific page.
+        """
 
     @typing.overload
     def once(
@@ -13588,11 +13783,7 @@ class BrowserContext(AsyncContextManager):
         )
 
     async def expose_binding(
-        self,
-        name: str,
-        callback: typing.Callable,
-        *,
-        handle: typing.Optional[bool] = None,
+        self, name: str, callback: typing.Callable
     ) -> "AsyncContextManager":
         """BrowserContext.expose_binding
 
@@ -13642,10 +13833,6 @@ class BrowserContext(AsyncContextManager):
             Name of the function on the window object.
         callback : Callable
             Callback function that will be called in the Playwright's context.
-        handle : Union[bool, None]
-            Whether to pass the argument as a handle, instead of passing by value. When passing a handle, only one argument is
-            supported. When passing by value, multiple arguments are supported.
-            Deprecated: This option will be removed in the future.
 
         Returns
         -------
@@ -13654,7 +13841,7 @@ class BrowserContext(AsyncContextManager):
 
         return mapping.from_impl(
             await self._impl_obj.expose_binding(
-                name=name, callback=self._wrap_handler(callback), handle=handle
+                name=name, callback=self._wrap_handler(callback)
             )
         )
 
@@ -14307,6 +14494,17 @@ class Browser(AsyncContextManager):
     @typing.overload
     def on(
         self,
+        event: Literal["context"],
+        f: typing.Callable[
+            ["BrowserContext"], "typing.Union[typing.Awaitable[None], None]"
+        ],
+    ) -> None:
+        """
+        Emitted when a new browser context is created."""
+
+    @typing.overload
+    def on(
+        self,
         event: Literal["disconnected"],
         f: typing.Callable[["Browser"], "typing.Union[typing.Awaitable[None], None]"],
     ) -> None:
@@ -14315,13 +14513,6 @@ class Browser(AsyncContextManager):
         following:
         - Browser application is closed or crashed.
         - The `browser.close()` method was called."""
-
-    @typing.overload
-    def on(
-        self,
-        event: str,
-        f: typing.Callable[..., typing.Union[typing.Awaitable[None], None]],
-    ) -> None: ...
 
     def on(
         self,
@@ -14333,6 +14524,17 @@ class Browser(AsyncContextManager):
     @typing.overload
     def once(
         self,
+        event: Literal["context"],
+        f: typing.Callable[
+            ["BrowserContext"], "typing.Union[typing.Awaitable[None], None]"
+        ],
+    ) -> None:
+        """
+        Emitted when a new browser context is created."""
+
+    @typing.overload
+    def once(
+        self,
         event: Literal["disconnected"],
         f: typing.Callable[["Browser"], "typing.Union[typing.Awaitable[None], None]"],
     ) -> None:
@@ -14341,13 +14543,6 @@ class Browser(AsyncContextManager):
         following:
         - Browser application is closed or crashed.
         - The `browser.close()` method was called."""
-
-    @typing.overload
-    def once(
-        self,
-        event: str,
-        f: typing.Callable[..., typing.Union[typing.Awaitable[None], None]],
-    ) -> None: ...
 
     def once(
         self,
@@ -15555,6 +15750,7 @@ class BrowserType(AsyncBase):
         slow_mo: typing.Optional[float] = None,
         headers: typing.Optional[typing.Dict[str, str]] = None,
         is_local: typing.Optional[bool] = None,
+        no_defaults: typing.Optional[bool] = None,
     ) -> "Browser":
         """BrowserType.connect_over_cdp
 
@@ -15592,6 +15788,12 @@ class BrowserType(AsyncBase):
         is_local : Union[bool, None]
             Tells Playwright that it runs on the same host as the CDP server. It will enable certain optimizations that rely
             upon the file system being the same between Playwright and the Browser.
+        no_defaults : Union[bool, None]
+            When true, Playwright will not apply its default overrides to the existing default browser context. Specifically,
+            `acceptDownloads` is left at the browser's setting, focus emulation is not enabled, and media emulation options
+            (such as `colorScheme`, `reducedMotion`, `forcedColors`, and `contrast`) are not applied. Useful when attaching to
+            a user's daily-driver browser where these overrides would interfere with existing browser state. New contexts
+            created via `browser.new_context()` are not affected. Defaults to `false`.
 
         Returns
         -------
@@ -15605,6 +15807,7 @@ class BrowserType(AsyncBase):
                 slowMo=slow_mo,
                 headers=mapping.to_impl(headers),
                 isLocal=is_local,
+                noDefaults=no_defaults,
             )
         )
 
@@ -15978,6 +16181,65 @@ class Tracing(AsyncBase):
         """
 
         return mapping.from_maybe_impl(await self._impl_obj.group_end())
+
+    async def start_har(
+        self,
+        path: typing.Union[pathlib.Path, str],
+        *,
+        content: typing.Optional[Literal["attach", "embed", "omit"]] = None,
+        mode: typing.Optional[Literal["full", "minimal"]] = None,
+        url_filter: typing.Optional[typing.Union[typing.Pattern[str], str]] = None,
+    ) -> "AsyncContextManager":
+        """Tracing.start_har
+
+        Start recording a HAR (HTTP Archive) of network activity in this context. The HAR file is written to disk when
+        `tracing.stop_har()` is called, or when the returned `Disposable` is disposed.
+
+        Only one HAR recording can be active at a time per `BrowserContext`.
+
+        **Usage**
+
+        ```py
+        await context.tracing.start_har(\"trace.har\")
+        page = await context.new_page()
+        await page.goto(\"https://playwright.dev\")
+        await context.tracing.stop_har()
+        ```
+
+        Parameters
+        ----------
+        path : Union[pathlib.Path, str]
+            Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, the HAR is saved as a zip
+            archive with response bodies attached as separate files.
+        content : Union["attach", "embed", "omit", None]
+            Optional setting to control resource content management. If `omit` is specified, content is not persisted. If
+            `attach` is specified, resources are persisted as separate files or entries in the ZIP archive. If `embed` is
+            specified, content is stored inline the HAR file as per HAR specification. Defaults to `attach` for `.zip` output
+            files and to `embed` for all other file extensions.
+        mode : Union["full", "minimal", None]
+            When set to `minimal`, only record information necessary for routing from HAR. This omits sizes, timing, page,
+            cookies, security and other types of HAR information that are not used when replaying from HAR. Defaults to `full`.
+        url_filter : Union[Pattern[str], str, None]
+            A glob or regex pattern to filter requests that are stored in the HAR. Defaults to none.
+
+        Returns
+        -------
+        AsyncContextManager
+        """
+
+        return mapping.from_impl(
+            await self._impl_obj.start_har(
+                path=path, content=content, mode=mode, urlFilter=url_filter
+            )
+        )
+
+    async def stop_har(self) -> None:
+        """Tracing.stop_har
+
+        Stop HAR recording and save the HAR file to the path given to `tracing.start_har()`.
+        """
+
+        return mapping.from_maybe_impl(await self._impl_obj.stop_har())
 
 
 mapping.register(TracingImpl, Tracing)
@@ -16929,6 +17191,7 @@ class Locator(AsyncBase):
         pressed: typing.Optional[bool] = None,
         selected: typing.Optional[bool] = None,
         exact: typing.Optional[bool] = None,
+        description: typing.Optional[typing.Union[typing.Pattern[str], str]] = None,
     ) -> "Locator":
         """Locator.get_by_role
 
@@ -17011,8 +17274,13 @@ class Locator(AsyncBase):
 
             Learn more about [`aria-selected`](https://www.w3.org/TR/wai-aria-1.2/#aria-selected).
         exact : Union[bool, None]
-            Whether `name` is matched exactly: case-sensitive and whole-string. Defaults to false. Ignored when `name` is a
-            regular expression. Note that exact match still trims whitespace.
+            Whether `name` and `description` are matched exactly: case-sensitive and whole-string. Defaults to false. Ignored
+            when the value is a regular expression. Note that exact match still trims whitespace.
+        description : Union[Pattern[str], str, None]
+            Option to match the [accessible description](https://w3c.github.io/accname/#dfn-accessible-description). By
+            default, matching is case-insensitive and searches for a substring, use `exact` to control this behavior.
+
+            Learn more about [accessible description](https://w3c.github.io/accname/#dfn-accessible-description).
 
         Returns
         -------
@@ -17031,6 +17299,7 @@ class Locator(AsyncBase):
                 pressed=pressed,
                 selected=selected,
                 exact=exact,
+                description=description,
             )
         )
 
@@ -17563,6 +17832,51 @@ class Locator(AsyncBase):
             )
         )
 
+    async def drop(
+        self,
+        payload: DropPayload,
+        *,
+        position: typing.Optional[Position] = None,
+        timeout: typing.Optional[float] = None,
+    ) -> None:
+        """Locator.drop
+
+        Simulate an external drag-and-drop of files or clipboard-like data onto this locator.
+
+        **Details**
+
+        Dispatches the native `dragenter`, `dragover`, and `drop` events at the center of the target element with a
+        synthetic [DataTransfer] carrying the provided files and/or data entries. Works cross-browser by constructing the
+        [DataTransfer] in the page context.
+
+        If the target element's `dragover` listener does not call `preventDefault()`, the target is considered to have
+        rejected the drop: Playwright dispatches `dragleave` and this method throws.
+
+        **Usage**
+
+        Drop a file buffer onto an upload area:
+
+        Drop plain text and a URL together:
+
+        Parameters
+        ----------
+        payload : {files: Union[Sequence[Union[pathlib.Path, str]], Sequence[{name: str, mimeType: str, buffer: bytes}], pathlib.Path, str, {name: str, mimeType: str, buffer: bytes}, None], data: Union[Dict[str, str], None]}
+            Data to drop onto the target. Provide `files` (file paths or in-memory buffers), `data` (a mime-type → string map
+            for clipboard-like content such as `text/plain`, `text/html`, `text/uri-list`), or both.
+        position : Union[{x: float, y: float}, None]
+            A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of
+            the element.
+        timeout : Union[float, None]
+            Maximum time in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can
+            be changed by using the `browser_context.set_default_timeout()` or `page.set_default_timeout()` methods.
+        """
+
+        return mapping.from_maybe_impl(
+            await self._impl_obj.drop(
+                payload=payload, position=position, timeout=timeout
+            )
+        )
+
     async def get_attribute(
         self, name: str, *, timeout: typing.Optional[float] = None
     ) -> typing.Optional[str]:
@@ -18078,6 +18392,7 @@ class Locator(AsyncBase):
         timeout: typing.Optional[float] = None,
         depth: typing.Optional[int] = None,
         mode: typing.Optional[Literal["ai", "default"]] = None,
+        boxes: typing.Optional[bool] = None,
     ) -> str:
         """Locator.aria_snapshot
 
@@ -18132,6 +18447,11 @@ class Locator(AsyncBase):
         mode : Union["ai", "default", None]
             When set to `"ai"`, returns a snapshot optimized for AI consumption. Defaults to `"default"`. See details for more
             information.
+        boxes : Union[bool, None]
+            When `true`, appends each element's bounding box as `[box=x,y,width,height]` to the snapshot. Coordinates are
+            relative to the viewport, in CSS pixels, as returned by
+            [`Element.getBoundingClientRect()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect).
+            Defaults to `false`.
 
         Returns
         -------
@@ -18139,7 +18459,9 @@ class Locator(AsyncBase):
         """
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.aria_snapshot(timeout=timeout, depth=depth, mode=mode)
+            await self._impl_obj.aria_snapshot(
+                timeout=timeout, depth=depth, mode=mode, boxes=boxes
+            )
         )
 
     async def normalize(self) -> "Locator":
@@ -18753,14 +19075,27 @@ class Locator(AsyncBase):
             )
         )
 
-    async def highlight(self) -> None:
+    async def highlight(self, *, style: typing.Optional[str] = None) -> None:
         """Locator.highlight
 
         Highlight the corresponding element(s) on the screen. Useful for debugging, don't commit the code that uses
         `locator.highlight()`.
+
+        Parameters
+        ----------
+        style : Union[str, None]
+            Additional inline CSS applied to the highlight overlay, e.g. `"outline: 2px dashed red"`.
         """
 
-        return mapping.from_maybe_impl(await self._impl_obj.highlight())
+        return mapping.from_maybe_impl(await self._impl_obj.highlight(style=style))
+
+    async def hide_highlight(self) -> None:
+        """Locator.hide_highlight
+
+        Hides the element highlight previously added by `locator.highlight()`.
+        """
+
+        return mapping.from_maybe_impl(await self._impl_obj.hide_highlight())
 
 
 mapping.register(LocatorImpl, Locator)
@@ -18893,6 +19228,16 @@ mapping.register(APIResponseImpl, APIResponse)
 
 class APIRequestContext(AsyncBase):
 
+    @property
+    def tracing(self) -> "Tracing":
+        """APIRequestContext.tracing
+
+        Returns
+        -------
+        Tracing
+        """
+        return mapping.from_impl(self._impl_obj.tracing)
+
     async def dispose(self, *, reason: typing.Optional[str] = None) -> None:
         """APIRequestContext.dispose
 
@@ -18949,11 +19294,13 @@ class APIRequestContext(AsyncBase):
         form : Union[Dict[str, Union[bool, float, str]], None]
             Provides an object that will be serialized as html form using `application/x-www-form-urlencoded` encoding and sent
             as this request body. If this parameter is specified `content-type` header will be set to
-            `application/x-www-form-urlencoded` unless explicitly provided.
+            `application/x-www-form-urlencoded` unless explicitly provided. Use `FormData` to send multiple values for the same
+            field.
         multipart : Union[Dict[str, Union[bool, bytes, float, str, {name: str, mimeType: str, buffer: bytes}]], None]
             Provides an object that will be serialized as html form using `multipart/form-data` encoding and sent as this
             request body. If this parameter is specified `content-type` header will be set to `multipart/form-data` unless
             explicitly provided. File values can be passed as file-like object containing file name, mime-type and its content.
+            Use `FormData` to send multiple files in the same field.
         timeout : Union[float, None]
             Request timeout in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout.
         fail_on_status_code : Union[bool, None]
@@ -19030,11 +19377,13 @@ class APIRequestContext(AsyncBase):
         form : Union[Dict[str, Union[bool, float, str]], None]
             Provides an object that will be serialized as html form using `application/x-www-form-urlencoded` encoding and sent
             as this request body. If this parameter is specified `content-type` header will be set to
-            `application/x-www-form-urlencoded` unless explicitly provided.
+            `application/x-www-form-urlencoded` unless explicitly provided. Use `FormData` to send multiple values for the same
+            field.
         multipart : Union[Dict[str, Union[bool, bytes, float, str, {name: str, mimeType: str, buffer: bytes}]], None]
             Provides an object that will be serialized as html form using `multipart/form-data` encoding and sent as this
             request body. If this parameter is specified `content-type` header will be set to `multipart/form-data` unless
             explicitly provided. File values can be passed as file-like object containing file name, mime-type and its content.
+            Use `FormData` to send multiple files in the same field.
         timeout : Union[float, None]
             Request timeout in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout.
         fail_on_status_code : Union[bool, None]
@@ -19123,11 +19472,13 @@ class APIRequestContext(AsyncBase):
         form : Union[Dict[str, Union[bool, float, str]], None]
             Provides an object that will be serialized as html form using `application/x-www-form-urlencoded` encoding and sent
             as this request body. If this parameter is specified `content-type` header will be set to
-            `application/x-www-form-urlencoded` unless explicitly provided.
+            `application/x-www-form-urlencoded` unless explicitly provided. Use `FormData` to send multiple values for the same
+            field.
         multipart : Union[Dict[str, Union[bool, bytes, float, str, {name: str, mimeType: str, buffer: bytes}]], None]
             Provides an object that will be serialized as html form using `multipart/form-data` encoding and sent as this
             request body. If this parameter is specified `content-type` header will be set to `multipart/form-data` unless
             explicitly provided. File values can be passed as file-like object containing file name, mime-type and its content.
+            Use `FormData` to send multiple files in the same field.
         timeout : Union[float, None]
             Request timeout in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout.
         fail_on_status_code : Union[bool, None]
@@ -19204,11 +19555,13 @@ class APIRequestContext(AsyncBase):
         form : Union[Dict[str, Union[bool, float, str]], None]
             Provides an object that will be serialized as html form using `application/x-www-form-urlencoded` encoding and sent
             as this request body. If this parameter is specified `content-type` header will be set to
-            `application/x-www-form-urlencoded` unless explicitly provided.
+            `application/x-www-form-urlencoded` unless explicitly provided. Use `FormData` to send multiple values for the same
+            field.
         multipart : Union[Dict[str, Union[bool, bytes, float, str, {name: str, mimeType: str, buffer: bytes}]], None]
             Provides an object that will be serialized as html form using `multipart/form-data` encoding and sent as this
             request body. If this parameter is specified `content-type` header will be set to `multipart/form-data` unless
             explicitly provided. File values can be passed as file-like object containing file name, mime-type and its content.
+            Use `FormData` to send multiple files in the same field.
         timeout : Union[float, None]
             Request timeout in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout.
         fail_on_status_code : Union[bool, None]
@@ -19285,11 +19638,13 @@ class APIRequestContext(AsyncBase):
         form : Union[Dict[str, Union[bool, float, str]], None]
             Provides an object that will be serialized as html form using `application/x-www-form-urlencoded` encoding and sent
             as this request body. If this parameter is specified `content-type` header will be set to
-            `application/x-www-form-urlencoded` unless explicitly provided.
+            `application/x-www-form-urlencoded` unless explicitly provided. Use `FormData` to send multiple values for the same
+            field.
         multipart : Union[Dict[str, Union[bool, bytes, float, str, {name: str, mimeType: str, buffer: bytes}]], None]
             Provides an object that will be serialized as html form using `multipart/form-data` encoding and sent as this
             request body. If this parameter is specified `content-type` header will be set to `multipart/form-data` unless
             explicitly provided. File values can be passed as file-like object containing file name, mime-type and its content.
+            Use `FormData` to send multiple files in the same field.
         timeout : Union[float, None]
             Request timeout in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout.
         fail_on_status_code : Union[bool, None]
@@ -19397,11 +19752,13 @@ class APIRequestContext(AsyncBase):
         form : Union[Dict[str, Union[bool, float, str]], None]
             Provides an object that will be serialized as html form using `application/x-www-form-urlencoded` encoding and sent
             as this request body. If this parameter is specified `content-type` header will be set to
-            `application/x-www-form-urlencoded` unless explicitly provided.
+            `application/x-www-form-urlencoded` unless explicitly provided. Use `FormData` to send multiple values for the same
+            field.
         multipart : Union[Dict[str, Union[bool, bytes, float, str, {name: str, mimeType: str, buffer: bytes}]], None]
             Provides an object that will be serialized as html form using `multipart/form-data` encoding and sent as this
             request body. If this parameter is specified `content-type` header will be set to `multipart/form-data` unless
             explicitly provided. File values can be passed as file-like object containing file name, mime-type and its content.
+            Use `FormData` to send multiple files in the same field.
         timeout : Union[float, None]
             Request timeout in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout.
         fail_on_status_code : Union[bool, None]
@@ -19496,11 +19853,13 @@ class APIRequestContext(AsyncBase):
         form : Union[Dict[str, Union[bool, float, str]], None]
             Provides an object that will be serialized as html form using `application/x-www-form-urlencoded` encoding and sent
             as this request body. If this parameter is specified `content-type` header will be set to
-            `application/x-www-form-urlencoded` unless explicitly provided.
+            `application/x-www-form-urlencoded` unless explicitly provided. Use `FormData` to send multiple values for the same
+            field.
         multipart : Union[Dict[str, Union[bool, bytes, float, str, {name: str, mimeType: str, buffer: bytes}]], None]
             Provides an object that will be serialized as html form using `multipart/form-data` encoding and sent as this
             request body. If this parameter is specified `content-type` header will be set to `multipart/form-data` unless
             explicitly provided. File values can be passed as file-like object containing file name, mime-type and its content.
+            Use `FormData` to send multiple files in the same field.
         timeout : Union[float, None]
             Request timeout in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout.
         fail_on_status_code : Union[bool, None]
@@ -19799,6 +20158,58 @@ class PageAssertions(AsyncBase):
         return mapping.from_maybe_impl(
             await self._impl_obj.not_to_have_url(
                 urlOrRegExp=url_or_reg_exp, timeout=timeout, ignoreCase=ignore_case
+            )
+        )
+
+    async def to_match_aria_snapshot(
+        self, expected: str, *, timeout: typing.Optional[float] = None
+    ) -> None:
+        """PageAssertions.to_match_aria_snapshot
+
+        Asserts that the page body matches the given [accessibility snapshot](https://playwright.dev/python/docs/aria-snapshots).
+
+        **Usage**
+
+        ```py
+        await page.goto(\"https://demo.playwright.dev/todomvc/\")
+        await expect(page).to_match_aria_snapshot('''
+          - heading \"todos\"
+          - textbox \"What needs to be done?\"
+        ''')
+        ```
+
+        Parameters
+        ----------
+        expected : str
+        timeout : Union[float, None]
+            Time to retry the assertion for in milliseconds. Defaults to `5000`.
+        """
+        __tracebackhide__ = True
+
+        return mapping.from_maybe_impl(
+            await self._impl_obj.to_match_aria_snapshot(
+                expected=expected, timeout=timeout
+            )
+        )
+
+    async def not_to_match_aria_snapshot(
+        self, expected: str, *, timeout: typing.Optional[float] = None
+    ) -> None:
+        """PageAssertions.not_to_match_aria_snapshot
+
+        The opposite of `page_assertions.to_match_aria_snapshot()`.
+
+        Parameters
+        ----------
+        expected : str
+        timeout : Union[float, None]
+            Time to retry the assertion for in milliseconds. Defaults to `5000`.
+        """
+        __tracebackhide__ = True
+
+        return mapping.from_maybe_impl(
+            await self._impl_obj.not_to_match_aria_snapshot(
+                expected=expected, timeout=timeout
             )
         )
 
@@ -20243,6 +20654,7 @@ class LocatorAssertions(AsyncBase):
         value: typing.Union[str, typing.Pattern[str]],
         *,
         timeout: typing.Optional[float] = None,
+        pseudo: typing.Optional[Literal["after", "before"]] = None,
     ) -> None:
         """LocatorAssertions.to_have_css
 
@@ -20265,11 +20677,15 @@ class LocatorAssertions(AsyncBase):
             CSS property value.
         timeout : Union[float, None]
             Time to retry the assertion for in milliseconds. Defaults to `5000`.
+        pseudo : Union["after", "before", None]
+            Pseudo-element to read computed styles from.
         """
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
-            await self._impl_obj.to_have_css(name=name, value=value, timeout=timeout)
+            await self._impl_obj.to_have_css(
+                name=name, value=value, timeout=timeout, pseudo=pseudo
+            )
         )
 
     async def not_to_have_css(

--- a/playwright/sync_api/_generated.py
+++ b/playwright/sync_api/_generated.py
@@ -24,6 +24,7 @@ from playwright._impl._api_structures import (
     Cookie,
     DebuggerLocation,
     DebuggerPausedDetails,
+    DropPayload,
     FilePayload,
     FloatRect,
     Geolocation,
@@ -42,6 +43,7 @@ from playwright._impl._api_structures import (
     StorageState,
     TracingGroupLocation,
     ViewportSize,
+    WebErrorLocation,
 )
 from playwright._impl._assertions import (
     APIResponseAssertions as APIResponseAssertionsImpl,
@@ -1214,6 +1216,34 @@ class WebSocketRoute(SyncBase):
         str
         """
         return mapping.from_maybe_impl(self._impl_obj.url)
+
+    @property
+    def protocols(self) -> typing.List[str]:
+        """WebSocketRoute.protocols
+
+        The list of WebSocket subprotocols requested by the page, as passed via the second argument to the
+        [`WebSocket` constructor](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/WebSocket). Corresponds to the
+        `Sec-WebSocket-Protocol` request header.
+
+        Returns an empty array if no protocols were specified.
+
+        **Usage**
+
+        ```py
+        def handler(ws: WebSocketRoute):
+          if \"chat.v2\" in ws.protocols:
+            ws.on_message(lambda message: ws.send(f\"v2:{message}\"))
+          else:
+            ws.close(code=1002, reason=\"Unsupported protocol\")
+
+        page.route_web_socket(\"wss://example.com/ws\", handler)
+        ```
+
+        Returns
+        -------
+        List[str]
+        """
+        return mapping.from_maybe_impl(self._impl_obj.protocols)
 
     def close(
         self, *, code: typing.Optional[int] = None, reason: typing.Optional[str] = None
@@ -4910,6 +4940,7 @@ class Frame(SyncBase):
         pressed: typing.Optional[bool] = None,
         selected: typing.Optional[bool] = None,
         exact: typing.Optional[bool] = None,
+        description: typing.Optional[typing.Union[typing.Pattern[str], str]] = None,
     ) -> "Locator":
         """Frame.get_by_role
 
@@ -4992,8 +5023,13 @@ class Frame(SyncBase):
 
             Learn more about [`aria-selected`](https://www.w3.org/TR/wai-aria-1.2/#aria-selected).
         exact : Union[bool, None]
-            Whether `name` is matched exactly: case-sensitive and whole-string. Defaults to false. Ignored when `name` is a
-            regular expression. Note that exact match still trims whitespace.
+            Whether `name` and `description` are matched exactly: case-sensitive and whole-string. Defaults to false. Ignored
+            when the value is a regular expression. Note that exact match still trims whitespace.
+        description : Union[Pattern[str], str, None]
+            Option to match the [accessible description](https://w3c.github.io/accname/#dfn-accessible-description). By
+            default, matching is case-insensitive and searches for a substring, use `exact` to control this behavior.
+
+            Learn more about [accessible description](https://w3c.github.io/accname/#dfn-accessible-description).
 
         Returns
         -------
@@ -5012,6 +5048,7 @@ class Frame(SyncBase):
                 pressed=pressed,
                 selected=selected,
                 exact=exact,
+                description=description,
             )
         )
 
@@ -6424,6 +6461,7 @@ class FrameLocator(SyncBase):
         pressed: typing.Optional[bool] = None,
         selected: typing.Optional[bool] = None,
         exact: typing.Optional[bool] = None,
+        description: typing.Optional[typing.Union[typing.Pattern[str], str]] = None,
     ) -> "Locator":
         """FrameLocator.get_by_role
 
@@ -6506,8 +6544,13 @@ class FrameLocator(SyncBase):
 
             Learn more about [`aria-selected`](https://www.w3.org/TR/wai-aria-1.2/#aria-selected).
         exact : Union[bool, None]
-            Whether `name` is matched exactly: case-sensitive and whole-string. Defaults to false. Ignored when `name` is a
-            regular expression. Note that exact match still trims whitespace.
+            Whether `name` and `description` are matched exactly: case-sensitive and whole-string. Defaults to false. Ignored
+            when the value is a regular expression. Note that exact match still trims whitespace.
+        description : Union[Pattern[str], str, None]
+            Option to match the [accessible description](https://w3c.github.io/accname/#dfn-accessible-description). By
+            default, matching is case-insensitive and searches for a substring, use `exact` to control this behavior.
+
+            Learn more about [accessible description](https://w3c.github.io/accname/#dfn-accessible-description).
 
         Returns
         -------
@@ -6526,6 +6569,7 @@ class FrameLocator(SyncBase):
                 pressed=pressed,
                 selected=selected,
                 exact=exact,
+                description=description,
             )
         )
 
@@ -7209,7 +7253,7 @@ class ConsoleMessage(SyncBase):
 
         Returns
         -------
-        {url: str, lineNumber: int, columnNumber: int}
+        {url: str, line: int, column: int, lineNumber: int, columnNumber: int}
         """
         return mapping.from_impl(self._impl_obj.location)
 
@@ -7552,8 +7596,8 @@ class Screencast(SyncBase):
 
         Parameters
         ----------
-        on_frame : Union[Callable[[{data: bytes}], Any], None]
-            Callback that receives JPEG-encoded frame data.
+        on_frame : Union[Callable[[{data: bytes, viewportWidth: int, viewportHeight: int}], Any], None]
+            Callback that receives JPEG-encoded frame data along with the page viewport size at the time of capture.
         path : Union[pathlib.Path, str, None]
             Path where the video should be saved when the screencast is stopped. When provided, video recording is started.
         quality : Union[int, None]
@@ -9178,11 +9222,7 @@ class Page(SyncContextManager):
         )
 
     def expose_binding(
-        self,
-        name: str,
-        callback: typing.Callable,
-        *,
-        handle: typing.Optional[bool] = None,
+        self, name: str, callback: typing.Callable
     ) -> "SyncContextManager":
         """Page.expose_binding
 
@@ -9231,10 +9271,6 @@ class Page(SyncContextManager):
             Name of the function on the window object.
         callback : Callable
             Callback function that will be called in the Playwright's context.
-        handle : Union[bool, None]
-            Whether to pass the argument as a handle, instead of passing by value. When passing a handle, only one argument is
-            supported. When passing by value, multiple arguments are supported.
-            Deprecated: This option will be removed in the future.
 
         Returns
         -------
@@ -9244,7 +9280,7 @@ class Page(SyncContextManager):
         return mapping.from_impl(
             self._sync(
                 self._impl_obj.expose_binding(
-                    name=name, callback=self._wrap_handler(callback), handle=handle
+                    name=name, callback=self._wrap_handler(callback)
                 )
             )
         )
@@ -9785,6 +9821,14 @@ class Page(SyncContextManager):
 
         return mapping.from_maybe_impl(self._sync(self._impl_obj.bring_to_front()))
 
+    def hide_highlight(self) -> None:
+        """Page.hide_highlight
+
+        Hide all locator highlight overlays previously added by `locator.highlight()` on this page.
+        """
+
+        return mapping.from_maybe_impl(self._sync(self._impl_obj.hide_highlight()))
+
     def add_init_script(
         self,
         script: typing.Optional[str] = None,
@@ -10194,6 +10238,7 @@ class Page(SyncContextManager):
         timeout: typing.Optional[float] = None,
         depth: typing.Optional[int] = None,
         mode: typing.Optional[Literal["ai", "default"]] = None,
+        boxes: typing.Optional[bool] = None,
     ) -> str:
         """Page.aria_snapshot
 
@@ -10209,6 +10254,11 @@ class Page(SyncContextManager):
         mode : Union["ai", "default", None]
             When set to `"ai"`, returns a snapshot optimized for AI consumption: including element references like `[ref=e2]`
             and snapshots of `<iframe>`s. Defaults to `"default"`.
+        boxes : Union[bool, None]
+            When `true`, appends each element's bounding box as `[box=x,y,width,height]` to the snapshot. Coordinates are
+            relative to the viewport, in CSS pixels, as returned by
+            [`Element.getBoundingClientRect()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect).
+            Defaults to `false`.
 
         Returns
         -------
@@ -10217,7 +10267,9 @@ class Page(SyncContextManager):
 
         return mapping.from_maybe_impl(
             self._sync(
-                self._impl_obj.aria_snapshot(timeout=timeout, depth=depth, mode=mode)
+                self._impl_obj.aria_snapshot(
+                    timeout=timeout, depth=depth, mode=mode, boxes=boxes
+                )
             )
         )
 
@@ -10834,6 +10886,7 @@ class Page(SyncContextManager):
         pressed: typing.Optional[bool] = None,
         selected: typing.Optional[bool] = None,
         exact: typing.Optional[bool] = None,
+        description: typing.Optional[typing.Union[typing.Pattern[str], str]] = None,
     ) -> "Locator":
         """Page.get_by_role
 
@@ -10916,8 +10969,13 @@ class Page(SyncContextManager):
 
             Learn more about [`aria-selected`](https://www.w3.org/TR/wai-aria-1.2/#aria-selected).
         exact : Union[bool, None]
-            Whether `name` is matched exactly: case-sensitive and whole-string. Defaults to false. Ignored when `name` is a
-            regular expression. Note that exact match still trims whitespace.
+            Whether `name` and `description` are matched exactly: case-sensitive and whole-string. Defaults to false. Ignored
+            when the value is a regular expression. Note that exact match still trims whitespace.
+        description : Union[Pattern[str], str, None]
+            Option to match the [accessible description](https://w3c.github.io/accname/#dfn-accessible-description). By
+            default, matching is case-insensitive and searches for a substring, use `exact` to control this behavior.
+
+            Learn more about [accessible description](https://w3c.github.io/accname/#dfn-accessible-description).
 
         Returns
         -------
@@ -10936,6 +10994,7 @@ class Page(SyncContextManager):
                 pressed=pressed,
                 selected=selected,
                 exact=exact,
+                description=description,
             )
         )
 
@@ -12896,6 +12955,16 @@ class WebError(SyncBase):
         """
         return mapping.from_impl(self._impl_obj.error)
 
+    @property
+    def location(self) -> WebErrorLocation:
+        """WebError.location
+
+        Returns
+        -------
+        {url: str, line: int, column: int}
+        """
+        return mapping.from_impl(self._impl_obj.location)
+
 
 mapping.register(WebErrorImpl, WebError)
 
@@ -12959,6 +13028,40 @@ class BrowserContext(SyncContextManager):
         automatically dismissed."""
 
     @typing.overload
+    def on(
+        self, event: Literal["download"], f: typing.Callable[["Download"], "None"]
+    ) -> None:
+        """
+        Emitted when attachment download started in any page belonging to this context. User can access basic file
+        operations on downloaded content via the passed `Download` instance. See also `page.on('download')` to receive
+        events about a specific page."""
+
+    @typing.overload
+    def on(
+        self, event: Literal["frameattached"], f: typing.Callable[["Frame"], "None"]
+    ) -> None:
+        """
+        Emitted when a frame is attached in any page belonging to this context. See also `page.on('frame_attached')` to
+        receive events about a specific page."""
+
+    @typing.overload
+    def on(
+        self, event: Literal["framedetached"], f: typing.Callable[["Frame"], "None"]
+    ) -> None:
+        """
+        Emitted when a frame is detached in any page belonging to this context. See also `page.on('frame_detached')` to
+        receive events about a specific page."""
+
+    @typing.overload
+    def on(
+        self, event: Literal["framenavigated"], f: typing.Callable[["Frame"], "None"]
+    ) -> None:
+        """
+        Emitted when a frame is navigated to a new url in any page belonging to this context. See also
+        `page.on('frame_navigated')` to receive events about navigations in a specific page.
+        """
+
+    @typing.overload
     def on(self, event: Literal["page"], f: typing.Callable[["Page"], "None"]) -> None:
         """
         The event is emitted when a new Page is created in the BrowserContext. The page may still be loading. The event
@@ -12980,6 +13083,23 @@ class BrowserContext(SyncContextManager):
 
         **NOTE** Use `page.wait_for_load_state()` to wait until the page gets to a particular state (you should not
         need it in most cases)."""
+
+    @typing.overload
+    def on(
+        self, event: Literal["pageclose"], f: typing.Callable[["Page"], "None"]
+    ) -> None:
+        """
+        Emitted when a page in this context is closed. See also `page.on('close')` to receive events about a specific
+        page."""
+
+    @typing.overload
+    def on(
+        self, event: Literal["pageload"], f: typing.Callable[["Page"], "None"]
+    ) -> None:
+        """
+        Emitted when the JavaScript [`load`](https://developer.mozilla.org/en-US/docs/Web/Events/load) event is dispatched
+        in any page belonging to this context. See also `page.on('load')` to receive events about a specific page.
+        """
 
     @typing.overload
     def on(
@@ -13100,6 +13220,40 @@ class BrowserContext(SyncContextManager):
 
     @typing.overload
     def once(
+        self, event: Literal["download"], f: typing.Callable[["Download"], "None"]
+    ) -> None:
+        """
+        Emitted when attachment download started in any page belonging to this context. User can access basic file
+        operations on downloaded content via the passed `Download` instance. See also `page.on('download')` to receive
+        events about a specific page."""
+
+    @typing.overload
+    def once(
+        self, event: Literal["frameattached"], f: typing.Callable[["Frame"], "None"]
+    ) -> None:
+        """
+        Emitted when a frame is attached in any page belonging to this context. See also `page.on('frame_attached')` to
+        receive events about a specific page."""
+
+    @typing.overload
+    def once(
+        self, event: Literal["framedetached"], f: typing.Callable[["Frame"], "None"]
+    ) -> None:
+        """
+        Emitted when a frame is detached in any page belonging to this context. See also `page.on('frame_detached')` to
+        receive events about a specific page."""
+
+    @typing.overload
+    def once(
+        self, event: Literal["framenavigated"], f: typing.Callable[["Frame"], "None"]
+    ) -> None:
+        """
+        Emitted when a frame is navigated to a new url in any page belonging to this context. See also
+        `page.on('frame_navigated')` to receive events about navigations in a specific page.
+        """
+
+    @typing.overload
+    def once(
         self, event: Literal["page"], f: typing.Callable[["Page"], "None"]
     ) -> None:
         """
@@ -13122,6 +13276,23 @@ class BrowserContext(SyncContextManager):
 
         **NOTE** Use `page.wait_for_load_state()` to wait until the page gets to a particular state (you should not
         need it in most cases)."""
+
+    @typing.overload
+    def once(
+        self, event: Literal["pageclose"], f: typing.Callable[["Page"], "None"]
+    ) -> None:
+        """
+        Emitted when a page in this context is closed. See also `page.on('close')` to receive events about a specific
+        page."""
+
+    @typing.overload
+    def once(
+        self, event: Literal["pageload"], f: typing.Callable[["Page"], "None"]
+    ) -> None:
+        """
+        Emitted when the JavaScript [`load`](https://developer.mozilla.org/en-US/docs/Web/Events/load) event is dispatched
+        in any page belonging to this context. See also `page.on('load')` to receive events about a specific page.
+        """
 
     @typing.overload
     def once(
@@ -13584,11 +13755,7 @@ class BrowserContext(SyncContextManager):
         )
 
     def expose_binding(
-        self,
-        name: str,
-        callback: typing.Callable,
-        *,
-        handle: typing.Optional[bool] = None,
+        self, name: str, callback: typing.Callable
     ) -> "SyncContextManager":
         """BrowserContext.expose_binding
 
@@ -13635,10 +13802,6 @@ class BrowserContext(SyncContextManager):
             Name of the function on the window object.
         callback : Callable
             Callback function that will be called in the Playwright's context.
-        handle : Union[bool, None]
-            Whether to pass the argument as a handle, instead of passing by value. When passing a handle, only one argument is
-            supported. When passing by value, multiple arguments are supported.
-            Deprecated: This option will be removed in the future.
 
         Returns
         -------
@@ -13648,7 +13811,7 @@ class BrowserContext(SyncContextManager):
         return mapping.from_impl(
             self._sync(
                 self._impl_obj.expose_binding(
-                    name=name, callback=self._wrap_handler(callback), handle=handle
+                    name=name, callback=self._wrap_handler(callback)
                 )
             )
         )
@@ -14289,6 +14452,13 @@ class Browser(SyncContextManager):
 
     @typing.overload
     def on(
+        self, event: Literal["context"], f: typing.Callable[["BrowserContext"], "None"]
+    ) -> None:
+        """
+        Emitted when a new browser context is created."""
+
+    @typing.overload
+    def on(
         self, event: Literal["disconnected"], f: typing.Callable[["Browser"], "None"]
     ) -> None:
         """
@@ -14297,11 +14467,15 @@ class Browser(SyncContextManager):
         - Browser application is closed or crashed.
         - The `browser.close()` method was called."""
 
-    @typing.overload
-    def on(self, event: str, f: typing.Callable[..., None]) -> None: ...
-
     def on(self, event: str, f: typing.Callable[..., None]) -> None:
         return super().on(event=event, f=f)
+
+    @typing.overload
+    def once(
+        self, event: Literal["context"], f: typing.Callable[["BrowserContext"], "None"]
+    ) -> None:
+        """
+        Emitted when a new browser context is created."""
 
     @typing.overload
     def once(
@@ -14312,9 +14486,6 @@ class Browser(SyncContextManager):
         following:
         - Browser application is closed or crashed.
         - The `browser.close()` method was called."""
-
-    @typing.overload
-    def once(self, event: str, f: typing.Callable[..., None]) -> None: ...
 
     def once(self, event: str, f: typing.Callable[..., None]) -> None:
         return super().once(event=event, f=f)
@@ -15530,6 +15701,7 @@ class BrowserType(SyncBase):
         slow_mo: typing.Optional[float] = None,
         headers: typing.Optional[typing.Dict[str, str]] = None,
         is_local: typing.Optional[bool] = None,
+        no_defaults: typing.Optional[bool] = None,
     ) -> "Browser":
         """BrowserType.connect_over_cdp
 
@@ -15567,6 +15739,12 @@ class BrowserType(SyncBase):
         is_local : Union[bool, None]
             Tells Playwright that it runs on the same host as the CDP server. It will enable certain optimizations that rely
             upon the file system being the same between Playwright and the Browser.
+        no_defaults : Union[bool, None]
+            When true, Playwright will not apply its default overrides to the existing default browser context. Specifically,
+            `acceptDownloads` is left at the browser's setting, focus emulation is not enabled, and media emulation options
+            (such as `colorScheme`, `reducedMotion`, `forcedColors`, and `contrast`) are not applied. Useful when attaching to
+            a user's daily-driver browser where these overrides would interfere with existing browser state. New contexts
+            created via `browser.new_context()` are not affected. Defaults to `false`.
 
         Returns
         -------
@@ -15581,6 +15759,7 @@ class BrowserType(SyncBase):
                     slowMo=slow_mo,
                     headers=mapping.to_impl(headers),
                     isLocal=is_local,
+                    noDefaults=no_defaults,
                 )
             )
         )
@@ -15956,6 +16135,67 @@ class Tracing(SyncBase):
         """
 
         return mapping.from_maybe_impl(self._sync(self._impl_obj.group_end()))
+
+    def start_har(
+        self,
+        path: typing.Union[pathlib.Path, str],
+        *,
+        content: typing.Optional[Literal["attach", "embed", "omit"]] = None,
+        mode: typing.Optional[Literal["full", "minimal"]] = None,
+        url_filter: typing.Optional[typing.Union[typing.Pattern[str], str]] = None,
+    ) -> "SyncContextManager":
+        """Tracing.start_har
+
+        Start recording a HAR (HTTP Archive) of network activity in this context. The HAR file is written to disk when
+        `tracing.stop_har()` is called, or when the returned `Disposable` is disposed.
+
+        Only one HAR recording can be active at a time per `BrowserContext`.
+
+        **Usage**
+
+        ```py
+        context.tracing.start_har(\"trace.har\")
+        page = context.new_page()
+        page.goto(\"https://playwright.dev\")
+        context.tracing.stop_har()
+        ```
+
+        Parameters
+        ----------
+        path : Union[pathlib.Path, str]
+            Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, the HAR is saved as a zip
+            archive with response bodies attached as separate files.
+        content : Union["attach", "embed", "omit", None]
+            Optional setting to control resource content management. If `omit` is specified, content is not persisted. If
+            `attach` is specified, resources are persisted as separate files or entries in the ZIP archive. If `embed` is
+            specified, content is stored inline the HAR file as per HAR specification. Defaults to `attach` for `.zip` output
+            files and to `embed` for all other file extensions.
+        mode : Union["full", "minimal", None]
+            When set to `minimal`, only record information necessary for routing from HAR. This omits sizes, timing, page,
+            cookies, security and other types of HAR information that are not used when replaying from HAR. Defaults to `full`.
+        url_filter : Union[Pattern[str], str, None]
+            A glob or regex pattern to filter requests that are stored in the HAR. Defaults to none.
+
+        Returns
+        -------
+        SyncContextManager
+        """
+
+        return mapping.from_impl(
+            self._sync(
+                self._impl_obj.start_har(
+                    path=path, content=content, mode=mode, urlFilter=url_filter
+                )
+            )
+        )
+
+    def stop_har(self) -> None:
+        """Tracing.stop_har
+
+        Stop HAR recording and save the HAR file to the path given to `tracing.start_har()`.
+        """
+
+        return mapping.from_maybe_impl(self._sync(self._impl_obj.stop_har()))
 
 
 mapping.register(TracingImpl, Tracing)
@@ -16925,6 +17165,7 @@ class Locator(SyncBase):
         pressed: typing.Optional[bool] = None,
         selected: typing.Optional[bool] = None,
         exact: typing.Optional[bool] = None,
+        description: typing.Optional[typing.Union[typing.Pattern[str], str]] = None,
     ) -> "Locator":
         """Locator.get_by_role
 
@@ -17007,8 +17248,13 @@ class Locator(SyncBase):
 
             Learn more about [`aria-selected`](https://www.w3.org/TR/wai-aria-1.2/#aria-selected).
         exact : Union[bool, None]
-            Whether `name` is matched exactly: case-sensitive and whole-string. Defaults to false. Ignored when `name` is a
-            regular expression. Note that exact match still trims whitespace.
+            Whether `name` and `description` are matched exactly: case-sensitive and whole-string. Defaults to false. Ignored
+            when the value is a regular expression. Note that exact match still trims whitespace.
+        description : Union[Pattern[str], str, None]
+            Option to match the [accessible description](https://w3c.github.io/accname/#dfn-accessible-description). By
+            default, matching is case-insensitive and searches for a substring, use `exact` to control this behavior.
+
+            Learn more about [accessible description](https://w3c.github.io/accname/#dfn-accessible-description).
 
         Returns
         -------
@@ -17027,6 +17273,7 @@ class Locator(SyncBase):
                 pressed=pressed,
                 selected=selected,
                 exact=exact,
+                description=description,
             )
         )
 
@@ -17564,6 +17811,51 @@ class Locator(SyncBase):
             )
         )
 
+    def drop(
+        self,
+        payload: DropPayload,
+        *,
+        position: typing.Optional[Position] = None,
+        timeout: typing.Optional[float] = None,
+    ) -> None:
+        """Locator.drop
+
+        Simulate an external drag-and-drop of files or clipboard-like data onto this locator.
+
+        **Details**
+
+        Dispatches the native `dragenter`, `dragover`, and `drop` events at the center of the target element with a
+        synthetic [DataTransfer] carrying the provided files and/or data entries. Works cross-browser by constructing the
+        [DataTransfer] in the page context.
+
+        If the target element's `dragover` listener does not call `preventDefault()`, the target is considered to have
+        rejected the drop: Playwright dispatches `dragleave` and this method throws.
+
+        **Usage**
+
+        Drop a file buffer onto an upload area:
+
+        Drop plain text and a URL together:
+
+        Parameters
+        ----------
+        payload : {files: Union[Sequence[Union[pathlib.Path, str]], Sequence[{name: str, mimeType: str, buffer: bytes}], pathlib.Path, str, {name: str, mimeType: str, buffer: bytes}, None], data: Union[Dict[str, str], None]}
+            Data to drop onto the target. Provide `files` (file paths or in-memory buffers), `data` (a mime-type → string map
+            for clipboard-like content such as `text/plain`, `text/html`, `text/uri-list`), or both.
+        position : Union[{x: float, y: float}, None]
+            A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of
+            the element.
+        timeout : Union[float, None]
+            Maximum time in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can
+            be changed by using the `browser_context.set_default_timeout()` or `page.set_default_timeout()` methods.
+        """
+
+        return mapping.from_maybe_impl(
+            self._sync(
+                self._impl_obj.drop(payload=payload, position=position, timeout=timeout)
+            )
+        )
+
     def get_attribute(
         self, name: str, *, timeout: typing.Optional[float] = None
     ) -> typing.Optional[str]:
@@ -18097,6 +18389,7 @@ class Locator(SyncBase):
         timeout: typing.Optional[float] = None,
         depth: typing.Optional[int] = None,
         mode: typing.Optional[Literal["ai", "default"]] = None,
+        boxes: typing.Optional[bool] = None,
     ) -> str:
         """Locator.aria_snapshot
 
@@ -18151,6 +18444,11 @@ class Locator(SyncBase):
         mode : Union["ai", "default", None]
             When set to `"ai"`, returns a snapshot optimized for AI consumption. Defaults to `"default"`. See details for more
             information.
+        boxes : Union[bool, None]
+            When `true`, appends each element's bounding box as `[box=x,y,width,height]` to the snapshot. Coordinates are
+            relative to the viewport, in CSS pixels, as returned by
+            [`Element.getBoundingClientRect()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect).
+            Defaults to `false`.
 
         Returns
         -------
@@ -18159,7 +18457,9 @@ class Locator(SyncBase):
 
         return mapping.from_maybe_impl(
             self._sync(
-                self._impl_obj.aria_snapshot(timeout=timeout, depth=depth, mode=mode)
+                self._impl_obj.aria_snapshot(
+                    timeout=timeout, depth=depth, mode=mode, boxes=boxes
+                )
             )
         )
 
@@ -18790,14 +19090,29 @@ class Locator(SyncBase):
             )
         )
 
-    def highlight(self) -> None:
+    def highlight(self, *, style: typing.Optional[str] = None) -> None:
         """Locator.highlight
 
         Highlight the corresponding element(s) on the screen. Useful for debugging, don't commit the code that uses
         `locator.highlight()`.
+
+        Parameters
+        ----------
+        style : Union[str, None]
+            Additional inline CSS applied to the highlight overlay, e.g. `"outline: 2px dashed red"`.
         """
 
-        return mapping.from_maybe_impl(self._sync(self._impl_obj.highlight()))
+        return mapping.from_maybe_impl(
+            self._sync(self._impl_obj.highlight(style=style))
+        )
+
+    def hide_highlight(self) -> None:
+        """Locator.hide_highlight
+
+        Hides the element highlight previously added by `locator.highlight()`.
+        """
+
+        return mapping.from_maybe_impl(self._sync(self._impl_obj.hide_highlight()))
 
 
 mapping.register(LocatorImpl, Locator)
@@ -18930,6 +19245,16 @@ mapping.register(APIResponseImpl, APIResponse)
 
 class APIRequestContext(SyncBase):
 
+    @property
+    def tracing(self) -> "Tracing":
+        """APIRequestContext.tracing
+
+        Returns
+        -------
+        Tracing
+        """
+        return mapping.from_impl(self._impl_obj.tracing)
+
     def dispose(self, *, reason: typing.Optional[str] = None) -> None:
         """APIRequestContext.dispose
 
@@ -18988,11 +19313,13 @@ class APIRequestContext(SyncBase):
         form : Union[Dict[str, Union[bool, float, str]], None]
             Provides an object that will be serialized as html form using `application/x-www-form-urlencoded` encoding and sent
             as this request body. If this parameter is specified `content-type` header will be set to
-            `application/x-www-form-urlencoded` unless explicitly provided.
+            `application/x-www-form-urlencoded` unless explicitly provided. Use `FormData` to send multiple values for the same
+            field.
         multipart : Union[Dict[str, Union[bool, bytes, float, str, {name: str, mimeType: str, buffer: bytes}]], None]
             Provides an object that will be serialized as html form using `multipart/form-data` encoding and sent as this
             request body. If this parameter is specified `content-type` header will be set to `multipart/form-data` unless
             explicitly provided. File values can be passed as file-like object containing file name, mime-type and its content.
+            Use `FormData` to send multiple files in the same field.
         timeout : Union[float, None]
             Request timeout in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout.
         fail_on_status_code : Union[bool, None]
@@ -19071,11 +19398,13 @@ class APIRequestContext(SyncBase):
         form : Union[Dict[str, Union[bool, float, str]], None]
             Provides an object that will be serialized as html form using `application/x-www-form-urlencoded` encoding and sent
             as this request body. If this parameter is specified `content-type` header will be set to
-            `application/x-www-form-urlencoded` unless explicitly provided.
+            `application/x-www-form-urlencoded` unless explicitly provided. Use `FormData` to send multiple values for the same
+            field.
         multipart : Union[Dict[str, Union[bool, bytes, float, str, {name: str, mimeType: str, buffer: bytes}]], None]
             Provides an object that will be serialized as html form using `multipart/form-data` encoding and sent as this
             request body. If this parameter is specified `content-type` header will be set to `multipart/form-data` unless
             explicitly provided. File values can be passed as file-like object containing file name, mime-type and its content.
+            Use `FormData` to send multiple files in the same field.
         timeout : Union[float, None]
             Request timeout in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout.
         fail_on_status_code : Union[bool, None]
@@ -19166,11 +19495,13 @@ class APIRequestContext(SyncBase):
         form : Union[Dict[str, Union[bool, float, str]], None]
             Provides an object that will be serialized as html form using `application/x-www-form-urlencoded` encoding and sent
             as this request body. If this parameter is specified `content-type` header will be set to
-            `application/x-www-form-urlencoded` unless explicitly provided.
+            `application/x-www-form-urlencoded` unless explicitly provided. Use `FormData` to send multiple values for the same
+            field.
         multipart : Union[Dict[str, Union[bool, bytes, float, str, {name: str, mimeType: str, buffer: bytes}]], None]
             Provides an object that will be serialized as html form using `multipart/form-data` encoding and sent as this
             request body. If this parameter is specified `content-type` header will be set to `multipart/form-data` unless
             explicitly provided. File values can be passed as file-like object containing file name, mime-type and its content.
+            Use `FormData` to send multiple files in the same field.
         timeout : Union[float, None]
             Request timeout in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout.
         fail_on_status_code : Union[bool, None]
@@ -19249,11 +19580,13 @@ class APIRequestContext(SyncBase):
         form : Union[Dict[str, Union[bool, float, str]], None]
             Provides an object that will be serialized as html form using `application/x-www-form-urlencoded` encoding and sent
             as this request body. If this parameter is specified `content-type` header will be set to
-            `application/x-www-form-urlencoded` unless explicitly provided.
+            `application/x-www-form-urlencoded` unless explicitly provided. Use `FormData` to send multiple values for the same
+            field.
         multipart : Union[Dict[str, Union[bool, bytes, float, str, {name: str, mimeType: str, buffer: bytes}]], None]
             Provides an object that will be serialized as html form using `multipart/form-data` encoding and sent as this
             request body. If this parameter is specified `content-type` header will be set to `multipart/form-data` unless
             explicitly provided. File values can be passed as file-like object containing file name, mime-type and its content.
+            Use `FormData` to send multiple files in the same field.
         timeout : Union[float, None]
             Request timeout in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout.
         fail_on_status_code : Union[bool, None]
@@ -19332,11 +19665,13 @@ class APIRequestContext(SyncBase):
         form : Union[Dict[str, Union[bool, float, str]], None]
             Provides an object that will be serialized as html form using `application/x-www-form-urlencoded` encoding and sent
             as this request body. If this parameter is specified `content-type` header will be set to
-            `application/x-www-form-urlencoded` unless explicitly provided.
+            `application/x-www-form-urlencoded` unless explicitly provided. Use `FormData` to send multiple values for the same
+            field.
         multipart : Union[Dict[str, Union[bool, bytes, float, str, {name: str, mimeType: str, buffer: bytes}]], None]
             Provides an object that will be serialized as html form using `multipart/form-data` encoding and sent as this
             request body. If this parameter is specified `content-type` header will be set to `multipart/form-data` unless
             explicitly provided. File values can be passed as file-like object containing file name, mime-type and its content.
+            Use `FormData` to send multiple files in the same field.
         timeout : Union[float, None]
             Request timeout in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout.
         fail_on_status_code : Union[bool, None]
@@ -19446,11 +19781,13 @@ class APIRequestContext(SyncBase):
         form : Union[Dict[str, Union[bool, float, str]], None]
             Provides an object that will be serialized as html form using `application/x-www-form-urlencoded` encoding and sent
             as this request body. If this parameter is specified `content-type` header will be set to
-            `application/x-www-form-urlencoded` unless explicitly provided.
+            `application/x-www-form-urlencoded` unless explicitly provided. Use `FormData` to send multiple values for the same
+            field.
         multipart : Union[Dict[str, Union[bool, bytes, float, str, {name: str, mimeType: str, buffer: bytes}]], None]
             Provides an object that will be serialized as html form using `multipart/form-data` encoding and sent as this
             request body. If this parameter is specified `content-type` header will be set to `multipart/form-data` unless
             explicitly provided. File values can be passed as file-like object containing file name, mime-type and its content.
+            Use `FormData` to send multiple files in the same field.
         timeout : Union[float, None]
             Request timeout in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout.
         fail_on_status_code : Union[bool, None]
@@ -19551,11 +19888,13 @@ class APIRequestContext(SyncBase):
         form : Union[Dict[str, Union[bool, float, str]], None]
             Provides an object that will be serialized as html form using `application/x-www-form-urlencoded` encoding and sent
             as this request body. If this parameter is specified `content-type` header will be set to
-            `application/x-www-form-urlencoded` unless explicitly provided.
+            `application/x-www-form-urlencoded` unless explicitly provided. Use `FormData` to send multiple values for the same
+            field.
         multipart : Union[Dict[str, Union[bool, bytes, float, str, {name: str, mimeType: str, buffer: bytes}]], None]
             Provides an object that will be serialized as html form using `multipart/form-data` encoding and sent as this
             request body. If this parameter is specified `content-type` header will be set to `multipart/form-data` unless
             explicitly provided. File values can be passed as file-like object containing file name, mime-type and its content.
+            Use `FormData` to send multiple files in the same field.
         timeout : Union[float, None]
             Request timeout in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout.
         fail_on_status_code : Union[bool, None]
@@ -19865,6 +20204,62 @@ class PageAssertions(SyncBase):
             self._sync(
                 self._impl_obj.not_to_have_url(
                     urlOrRegExp=url_or_reg_exp, timeout=timeout, ignoreCase=ignore_case
+                )
+            )
+        )
+
+    def to_match_aria_snapshot(
+        self, expected: str, *, timeout: typing.Optional[float] = None
+    ) -> None:
+        """PageAssertions.to_match_aria_snapshot
+
+        Asserts that the page body matches the given [accessibility snapshot](https://playwright.dev/python/docs/aria-snapshots).
+
+        **Usage**
+
+        ```py
+        page.goto(\"https://demo.playwright.dev/todomvc/\")
+        expect(page).to_match_aria_snapshot('''
+          - heading \"todos\"
+          - textbox \"What needs to be done?\"
+        ''')
+        ```
+
+        Parameters
+        ----------
+        expected : str
+        timeout : Union[float, None]
+            Time to retry the assertion for in milliseconds. Defaults to `5000`.
+        """
+        __tracebackhide__ = True
+
+        return mapping.from_maybe_impl(
+            self._sync(
+                self._impl_obj.to_match_aria_snapshot(
+                    expected=expected, timeout=timeout
+                )
+            )
+        )
+
+    def not_to_match_aria_snapshot(
+        self, expected: str, *, timeout: typing.Optional[float] = None
+    ) -> None:
+        """PageAssertions.not_to_match_aria_snapshot
+
+        The opposite of `page_assertions.to_match_aria_snapshot()`.
+
+        Parameters
+        ----------
+        expected : str
+        timeout : Union[float, None]
+            Time to retry the assertion for in milliseconds. Defaults to `5000`.
+        """
+        __tracebackhide__ = True
+
+        return mapping.from_maybe_impl(
+            self._sync(
+                self._impl_obj.not_to_match_aria_snapshot(
+                    expected=expected, timeout=timeout
                 )
             )
         )
@@ -20326,6 +20721,7 @@ class LocatorAssertions(SyncBase):
         value: typing.Union[str, typing.Pattern[str]],
         *,
         timeout: typing.Optional[float] = None,
+        pseudo: typing.Optional[Literal["after", "before"]] = None,
     ) -> None:
         """LocatorAssertions.to_have_css
 
@@ -20348,12 +20744,16 @@ class LocatorAssertions(SyncBase):
             CSS property value.
         timeout : Union[float, None]
             Time to retry the assertion for in milliseconds. Defaults to `5000`.
+        pseudo : Union["after", "before", None]
+            Pseudo-element to read computed styles from.
         """
         __tracebackhide__ = True
 
         return mapping.from_maybe_impl(
             self._sync(
-                self._impl_obj.to_have_css(name=name, value=value, timeout=timeout)
+                self._impl_obj.to_have_css(
+                    name=name, value=value, timeout=timeout, pseudo=pseudo
+                )
             )
         )
 

--- a/scripts/documentation_provider.py
+++ b/scripts/documentation_provider.py
@@ -474,7 +474,7 @@ class DocumentationProvider:
             return f"Union[{', '.join(ll)}]"
 
         type_name = type["name"]
-        if type_name in ("path", "Path"):
+        if type_name == "path":
             if direction == "in":
                 return "Union[pathlib.Path, str]"
             else:

--- a/scripts/documentation_provider.py
+++ b/scripts/documentation_provider.py
@@ -474,13 +474,11 @@ class DocumentationProvider:
             return f"Union[{', '.join(ll)}]"
 
         type_name = type["name"]
-        if type_name == "path":
+        if type_name in ("path", "Path"):
             if direction == "in":
                 return "Union[pathlib.Path, str]"
             else:
                 return "pathlib.Path"
-        if type_name == "Path":
-            return "pathlib.Path"
 
         if type_name == "function" and "args" not in type:
             return "Callable"

--- a/scripts/documentation_provider.py
+++ b/scripts/documentation_provider.py
@@ -479,6 +479,8 @@ class DocumentationProvider:
                 return "Union[pathlib.Path, str]"
             else:
                 return "pathlib.Path"
+        if type_name == "Path":
+            return "pathlib.Path"
 
         if type_name == "function" and "args" not in type:
             return "Callable"

--- a/scripts/expected_api_mismatch.txt
+++ b/scripts/expected_api_mismatch.txt
@@ -21,6 +21,24 @@ Parameter type mismatch in Page.route_web_socket(handler=): documented as Callab
 Parameter type mismatch in WebSocketRoute.on_close(handler=): documented as Callable[[Union[int, undefined]], Union[Any, Any]], code has Callable[[Union[int, None], Union[str, None]], Any]
 Parameter type mismatch in WebSocketRoute.on_message(handler=): documented as Callable[[str], Union[Any, Any]], code has Callable[[Union[bytes, str]], Any]
 
+# FormData support is not in this roll; tracked separately in PR #3060.
+Method not implemented: FormData.append
+Method not implemented: FormData.set
+Parameter type mismatch in APIRequestContext.delete(form=): documented as Union[Dict[str, Union[bool, float, str]], FormData, None], code has Union[Dict[str, Union[bool, float, str]], None]
+Parameter type mismatch in APIRequestContext.delete(multipart=): documented as Union[Dict[str, Union[bool, bytes, float, str, {name: str, mimeType: str, buffer: bytes}]], FormData, None], code has Union[Dict[str, Union[bool, bytes, float, str, {name: str, mimeType: str, buffer: bytes}]], None]
+Parameter type mismatch in APIRequestContext.fetch(form=): documented as Union[Dict[str, Union[bool, float, str]], FormData, None], code has Union[Dict[str, Union[bool, float, str]], None]
+Parameter type mismatch in APIRequestContext.fetch(multipart=): documented as Union[Dict[str, Union[bool, bytes, float, str, {name: str, mimeType: str, buffer: bytes}]], FormData, None], code has Union[Dict[str, Union[bool, bytes, float, str, {name: str, mimeType: str, buffer: bytes}]], None]
+Parameter type mismatch in APIRequestContext.get(form=): documented as Union[Dict[str, Union[bool, float, str]], FormData, None], code has Union[Dict[str, Union[bool, float, str]], None]
+Parameter type mismatch in APIRequestContext.get(multipart=): documented as Union[Dict[str, Union[bool, bytes, float, str, {name: str, mimeType: str, buffer: bytes}]], FormData, None], code has Union[Dict[str, Union[bool, bytes, float, str, {name: str, mimeType: str, buffer: bytes}]], None]
+Parameter type mismatch in APIRequestContext.head(form=): documented as Union[Dict[str, Union[bool, float, str]], FormData, None], code has Union[Dict[str, Union[bool, float, str]], None]
+Parameter type mismatch in APIRequestContext.head(multipart=): documented as Union[Dict[str, Union[bool, bytes, float, str, {name: str, mimeType: str, buffer: bytes}]], FormData, None], code has Union[Dict[str, Union[bool, bytes, float, str, {name: str, mimeType: str, buffer: bytes}]], None]
+Parameter type mismatch in APIRequestContext.patch(form=): documented as Union[Dict[str, Union[bool, float, str]], FormData, None], code has Union[Dict[str, Union[bool, float, str]], None]
+Parameter type mismatch in APIRequestContext.patch(multipart=): documented as Union[Dict[str, Union[bool, bytes, float, str, {name: str, mimeType: str, buffer: bytes}]], FormData, None], code has Union[Dict[str, Union[bool, bytes, float, str, {name: str, mimeType: str, buffer: bytes}]], None]
+Parameter type mismatch in APIRequestContext.post(form=): documented as Union[Dict[str, Union[bool, float, str]], FormData, None], code has Union[Dict[str, Union[bool, float, str]], None]
+Parameter type mismatch in APIRequestContext.post(multipart=): documented as Union[Dict[str, Union[bool, bytes, float, str, {name: str, mimeType: str, buffer: bytes}]], FormData, None], code has Union[Dict[str, Union[bool, bytes, float, str, {name: str, mimeType: str, buffer: bytes}]], None]
+Parameter type mismatch in APIRequestContext.put(form=): documented as Union[Dict[str, Union[bool, float, str]], FormData, None], code has Union[Dict[str, Union[bool, float, str]], None]
+Parameter type mismatch in APIRequestContext.put(multipart=): documented as Union[Dict[str, Union[bool, bytes, float, str, {name: str, mimeType: str, buffer: bytes}]], FormData, None], code has Union[Dict[str, Union[bool, bytes, float, str, {name: str, mimeType: str, buffer: bytes}]], None]
+
 # Async API additionally accepts an `async def` predicate.
 Parameter type mismatch in Page.expect_request(url_or_predicate=): documented as Union[Callable[[Request], bool], Pattern[str], str], code has Union[Callable[[Request], Union[bool, typing.Awaitable[bool]]], Pattern[str], str]
 Parameter type mismatch in Page.expect_response(url_or_predicate=): documented as Union[Callable[[Response], bool], Pattern[str], str], code has Union[Callable[[Response], Union[bool, typing.Awaitable[bool]]], Pattern[str], str]

--- a/scripts/generate_api.py
+++ b/scripts/generate_api.py
@@ -238,7 +238,7 @@ import datetime
 from typing import Literal
 
 
-from playwright._impl._api_structures import Cookie, SetCookieParam, FloatRect, FilePayload, Geolocation, HttpCredentials, PdfMargins, Position, ProxySettings, ResourceTiming, SourceLocation, StorageState, ClientCertificate, ViewportSize, RemoteAddr, SecurityDetails, RequestSizes, NameValue, TracingGroupLocation, DebuggerLocation, DebuggerPausedDetails, ScreencastFrame, BrowserBindResult
+from playwright._impl._api_structures import Cookie, SetCookieParam, FloatRect, FilePayload, Geolocation, HttpCredentials, PdfMargins, Position, ProxySettings, ResourceTiming, SourceLocation, StorageState, ClientCertificate, ViewportSize, RemoteAddr, SecurityDetails, RequestSizes, NameValue, TracingGroupLocation, DebuggerLocation, DebuggerPausedDetails, ScreencastFrame, BrowserBindResult, WebErrorLocation, DropPayload
 from playwright._impl._browser import Browser as BrowserImpl
 from playwright._impl._browser_context import BrowserContext as BrowserContextImpl
 from playwright._impl._browser_type import BrowserType as BrowserTypeImpl

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import sys
 import zipfile
 from typing import Dict
 
-driver_version = "1.59.1"
+driver_version = "1.60.0-alpha-1778075025000"
 
 base_wheel_bundles = [
     {

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import sys
 import zipfile
 from typing import Dict
 
-driver_version = "1.60.0-alpha-1778075025000"
+driver_version = "1.60.0-beta-1778142790000"
 
 base_wheel_bundles = [
     {

--- a/tests/async/conftest.py
+++ b/tests/async/conftest.py
@@ -153,7 +153,9 @@ class TraceViewerPage:
 
     @property
     def stack_frames(self) -> Locator:
-        return self.page.get_by_role("list", name="Stack Trace").get_by_role("listitem")
+        return self.page.get_by_role("listbox", name="Stack trace").get_by_role(
+            "option"
+        )
 
     async def select_action(self, title: str, ordinal: int = 0) -> None:
         await self.page.locator(".action-title", has_text=title).nth(ordinal).click()

--- a/tests/async/test_browser.py
+++ b/tests/async/test_browser.py
@@ -68,3 +68,14 @@ async def test_bind_should_return_endpoint_and_allow_unbind(
         await browser.unbind()
     finally:
         await browser.close()
+
+
+async def test_should_fire_context_event_on_new_context(browser: Browser) -> None:
+    # Ported from upstream tests/library/browser.spec.ts.
+    events = []
+    browser.on("context", lambda ctx: events.append(ctx))
+    context = await browser.new_context()
+    try:
+        assert events == [context]
+    finally:
+        await context.close()

--- a/tests/async/test_browsercontext.py
+++ b/tests/async/test_browsercontext.py
@@ -22,7 +22,6 @@ from playwright.async_api import (
     Browser,
     BrowserContext,
     Error,
-    JSHandle,
     Page,
     Playwright,
 )
@@ -467,20 +466,6 @@ async def test_expose_function_should_be_callable_from_inside_add_init_script(
     await page.add_init_script("woof('page')")
     await page.reload()
     assert args == ["context", "page"]
-
-
-async def test_expose_bindinghandle_should_work(context: BrowserContext) -> None:
-    targets: List[JSHandle] = []
-
-    def logme(t: JSHandle) -> int:
-        targets.append(t)
-        return 17
-
-    page = await context.new_page()
-    await page.expose_binding("logme", lambda source, t: logme(t), handle=True)
-    result = await page.evaluate("logme({ foo: 42 })")
-    assert (await targets[0].evaluate("x => x.foo")) == 42
-    assert result == 17
 
 
 async def test_auth_should_fail_without_credentials(

--- a/tests/async/test_browsercontext_events.py
+++ b/tests/async/test_browsercontext_events.py
@@ -206,3 +206,115 @@ async def test_weberror_event_should_work(context: BrowserContext, page: Page) -
     error = await error_info.value
     assert error.page == page
     assert error.error.message == "Test"
+
+
+async def test_weberror_event_should_include_location(
+    context: BrowserContext, page: Page, server: Server
+) -> None:
+    def handle_error_js(request: TestServerRequest) -> None:
+        request.setHeader("content-type", "application/javascript")
+        request.write(
+            b"""
+            function foo() {
+                throw new Error('boom');
+            }
+            foo();
+            """
+        )
+        request.finish()
+
+    def handle_error_html(request: TestServerRequest) -> None:
+        request.setHeader("content-type", "text/html")
+        request.write(b'<script src="/error.js"></script>')
+        request.finish()
+
+    server.set_route("/error.js", handle_error_js)
+    server.set_route("/error.html", handle_error_html)
+
+    async with context.expect_event("weberror") as error_info:
+        await page.goto(server.PREFIX + "/error.html")
+    web_error = await error_info.value
+    location = web_error.location
+    assert location["url"] == f"{server.PREFIX}/error.js"
+    assert location["line"] == 2
+    assert location["column"] > 0
+
+
+async def test_pageload_event_should_work(
+    context: BrowserContext, page: Page, server: Server
+) -> None:
+    async with context.expect_event("pageload") as info:
+        await page.goto(server.EMPTY_PAGE)
+    event_page = await info.value
+    assert event_page == page
+
+
+async def test_framenavigated_event_should_work(
+    context: BrowserContext, page: Page, server: Server
+) -> None:
+    async with context.expect_event("framenavigated") as info:
+        await page.goto(server.EMPTY_PAGE)
+    frame = await info.value
+    assert frame == page.main_frame
+    assert frame.url == server.EMPTY_PAGE
+
+
+async def test_pageclose_event_should_work(context: BrowserContext) -> None:
+    page = await context.new_page()
+    async with context.expect_event("pageclose") as info:
+        await page.close()
+    closed = await info.value
+    assert closed == page
+
+
+async def test_frameattached_event_should_work(
+    context: BrowserContext, page: Page, server: Server
+) -> None:
+    await page.goto(server.EMPTY_PAGE)
+    async with context.expect_event("frameattached") as info:
+        await page.evaluate(
+            """() => {
+                const iframe = document.createElement('iframe');
+                iframe.src = 'about:blank';
+                document.body.appendChild(iframe);
+            }"""
+        )
+    frame = await info.value
+    assert frame.parent_frame == page.main_frame
+
+
+async def test_framedetached_event_should_work(
+    context: BrowserContext, page: Page, server: Server
+) -> None:
+    await page.goto(server.EMPTY_PAGE)
+    await page.evaluate(
+        """() => {
+            const iframe = document.createElement('iframe');
+            iframe.id = 'x';
+            iframe.src = 'about:blank';
+            document.body.appendChild(iframe);
+        }"""
+    )
+    await page.wait_for_selector("iframe")
+    async with context.expect_event("framedetached") as info:
+        await page.evaluate("() => document.getElementById('x').remove()")
+    frame = await info.value
+    assert frame.parent_frame == page.main_frame
+
+
+async def test_download_event_should_work(
+    context: BrowserContext, page: Page, server: Server
+) -> None:
+    def handle_download(request: TestServerRequest) -> None:
+        request.setHeader("Content-Type", "application/octet-stream")
+        request.setHeader("Content-Disposition", "attachment; filename=file.txt")
+        request.write(b"Hello world")
+        request.finish()
+
+    server.set_route("/download", handle_download)
+    await page.set_content(f'<a href="{server.PREFIX}/download">download</a>')
+    async with context.expect_event("download") as info:
+        await page.click("a")
+    download = await info.value
+    assert download.suggested_filename == "file.txt"
+    assert download.page == page

--- a/tests/async/test_console.py
+++ b/tests/async/test_console.py
@@ -124,6 +124,9 @@ async def test_console_should_have_location_for_console_api_calls(
     # Engines have different column notion.
     assert location["url"] == server.PREFIX + "/consolelog.html"
     assert location["lineNumber"] == 7
+    # Added in 1.60: location now also exposes line/column aliases for parity with WebError.location.
+    assert location["line"] == 7
+    assert location["column"] == location["columnNumber"]
 
 
 async def test_console_should_not_throw_when_there_are_console_messages_in_detached_iframes(

--- a/tests/async/test_locators.py
+++ b/tests/async/test_locators.py
@@ -15,13 +15,14 @@
 import os
 import re
 import traceback
+from pathlib import Path
 from typing import Callable
 from urllib.parse import urlparse
 
 import pytest
 
 from playwright._impl._path_utils import get_file_dirname
-from playwright.async_api import Error, Page, expect
+from playwright.async_api import Error, Locator, Page, expect
 from tests.server import Server
 
 _dirname = get_file_dirname()
@@ -1197,3 +1198,212 @@ async def test_normalize_should_resolve_to_a_locator(page: Page) -> None:
     await page.set_content("<button>Click me</button>")
     normalized = await page.get_by_role("button").normalize()
     assert await normalized.text_content() == "Click me"
+
+
+_DROPZONE_HTML = """
+    <style>#dropzone { width: 300px; height: 200px; border: 2px dashed #888; }</style>
+    <div id="dropzone"></div>
+    <script>
+      window.__dropInfo = null;
+      const zone = document.getElementById('dropzone');
+      zone.addEventListener('dragenter', e => e.preventDefault());
+      zone.addEventListener('dragover', e => e.preventDefault());
+      zone.addEventListener('drop', async e => {
+        e.preventDefault();
+        const files = [];
+        for (const file of e.dataTransfer.files)
+          files.push({ name: file.name, type: file.type, size: file.size, text: await file.text() });
+        const data = {};
+        for (const t of e.dataTransfer.types) {
+          if (t !== 'Files')
+            data[t] = e.dataTransfer.getData(t);
+        }
+        window.__dropInfo = { files, data };
+      });
+    </script>
+"""
+
+
+async def _get_drop_info(page: Page) -> dict:
+    handle = await page.wait_for_function("() => window.__dropInfo")
+    return await handle.json_value()
+
+
+async def test_drop_should_drop_a_file_payload(page: Page) -> None:
+    await page.set_content(_DROPZONE_HTML)
+    await page.locator("#dropzone").drop(
+        {"files": {"name": "note.txt", "mimeType": "text/plain", "buffer": b"hello"}}
+    )
+    info = await _get_drop_info(page)
+    assert info == {
+        "files": [
+            {"name": "note.txt", "type": "text/plain", "size": 5, "text": "hello"}
+        ],
+        "data": {},
+    }
+
+
+async def test_drop_should_drop_multiple_file_payloads(page: Page) -> None:
+    await page.set_content(_DROPZONE_HTML)
+    files: list = [
+        {"name": "a.txt", "mimeType": "text/plain", "buffer": b"AAA"},
+        {"name": "b.txt", "mimeType": "text/plain", "buffer": b"BB"},
+    ]
+    await page.locator("#dropzone").drop({"files": files})
+    info = await _get_drop_info(page)
+    assert [(f["name"], f["text"]) for f in info["files"]] == [
+        ("a.txt", "AAA"),
+        ("b.txt", "BB"),
+    ]
+
+
+async def test_drop_should_drop_a_file_by_local_path(
+    page: Page, tmp_path: Path
+) -> None:
+    await page.set_content(_DROPZONE_HTML)
+    file_path = tmp_path / "hello.txt"
+    file_path.write_text("path-content")
+    await page.locator("#dropzone").drop({"files": str(file_path)})
+    info = await _get_drop_info(page)
+    assert len(info["files"]) == 1
+    assert info["files"][0]["name"] == "hello.txt"
+    assert info["files"][0]["text"] == "path-content"
+
+
+async def test_drop_should_drop_clipboard_like_data(page: Page) -> None:
+    await page.set_content(_DROPZONE_HTML)
+    await page.locator("#dropzone").drop(
+        {"data": {"text/plain": "hello world", "text/uri-list": "https://example.com"}}
+    )
+    info = await _get_drop_info(page)
+    assert info["files"] == []
+    assert info["data"]["text/plain"] == "hello world"
+    assert info["data"]["text/uri-list"] == "https://example.com"
+
+
+async def test_drop_should_drop_files_and_data_together(page: Page) -> None:
+    await page.set_content(_DROPZONE_HTML)
+    await page.locator("#dropzone").drop(
+        {
+            "files": {"name": "mix.txt", "mimeType": "text/plain", "buffer": b"mix"},
+            "data": {"text/plain": "label"},
+        }
+    )
+    info = await _get_drop_info(page)
+    assert info["files"][0]["text"] == "mix"
+    assert info["data"]["text/plain"] == "label"
+
+
+async def test_highlight_should_attach_a_glass_pane(page: Page) -> None:
+    # Ported from upstream tests/page/locator-highlight.spec.ts. The Python
+    # SDK uses a closed shadow root for the highlight overlay, so we can only
+    # observe the host element x-pw-glass from outside the shadow. We verify
+    # that highlight() and hide_highlight() invoke without error and that
+    # multiple highlights stack on the page.
+    await page.set_content("<button>One</button><button>Two</button>")
+    await page.get_by_role("button", name="One").highlight()
+    await page.get_by_role("button", name="Two").highlight()
+    await expect(page.locator("x-pw-glass")).to_have_count(1)
+    # hide_highlight per-locator and page-level should not raise.
+    await page.get_by_role("button", name="One").hide_highlight()
+    await page.hide_highlight()
+
+
+async def test_get_by_role_with_description(page: Page) -> None:
+    # Ported from upstream tests/page/selectors-get-by.spec.ts.
+    await page.set_content(
+        """
+        <div role="alert" aria-label="Upload successful" aria-description="File doc-2025.pdf was uploaded successfully">Alert 1</div>
+        <div role="alert" aria-label="Upload successful" aria-description="File report-2026.pdf was uploaded successfully">Alert 2</div>
+        <div role="alert" aria-label="Invalid file" aria-description="File demo.doc has an invalid file format">Alert 3</div>
+    """
+    )
+
+    async def texts(locator: Locator) -> list:
+        return await locator.evaluate_all("els => els.map(e => e.textContent)")
+
+    # description substring match (default)
+    assert await texts(page.get_by_role("alert", description="doc-2025")) == ["Alert 1"]
+    assert await texts(page.get_by_role("alert", description="report-2026")) == [
+        "Alert 2"
+    ]
+
+    # description with name combined
+    assert await texts(
+        page.get_by_role("alert", name="Upload successful", description="doc-2025")
+    ) == ["Alert 1"]
+    assert await texts(
+        page.get_by_role("alert", name="Upload successful", description="report-2026")
+    ) == ["Alert 2"]
+    assert (
+        await texts(
+            page.get_by_role("alert", name="Invalid file", description="doc-2025")
+        )
+        == []
+    )
+
+    # description exact match
+    assert (
+        await texts(page.get_by_role("alert", description="doc-2025", exact=True)) == []
+    )
+    assert await texts(
+        page.get_by_role(
+            "alert",
+            description="File doc-2025.pdf was uploaded successfully",
+            exact=True,
+        )
+    ) == ["Alert 1"]
+
+    # description regex match
+    assert await texts(
+        page.get_by_role("alert", description=re.compile(r"report-\d+"))
+    ) == ["Alert 2"]
+    assert await texts(
+        page.get_by_role("alert", description=re.compile(r"uploaded successfully$"))
+    ) == ["Alert 1", "Alert 2"]
+
+
+async def test_get_by_role_with_description_via_aria_describedby(page: Page) -> None:
+    # Ported from upstream tests/page/selectors-get-by.spec.ts.
+    await page.set_content(
+        """
+        <button aria-describedby="desc1">Submit</button>
+        <span id="desc1">Submits the form data</span>
+        <button aria-describedby="desc2">Submit</button>
+        <span id="desc2">Saves as draft</span>
+    """
+    )
+    assert await page.get_by_role(
+        "button", name="Submit", description="form data"
+    ).evaluate_all("els => els.map(e => e.textContent)") == ["Submit"]
+    assert await page.get_by_role(
+        "button", name="Submit", description="draft"
+    ).evaluate_all("els => els.map(e => e.textContent)") == ["Submit"]
+
+
+async def test_get_by_role_with_description_via_title_fallback(page: Page) -> None:
+    # Ported from upstream tests/page/selectors-get-by.spec.ts.
+    await page.set_content(
+        """
+        <button title="Submits the form">Submit</button>
+        <button title="Resets the form">Reset</button>
+    """
+    )
+    assert await page.get_by_role("button", description="Submits").evaluate_all(
+        "els => els.map(e => e.textContent)"
+    ) == ["Submit"]
+    assert await page.get_by_role("button", description="Resets").evaluate_all(
+        "els => els.map(e => e.textContent)"
+    ) == ["Reset"]
+
+
+async def test_get_by_role_with_description_whitespace_normalization(
+    page: Page,
+) -> None:
+    # Ported from upstream tests/page/selectors-get-by.spec.ts.
+    await page.set_content(
+        '<div role="alert" aria-description="File  doc-2025.pdf   was uploaded   successfully">Alert</div>'
+    )
+    assert await page.get_by_role(
+        "alert", description="  doc-2025.pdf \n was  uploaded "
+    ).evaluate_all("els => els.map(e => e.textContent)") == ["Alert"]

--- a/tests/async/test_locators.py
+++ b/tests/async/test_locators.py
@@ -1294,21 +1294,6 @@ async def test_drop_should_drop_files_and_data_together(page: Page) -> None:
     assert info["data"]["text/plain"] == "label"
 
 
-async def test_highlight_should_attach_a_glass_pane(page: Page) -> None:
-    # Ported from upstream tests/page/locator-highlight.spec.ts. The Python
-    # SDK uses a closed shadow root for the highlight overlay, so we can only
-    # observe the host element x-pw-glass from outside the shadow. We verify
-    # that highlight() and hide_highlight() invoke without error and that
-    # multiple highlights stack on the page.
-    await page.set_content("<button>One</button><button>Two</button>")
-    await page.get_by_role("button", name="One").highlight()
-    await page.get_by_role("button", name="Two").highlight()
-    await expect(page.locator("x-pw-glass")).to_have_count(1)
-    # hide_highlight per-locator and page-level should not raise.
-    await page.get_by_role("button", name="One").hide_highlight()
-    await page.hide_highlight()
-
-
 async def test_get_by_role_with_description(page: Page) -> None:
     # Ported from upstream tests/page/selectors-get-by.spec.ts.
     await page.set_content(
@@ -1361,40 +1346,6 @@ async def test_get_by_role_with_description(page: Page) -> None:
     assert await texts(
         page.get_by_role("alert", description=re.compile(r"uploaded successfully$"))
     ) == ["Alert 1", "Alert 2"]
-
-
-async def test_get_by_role_with_description_via_aria_describedby(page: Page) -> None:
-    # Ported from upstream tests/page/selectors-get-by.spec.ts.
-    await page.set_content(
-        """
-        <button aria-describedby="desc1">Submit</button>
-        <span id="desc1">Submits the form data</span>
-        <button aria-describedby="desc2">Submit</button>
-        <span id="desc2">Saves as draft</span>
-    """
-    )
-    assert await page.get_by_role(
-        "button", name="Submit", description="form data"
-    ).evaluate_all("els => els.map(e => e.textContent)") == ["Submit"]
-    assert await page.get_by_role(
-        "button", name="Submit", description="draft"
-    ).evaluate_all("els => els.map(e => e.textContent)") == ["Submit"]
-
-
-async def test_get_by_role_with_description_via_title_fallback(page: Page) -> None:
-    # Ported from upstream tests/page/selectors-get-by.spec.ts.
-    await page.set_content(
-        """
-        <button title="Submits the form">Submit</button>
-        <button title="Resets the form">Reset</button>
-    """
-    )
-    assert await page.get_by_role("button", description="Submits").evaluate_all(
-        "els => els.map(e => e.textContent)"
-    ) == ["Submit"]
-    assert await page.get_by_role("button", description="Resets").evaluate_all(
-        "els => els.map(e => e.textContent)"
-    ) == ["Reset"]
 
 
 async def test_get_by_role_with_description_whitespace_normalization(

--- a/tests/async/test_page.py
+++ b/tests/async/test_page.py
@@ -16,14 +16,13 @@ import asyncio
 import os
 import re
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 import pytest
 
 from playwright.async_api import (
     BrowserContext,
     Error,
-    JSHandle,
     Page,
     Route,
     TimeoutError,
@@ -539,19 +538,6 @@ async def test_expose_function_should_work_with_complex_objects(
     await page.expose_function("complexObject", lambda a, b: dict(x=a["x"] + b["x"]))
     result = await page.evaluate("complexObject({x: 5}, {x: 2})")
     assert result["x"] == 7
-
-
-async def test_expose_bindinghandle_should_work(page: Page, server: Server) -> None:
-    targets: List[JSHandle] = []
-
-    def logme(t: JSHandle) -> int:
-        targets.append(t)
-        return 17
-
-    await page.expose_binding("logme", lambda source, t: logme(t), handle=True)
-    result = await page.evaluate("logme({ foo: 42 })")
-    assert (await targets[0].evaluate("x => x.foo")) == 42
-    assert result == 17
 
 
 async def test_page_error_should_fire(

--- a/tests/async/test_page_aria_snapshot.py
+++ b/tests/async/test_page_aria_snapshot.py
@@ -231,3 +231,47 @@ async def test_page_aria_snapshot_should_work(page: Page) -> None:
       - heading "title" [level=1]
     """
     )
+
+
+async def test_to_match_aria_snapshot_should_match_page(page: Page) -> None:
+    # Ported from upstream tests/page/to-match-aria-snapshot.spec.ts.
+    await page.set_content("<h1>title</h1>")
+    await expect(page).to_match_aria_snapshot(
+        """
+        - heading "title"
+        """
+    )
+
+
+async def test_to_match_aria_snapshot_should_match_page_complex(page: Page) -> None:
+    # Ported from upstream tests/page/to-match-aria-snapshot.spec.ts.
+    await page.set_content(
+        """
+        <h1>Microsoft</h1>
+        <div>Open source projects and samples from Microsoft</div>
+        <ul>
+          <li>
+            <a href="about:blank">Playwright</a>
+          </li>
+        </ul>
+        """
+    )
+    await expect(page).to_match_aria_snapshot(
+        """
+        - heading "Microsoft"
+        - text: Open source projects and samples from Microsoft
+        - list:
+          - listitem:
+            - link "Playwright"
+        """
+    )
+
+
+async def test_to_match_aria_snapshot_should_match_page_with_not(page: Page) -> None:
+    # Ported from upstream tests/page/to-match-aria-snapshot.spec.ts.
+    await page.set_content("<h1>title</h1>")
+    await expect(page).not_to_match_aria_snapshot(
+        """
+        - heading "wrong"
+        """
+    )

--- a/tests/async/test_tracing.py
+++ b/tests/async/test_tracing.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import asyncio
+import json
 import re
+import zipfile
 from pathlib import Path
 from typing import AsyncContextManager, Callable
 
@@ -22,6 +24,7 @@ from playwright.async_api import (
     BrowserContext,
     BrowserType,
     Page,
+    Playwright,
     Response,
     expect,
 )
@@ -387,3 +390,56 @@ async def test_should_show_tracing_group_in_action_list(
                 re.compile(r"inner group 2"),
             ]
         )
+
+
+async def test_should_start_and_stop_har(
+    browser: Browser, server: Server, tmp_path: Path
+) -> None:
+    context = await browser.new_context()
+    page = await context.new_page()
+    har_path = tmp_path / "test.har"
+    await context.tracing.start_har(path=har_path, content="embed", mode="full")
+    await page.goto(server.PREFIX + "/empty.html")
+    await context.tracing.stop_har()
+    await context.close()
+    assert har_path.exists()
+    assert har_path.stat().st_size > 0
+
+
+async def test_should_record_a_har_with_options(
+    browser: Browser, server: Server, tmp_path: Path
+) -> None:
+    # Ported from upstream tests/library/har.spec.ts.
+    context = await browser.new_context()
+    har_path = tmp_path / "tracing.har"
+    await context.tracing.start_har(
+        path=har_path, mode="minimal", url_filter="**/one-style.css"
+    )
+    page = await context.new_page()
+    await page.goto(server.PREFIX + "/one-style.html")
+    await context.tracing.stop_har()
+    await context.close()
+
+    log = json.loads(har_path.read_text())["log"]
+    urls = [e["request"]["url"] for e in log["entries"]]
+    assert urls == [server.PREFIX + "/one-style.css"]
+    # Minimal mode drops body sizes.
+    assert log["entries"][0]["request"]["bodySize"] == -1
+
+
+async def test_should_record_a_zipped_har_for_apirequestcontext(
+    playwright: Playwright, server: Server, tmp_path: Path
+) -> None:
+    # Ported from upstream tests/library/har.spec.ts.
+    request = await playwright.request.new_context()
+    har_path = tmp_path / "tracing.har.zip"
+    await request.tracing.start_har(path=har_path, content="attach")
+    await request.get(server.PREFIX + "/simple.json")
+    await request.tracing.stop_har()
+    await request.dispose()
+
+    with zipfile.ZipFile(har_path) as zf:
+        log = json.loads(zf.read("har.har"))["log"]
+    assert any(
+        e["request"]["url"] == server.PREFIX + "/simple.json" for e in log["entries"]
+    )

--- a/tests/sync/conftest.py
+++ b/tests/sync/conftest.py
@@ -143,7 +143,9 @@ class TraceViewerPage:
 
     @property
     def stack_frames(self) -> Locator:
-        return self.page.get_by_role("list", name="Stack trace").get_by_role("listitem")
+        return self.page.get_by_role("listbox", name="Stack trace").get_by_role(
+            "option"
+        )
 
     def select_action(self, title: str, ordinal: int = 0) -> None:
         self.page.locator(".action-title", has_text=title).nth(ordinal).click()

--- a/tests/sync/test_browser.py
+++ b/tests/sync/test_browser.py
@@ -35,3 +35,13 @@ def test_bind_should_return_endpoint_and_allow_unbind(
         browser.unbind()
     finally:
         browser.close()
+
+
+def test_should_fire_context_event_on_new_context(browser: Browser) -> None:
+    events = []
+    browser.on("context", lambda ctx: events.append(ctx))
+    context = browser.new_context()
+    try:
+        assert events == [context]
+    finally:
+        context.close()

--- a/tests/sync/test_browsercontext_events.py
+++ b/tests/sync/test_browsercontext_events.py
@@ -208,3 +208,111 @@ def test_weberror_event_should_work(context: BrowserContext, page: Page) -> None
     error = error_info.value
     assert error.page == page
     assert error.error.message == "Test"
+
+
+def test_weberror_event_should_include_location(
+    context: BrowserContext, page: Page, server: Server
+) -> None:
+    def handle_error_js(request: TestServerRequest) -> None:
+        request.setHeader("content-type", "application/javascript")
+        request.write(
+            b"""
+            function foo() {
+                throw new Error('boom');
+            }
+            foo();
+            """
+        )
+        request.finish()
+
+    def handle_error_html(request: TestServerRequest) -> None:
+        request.setHeader("content-type", "text/html")
+        request.write(b'<script src="/error.js"></script>')
+        request.finish()
+
+    server.set_route("/error.js", handle_error_js)
+    server.set_route("/error.html", handle_error_html)
+
+    with context.expect_event("weberror") as error_info:
+        page.goto(server.PREFIX + "/error.html")
+    web_error = error_info.value
+    location = web_error.location
+    assert location["url"] == f"{server.PREFIX}/error.js"
+    assert location["line"] == 2
+    assert location["column"] > 0
+
+
+def test_pageload_event_should_work(
+    context: BrowserContext, page: Page, server: Server
+) -> None:
+    with context.expect_event("pageload") as info:
+        page.goto(server.EMPTY_PAGE)
+    assert info.value == page
+
+
+def test_framenavigated_event_should_work(
+    context: BrowserContext, page: Page, server: Server
+) -> None:
+    with context.expect_event("framenavigated") as info:
+        page.goto(server.EMPTY_PAGE)
+    frame = info.value
+    assert frame == page.main_frame
+    assert frame.url == server.EMPTY_PAGE
+
+
+def test_pageclose_event_should_work(context: BrowserContext) -> None:
+    page = context.new_page()
+    with context.expect_event("pageclose") as info:
+        page.close()
+    assert info.value == page
+
+
+def test_frameattached_event_should_work(
+    context: BrowserContext, page: Page, server: Server
+) -> None:
+    page.goto(server.EMPTY_PAGE)
+    with context.expect_event("frameattached") as info:
+        page.evaluate(
+            """() => {
+                const iframe = document.createElement('iframe');
+                iframe.src = 'about:blank';
+                document.body.appendChild(iframe);
+            }"""
+        )
+    assert info.value.parent_frame == page.main_frame
+
+
+def test_framedetached_event_should_work(
+    context: BrowserContext, page: Page, server: Server
+) -> None:
+    page.goto(server.EMPTY_PAGE)
+    page.evaluate(
+        """() => {
+            const iframe = document.createElement('iframe');
+            iframe.id = 'x';
+            iframe.src = 'about:blank';
+            document.body.appendChild(iframe);
+        }"""
+    )
+    page.wait_for_selector("iframe")
+    with context.expect_event("framedetached") as info:
+        page.evaluate("() => document.getElementById('x').remove()")
+    assert info.value.parent_frame == page.main_frame
+
+
+def test_download_event_should_work(
+    context: BrowserContext, page: Page, server: Server
+) -> None:
+    def handle_download(request: TestServerRequest) -> None:
+        request.setHeader("Content-Type", "application/octet-stream")
+        request.setHeader("Content-Disposition", "attachment; filename=file.txt")
+        request.write(b"Hello world")
+        request.finish()
+
+    server.set_route("/download", handle_download)
+    page.set_content(f'<a href="{server.PREFIX}/download">download</a>')
+    with context.expect_event("download") as info:
+        page.click("a")
+    download = info.value
+    assert download.suggested_filename == "file.txt"
+    assert download.page == page

--- a/tests/sync/test_console.py
+++ b/tests/sync/test_console.py
@@ -129,6 +129,9 @@ def test_console_should_have_location_for_console_api_calls(
     # Engines have different column notion.
     assert location["url"] == server.PREFIX + "/consolelog.html"
     assert location["lineNumber"] == 7
+    # Added in 1.60: location now also exposes line/column aliases for parity with WebError.location.
+    assert location["line"] == 7
+    assert location["column"] == location["columnNumber"]
 
 
 def test_console_should_not_throw_when_there_are_console_messages_in_detached_iframes(

--- a/tests/sync/test_locators.py
+++ b/tests/sync/test_locators.py
@@ -1065,15 +1065,6 @@ def test_drop_should_drop_clipboard_like_data(page: Page) -> None:
     assert info["data"]["text/plain"] == "hello world"
 
 
-def test_highlight_should_attach_a_glass_pane(page: Page) -> None:
-    page.set_content("<button>One</button><button>Two</button>")
-    page.get_by_role("button", name="One").highlight()
-    page.get_by_role("button", name="Two").highlight()
-    expect(page.locator("x-pw-glass")).to_have_count(1)
-    page.get_by_role("button", name="One").hide_highlight()
-    page.hide_highlight()
-
-
 def test_get_by_role_with_description(page: Page) -> None:
     page.set_content(
         """
@@ -1105,20 +1096,6 @@ def test_get_by_role_with_description(page: Page) -> None:
     assert texts(
         page.get_by_role("alert", description=re.compile(r"uploaded successfully$"))
     ) == ["Alert 1", "Alert 2"]
-
-
-def test_get_by_role_with_description_via_aria_describedby(page: Page) -> None:
-    page.set_content(
-        """
-        <button aria-describedby="desc1">Submit</button>
-        <span id="desc1">Submits the form data</span>
-        <button aria-describedby="desc2">Submit</button>
-        <span id="desc2">Saves as draft</span>
-    """
-    )
-    assert page.get_by_role(
-        "button", name="Submit", description="form data"
-    ).evaluate_all("els => els.map(e => e.textContent)") == ["Submit"]
 
 
 def test_get_by_role_with_description_whitespace_normalization(page: Page) -> None:

--- a/tests/sync/test_locators.py
+++ b/tests/sync/test_locators.py
@@ -21,7 +21,7 @@ from urllib.parse import urlparse
 import pytest
 
 from playwright._impl._path_utils import get_file_dirname
-from playwright.sync_api import Error, Page, expect
+from playwright.sync_api import Error, Locator, Page, expect
 from tests.server import Server
 
 _dirname = get_file_dirname()
@@ -1012,3 +1012,119 @@ def test_locator_should_ignore_deprecated_is_hidden_and_visible_timeout(
     div = page.locator("div")
     assert div.is_hidden(timeout=10) is False
     assert div.is_visible(timeout=10) is True
+
+
+_DROPZONE_HTML = """
+    <style>#dropzone { width: 300px; height: 200px; border: 2px dashed #888; }</style>
+    <div id="dropzone"></div>
+    <script>
+      window.__dropInfo = null;
+      const zone = document.getElementById('dropzone');
+      zone.addEventListener('dragenter', e => e.preventDefault());
+      zone.addEventListener('dragover', e => e.preventDefault());
+      zone.addEventListener('drop', async e => {
+        e.preventDefault();
+        const files = [];
+        for (const file of e.dataTransfer.files)
+          files.push({ name: file.name, type: file.type, size: file.size, text: await file.text() });
+        const data = {};
+        for (const t of e.dataTransfer.types) {
+          if (t !== 'Files')
+            data[t] = e.dataTransfer.getData(t);
+        }
+        window.__dropInfo = { files, data };
+      });
+    </script>
+"""
+
+
+def _get_drop_info(page: Page) -> dict:
+    handle = page.wait_for_function("() => window.__dropInfo")
+    return handle.json_value()
+
+
+def test_drop_should_drop_a_file_payload(page: Page) -> None:
+    page.set_content(_DROPZONE_HTML)
+    page.locator("#dropzone").drop(
+        {"files": {"name": "note.txt", "mimeType": "text/plain", "buffer": b"hello"}}
+    )
+    info = _get_drop_info(page)
+    assert info == {
+        "files": [
+            {"name": "note.txt", "type": "text/plain", "size": 5, "text": "hello"}
+        ],
+        "data": {},
+    }
+
+
+def test_drop_should_drop_clipboard_like_data(page: Page) -> None:
+    page.set_content(_DROPZONE_HTML)
+    page.locator("#dropzone").drop({"data": {"text/plain": "hello world"}})
+    info = _get_drop_info(page)
+    assert info["files"] == []
+    assert info["data"]["text/plain"] == "hello world"
+
+
+def test_highlight_should_attach_a_glass_pane(page: Page) -> None:
+    page.set_content("<button>One</button><button>Two</button>")
+    page.get_by_role("button", name="One").highlight()
+    page.get_by_role("button", name="Two").highlight()
+    expect(page.locator("x-pw-glass")).to_have_count(1)
+    page.get_by_role("button", name="One").hide_highlight()
+    page.hide_highlight()
+
+
+def test_get_by_role_with_description(page: Page) -> None:
+    page.set_content(
+        """
+        <div role="alert" aria-label="Upload successful" aria-description="File doc-2025.pdf was uploaded successfully">Alert 1</div>
+        <div role="alert" aria-label="Upload successful" aria-description="File report-2026.pdf was uploaded successfully">Alert 2</div>
+        <div role="alert" aria-label="Invalid file" aria-description="File demo.doc has an invalid file format">Alert 3</div>
+    """
+    )
+
+    def texts(locator: Locator) -> list:
+        return locator.evaluate_all("els => els.map(e => e.textContent)")
+
+    assert texts(page.get_by_role("alert", description="doc-2025")) == ["Alert 1"]
+    assert texts(page.get_by_role("alert", description="report-2026")) == ["Alert 2"]
+    assert texts(
+        page.get_by_role("alert", name="Upload successful", description="doc-2025")
+    ) == ["Alert 1"]
+    assert texts(page.get_by_role("alert", description="doc-2025", exact=True)) == []
+    assert texts(
+        page.get_by_role(
+            "alert",
+            description="File doc-2025.pdf was uploaded successfully",
+            exact=True,
+        )
+    ) == ["Alert 1"]
+    assert texts(page.get_by_role("alert", description=re.compile(r"report-\d+"))) == [
+        "Alert 2"
+    ]
+    assert texts(
+        page.get_by_role("alert", description=re.compile(r"uploaded successfully$"))
+    ) == ["Alert 1", "Alert 2"]
+
+
+def test_get_by_role_with_description_via_aria_describedby(page: Page) -> None:
+    page.set_content(
+        """
+        <button aria-describedby="desc1">Submit</button>
+        <span id="desc1">Submits the form data</span>
+        <button aria-describedby="desc2">Submit</button>
+        <span id="desc2">Saves as draft</span>
+    """
+    )
+    assert page.get_by_role(
+        "button", name="Submit", description="form data"
+    ).evaluate_all("els => els.map(e => e.textContent)") == ["Submit"]
+
+
+def test_get_by_role_with_description_whitespace_normalization(page: Page) -> None:
+    page.set_content(
+        '<div role="alert" aria-description="File  doc-2025.pdf   was uploaded   successfully">Alert</div>'
+    )
+    assert page.get_by_role(
+        "alert", description="  doc-2025.pdf \n was  uploaded "
+    ).evaluate_all("els => els.map(e => e.textContent)") == ["Alert"]

--- a/tests/sync/test_page_aria_snapshot.py
+++ b/tests/sync/test_page_aria_snapshot.py
@@ -231,3 +231,44 @@ def test_page_aria_snapshot_should_work(page: Page) -> None:
       - heading "title" [level=1]
     """
     )
+
+
+def test_to_match_aria_snapshot_should_match_page(page: Page) -> None:
+    page.set_content("<h1>title</h1>")
+    expect(page).to_match_aria_snapshot(
+        """
+        - heading "title"
+        """
+    )
+
+
+def test_to_match_aria_snapshot_should_match_page_complex(page: Page) -> None:
+    page.set_content(
+        """
+        <h1>Microsoft</h1>
+        <div>Open source projects and samples from Microsoft</div>
+        <ul>
+          <li>
+            <a href="about:blank">Playwright</a>
+          </li>
+        </ul>
+        """
+    )
+    expect(page).to_match_aria_snapshot(
+        """
+        - heading "Microsoft"
+        - text: Open source projects and samples from Microsoft
+        - list:
+          - listitem:
+            - link "Playwright"
+        """
+    )
+
+
+def test_to_match_aria_snapshot_should_match_page_with_not(page: Page) -> None:
+    page.set_content("<h1>title</h1>")
+    expect(page).not_to_match_aria_snapshot(
+        """
+        - heading "wrong"
+        """
+    )

--- a/tests/sync/test_tracing.py
+++ b/tests/sync/test_tracing.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import re
 import threading
+import zipfile
 from pathlib import Path
 from typing import Callable, ContextManager
 
@@ -22,6 +24,7 @@ from playwright.sync_api import (
     BrowserContext,
     BrowserType,
     Page,
+    Playwright,
     Response,
     expect,
 )
@@ -388,3 +391,53 @@ def test_should_show_tracing_group_in_action_list(
                 re.compile(r"inner group 2"),
             ]
         )
+
+
+def test_should_start_and_stop_har(
+    browser: Browser, server: Server, tmp_path: Path
+) -> None:
+    context = browser.new_context()
+    page = context.new_page()
+    har_path = tmp_path / "test.har"
+    context.tracing.start_har(path=har_path, content="embed", mode="full")
+    page.goto(server.PREFIX + "/empty.html")
+    context.tracing.stop_har()
+    context.close()
+    assert har_path.exists()
+    assert har_path.stat().st_size > 0
+
+
+def test_should_record_a_har_with_options(
+    browser: Browser, server: Server, tmp_path: Path
+) -> None:
+    context = browser.new_context()
+    har_path = tmp_path / "tracing.har"
+    context.tracing.start_har(
+        path=har_path, mode="minimal", url_filter="**/one-style.css"
+    )
+    page = context.new_page()
+    page.goto(server.PREFIX + "/one-style.html")
+    context.tracing.stop_har()
+    context.close()
+
+    log = json.loads(har_path.read_text())["log"]
+    urls = [e["request"]["url"] for e in log["entries"]]
+    assert urls == [server.PREFIX + "/one-style.css"]
+    assert log["entries"][0]["request"]["bodySize"] == -1
+
+
+def test_should_record_a_zipped_har_for_apirequestcontext(
+    playwright: Playwright, server: Server, tmp_path: Path
+) -> None:
+    request = playwright.request.new_context()
+    har_path = tmp_path / "tracing.har.zip"
+    request.tracing.start_har(path=har_path, content="attach")
+    request.get(server.PREFIX + "/simple.json")
+    request.tracing.stop_har()
+    request.dispose()
+
+    with zipfile.ZipFile(har_path) as zf:
+        log = json.loads(zf.read("har.har"))["log"]
+    assert any(
+        e["request"]["url"] == server.PREFIX + "/simple.json" for e in log["entries"]
+    )


### PR DESCRIPTION
Rolls the driver to `1.60.0-alpha-1778075025000`.

- FormData support is deferred to #3060.
- New ports include: `Browser.context` event, `BrowserContext` lifecycle events (pageload/framenavigated/pageclose/frameattached/framedetached/download), `Locator.drop`, `Locator.highlight`/`hide_highlight`, `Page.hide_highlight`, `Page.to_match_aria_snapshot`, `Locator.get_by_role(description=)`, `Tracing.start_har`/`stop_har`, `WebError.location`, `ConsoleMessage.location` line/column fields.
- Tests added/ported from upstream specs.