### PR TITLE
fix(documentation_provider): correct spelling "redundant" in function name

### DIFF
--- a/scripts/documentation_provider.py
+++ b/scripts/documentation_provider.py
@@ -300,7 +300,7 @@ class DocumentationProvider:
         return "\n".join(result)
 
     def beautify_method_comment(self, comment: str, indent: str) -> str:
-        comment = self.filter_out_redudant_python_code_snippets(comment)
+        comment = self.filter_out_redundant_python_code_snippets(comment)
         comment = comment.replace("\\", "\\\\")
         comment = comment.replace('"', '\\"')
         lines = comment.split("\n")
@@ -331,7 +331,7 @@ class DocumentationProvider:
         comment = self.indent_paragraph("\n".join(result), indent)
         return self.resolve_playwright_dev_links(comment)
 
-    def filter_out_redudant_python_code_snippets(self, comment: str) -> str:
+    def filter_out_redundant_python_code_snippets(self, comment: str) -> str:
         groups = []
         current_group = []
         lines = comment.split("\n")


### PR DESCRIPTION
## Summary

* Renamed a misspelled helper function in `scripts/documentation_provider.py`
* Updated `filter_out_redudant_python_code_snippets` → `filter_out_redundant_python_code_snippets`
* Updated the corresponding call site in `beautify_method_comment()`
* No behavioral or functional changes

## Details

This is a small refactor to correct a spelling mistake in a helper function name (`redudant` → `redundant`).

The change is self-contained within a single file, and the related function call was updated accordingly.

### Before

```python
def filter_out_redudant_python_code_snippets(self, comment: str) -> str:
    groups = []

def beautify_method_comment(self, comment: str, indent: str) -> str:
    comment = self.filter_out_redudant_python_code_snippets(comment)
```

### After

```python
def filter_out_redundant_python_code_snippets(self, comment: str) -> str:
    groups = []

def beautify_method_comment(self, comment: str, indent: str) -> str:
    comment = self.filter_out_redundant_python_code_snippets(comment)
```

Verified that no external references to the old function name exist.
