### PR TITLE
fix: handle missing content-type header in Request.post_data_json

### DIFF
--- a/playwright/_impl/_network.py
+++ b/playwright/_impl/_network.py
@@ -220,8 +220,8 @@ class Request(ChannelOwner):
         post_data = self.post_data
         if not post_data:
             return None
-        content_type = self.headers["content-type"]
-        if "application/x-www-form-urlencoded" in content_type:
+        content_type = self.headers.get("content-type")
+        if content_type and "application/x-www-form-urlencoded" in content_type:
             return dict(parse.parse_qsl(post_data))
         try:
             return json.loads(post_data)

--- a/tests/async/test_network.py
+++ b/tests/async/test_network.py
@@ -468,6 +468,46 @@ async def test_should_throw_on_invalid_json_in_post_data(
     assert "POST data is not a valid JSON object: <not a json>" in str(exc_info.value)
 
 
+async def test_should_return_post_data_for_put_requests(
+    page: Page, server: Server
+) -> None:
+    await page.goto(server.EMPTY_PAGE)
+    async with page.expect_request("**/*") as request_info:
+        await page.evaluate(
+            """({url}) => {
+            const request = new Request(url, {
+                method: 'PUT',
+                body: JSON.stringify({ value: 42 }),
+            });
+            return fetch(request);
+        }""",
+            {"url": server.PREFIX + "/title.html"},
+        )
+    request = await request_info.value
+    assert request.post_data_json == {"value": 42}
+
+
+async def test_should_parse_the_json_post_data_when_content_type_header_is_missing(
+    page: Page, server: Server
+) -> None:
+    await page.goto(server.EMPTY_PAGE)
+    async with page.expect_request("**/*") as request_info:
+        await page.evaluate(
+            """({url}) => {
+            const request = new Request(url, {
+                method: 'POST',
+                body: JSON.stringify({ value: 42 }),
+            });
+            request.headers.delete('content-type');
+            return fetch(request);
+        }""",
+            {"url": server.PREFIX + "/title.html"},
+        )
+    request = await request_info.value
+    assert "content-type" not in request.headers
+    assert request.post_data_json == {"value": 42}
+
+
 async def test_should_work_with_binary_post_data(page: Page, server: Server) -> None:
     await page.goto(server.EMPTY_PAGE)
     server.set_route("/post", lambda req: req.finish())


### PR DESCRIPTION
## Problem

`Request.post_data_json` indexed `self.headers["content-type"]`, which raises `KeyError` when a POST request has a body but no `content-type` header:

```
KeyError: 'content-type'
```

The documented behavior is to parse form-urlencoded bodies when that content-type is set, and otherwise fall back to JSON parsing. A missing header should take the JSON fallback path. This matches the upstream JS implementation, where `this.headers()['content-type']` is `undefined`-safe before the form-urlencoded branch.

Closes #3093

## Fix

In `playwright/_impl/_network.py`, read the header defensively and guard the branch:

```python
content_type = self.headers.get("content-type")
if content_type and "application/x-www-form-urlencoded" in content_type:
    return dict(parse.parse_qsl(post_data))
```

## Tests

Added to `tests/async/test_network.py`:

- `test_should_parse_the_json_post_data_when_content_type_header_is_missing` — the regression guard. Uses `request.headers.delete('content-type')` to produce a request whose `content-type` key is genuinely absent (unlike setting it to `''`, which keeps an empty-valued key), then asserts `post_data_json` returns the parsed JSON. Verified to fail with `KeyError` on the unpatched code.
- `test_should_return_post_data_for_put_requests` — mirrors the upstream `network-post-data` suite for parity.

All existing network tests continue to pass.

## Notes

- No public API surface change, so no codegen / `api.json` updates are needed.
