### PR TITLE
chore: roll driver to 1.60.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ import zipfile
 from pathlib import Path
 from typing import Dict
 
-driver_version = "1.60.0-beta-1778142790000"
+driver_version = "1.60.0"
 
 base_wheel_bundles = [
     {


### PR DESCRIPTION
Bumps `driver_version` from `1.60.0-beta-1778142790000` to `1.60.0`. No public API surface changes since the beta roll — the four upstream `docs/src/api/` commits in the range are either langs-restricted, doc-only aliasing, or were already implemented in the beta.