### PR TITLE
feat(api): add screencast size option

### DIFF
--- a/playwright/_impl/_screencast.py
+++ b/playwright/_impl/_screencast.py
@@ -16,7 +16,7 @@ import base64
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union
 
-from playwright._impl._api_structures import ScreencastFrame
+from playwright._impl._api_structures import ScreencastFrame, ViewportSize
 from playwright._impl._artifact import Artifact
 from playwright._impl._connection import from_nullable_channel
 from playwright._impl._disposable import DisposableStub
@@ -70,6 +70,7 @@ class Screencast:
         onFrame: ScreencastFrameCallback = None,
         path: Union[str, Path] = None,
         quality: int = None,
+        size: ViewportSize = None,
     ) -> DisposableStub:
         if self._started:
             raise Error("Screencast is already started")
@@ -80,6 +81,7 @@ class Screencast:
             None,
             {
                 "quality": quality,
+                "size": size,
                 "sendFrames": bool(onFrame),
                 "record": bool(path),
             },

--- a/playwright/async_api/_generated.py
+++ b/playwright/async_api/_generated.py
@@ -7692,6 +7692,7 @@ class Screencast(AsyncBase):
         ] = None,
         path: typing.Optional[typing.Union[pathlib.Path, str]] = None,
         quality: typing.Optional[int] = None,
+        size: typing.Optional[ViewportSize] = None,
     ) -> "AsyncContextManager":
         """Screencast.start
 
@@ -7708,6 +7709,8 @@ class Screencast(AsyncBase):
             Path where the video should be saved when the screencast is stopped. When provided, video recording is started.
         quality : Union[int, None]
             The quality of the image, between 0-100.
+        size : Union[{width: int, height: int}, None]
+            Output frame size.
 
         Returns
         -------
@@ -7716,7 +7719,10 @@ class Screencast(AsyncBase):
 
         return mapping.from_impl(
             await self._impl_obj.start(
-                onFrame=self._wrap_handler(on_frame), path=path, quality=quality
+                onFrame=self._wrap_handler(on_frame),
+                path=path,
+                quality=quality,
+                size=size,
             )
         )
 

--- a/playwright/sync_api/_generated.py
+++ b/playwright/sync_api/_generated.py
@@ -7768,6 +7768,7 @@ class Screencast(SyncBase):
         ] = None,
         path: typing.Optional[typing.Union[pathlib.Path, str]] = None,
         quality: typing.Optional[int] = None,
+        size: typing.Optional[ViewportSize] = None,
     ) -> "SyncContextManager":
         """Screencast.start
 
@@ -7784,6 +7785,8 @@ class Screencast(SyncBase):
             Path where the video should be saved when the screencast is stopped. When provided, video recording is started.
         quality : Union[int, None]
             The quality of the image, between 0-100.
+        size : Union[{width: int, height: int}, None]
+            Output frame size.
 
         Returns
         -------
@@ -7793,7 +7796,10 @@ class Screencast(SyncBase):
         return mapping.from_impl(
             self._sync(
                 self._impl_obj.start(
-                    onFrame=self._wrap_handler(on_frame), path=path, quality=quality
+                    onFrame=self._wrap_handler(on_frame),
+                    path=path,
+                    quality=quality,
+                    size=size,
                 )
             )
         )


### PR DESCRIPTION
Fixes #3083

## Summary
This adds the missing `size` option to `page.screencast.start()` for both async and sync Python APIs.

## Why
The screencast protocol already accepts a size, but Python users could only set `quality`, `path`, and `on_frame`. That meant users could not control screencast frame/video resolution without changing the page viewport.

## Test plan
- `python3 - <<'PY'` signature import check for async and sync `Screencast.start`
- `git diff --check`
