### PR TITLE
fix(assertions): render aria snapshot in its own section on expect failure

### DIFF
--- a/playwright/_impl/_assertions.py
+++ b/playwright/_impl/_assertions.py
@@ -103,11 +103,11 @@ class AssertionsBase:
         result = await self._call_expect(expression, expect_options, title)
         if result["matches"] == self._is_not:
             received = result.get("received") or {}
+            aria_snapshot = None
             if isinstance(received, dict):
-                if "value" in received and received["value"] is not None:
-                    actual = parse_value(received["value"])
-                else:
-                    actual = received.get("ariaSnapshot")
+                aria_snapshot = received.get("ariaSnapshot")
+                value = received.get("value")
+                actual = parse_value(value) if value is not None else None
             else:
                 actual = received
             if self._custom_message:
@@ -120,9 +120,12 @@ class AssertionsBase:
                 )
             error_message = result.get("errorMessage")
             error_message = f"\n{error_message}" if error_message else ""
+            aria_snapshot_message = (
+                f"\nAria snapshot:\n{aria_snapshot}" if aria_snapshot else ""
+            )
             _record_soft_or_raise(
                 AssertionError(
-                    f"{out_message}\nActual value: {actual}{error_message} {format_call_log(result.get('log'))}"
+                    f"{out_message}\nActual value: {actual}{error_message} {format_call_log(result.get('log'))}{aria_snapshot_message}"
                 ),
                 self._is_soft,
             )

--- a/tests/async/test_assertions.py
+++ b/tests/async/test_assertions.py
@@ -1179,3 +1179,23 @@ async def test_soft_does_not_leak_between_scopes(page: Page, server: Server) -> 
     await page.set_content("<div>hello</div>")
     with pytest.raises(RuntimeError, match="pytest-playwright"):
         await expect.soft(page.locator("div")).to_have_text("nope", timeout=500)
+
+
+async def test_assertions_should_include_aria_snapshot_in_separate_section(
+    page: Page,
+) -> None:
+    await page.set_content(
+        """
+        <div id="hidden" style="display: none"><span>secret</span></div>
+        <main><h1>Page Heading</h1></main>
+        """
+    )
+    with pytest.raises(AssertionError) as excinfo:
+        await expect(page.locator("#hidden")).to_be_visible(timeout=500)
+    message = str(excinfo.value)
+    assert "Aria snapshot:" in message
+    # The aria snapshot lives in its own section, not in the "Actual value" line.
+    assert "Actual value: hidden" in message
+    actual_line = message.split("\n")[1]
+    assert 'heading "Page Heading"' not in actual_line
+    assert message.index('heading "Page Heading"') > message.index("Aria snapshot:")

--- a/tests/sync/test_assertions.py
+++ b/tests/sync/test_assertions.py
@@ -1089,3 +1089,23 @@ def test_soft_inside_scope_collects_failures(page: Page, server: Server) -> None
 
     assert len(errors) == 3
     assert all(isinstance(e, AssertionError) for e in errors)
+
+
+def test_assertions_should_include_aria_snapshot_in_separate_section(
+    page: Page,
+) -> None:
+    page.set_content(
+        """
+        <div id="hidden" style="display: none"><span>secret</span></div>
+        <main><h1>Page Heading</h1></main>
+        """
+    )
+    with pytest.raises(AssertionError) as excinfo:
+        expect(page.locator("#hidden")).to_be_visible(timeout=500)
+    message = str(excinfo.value)
+    assert "Aria snapshot:" in message
+    # The aria snapshot lives in its own section, not in the "Actual value" line.
+    assert "Actual value: hidden" in message
+    actual_line = message.split("\n")[1]
+    assert 'heading "Page Heading"' not in actual_line
+    assert message.index('heading "Page Heading"') > message.index("Aria snapshot:")


### PR DESCRIPTION
## Summary
- The 1.60.0 roll routed the new `received.ariaSnapshot` into the `Actual value:` line, dumping the whole-page aria snapshot there.
- Upstream renders it as a separate `Aria snapshot:` section; this aligns Python with that behavior so `Actual value:` shows only the received value.

Fixes https://github.com/microsoft/playwright-python/issues/3088