### PR TITLE
fix: tolerate non-utf8 request post data

### DIFF
--- a/playwright/_impl/_network.py
+++ b/playwright/_impl/_network.py
@@ -209,10 +209,12 @@ class Request(ChannelOwner):
     def post_data(self) -> Optional[str]:
         data = self._fallback_overrides.post_data_buffer
         if data:
-            return data.decode()
+            return data.decode("utf-8", errors="replace")
         base64_post_data = self._initializer.get("postData")
         if base64_post_data is not None:
-            return base64.b64decode(base64_post_data).decode()
+            return base64.b64decode(base64_post_data).decode(
+                "utf-8", errors="replace"
+            )
         return None
 
     @property

--- a/tests/async/test_network.py
+++ b/tests/async/test_network.py
@@ -485,6 +485,23 @@ async def test_should_work_with_binary_post_data(page: Page, server: Server) -> 
         assert buffer[i] == i
 
 
+async def test_should_not_throw_for_non_utf8_post_data(
+    page: Page, server: Server
+) -> None:
+    await page.goto(server.EMPTY_PAGE)
+    server.set_route("/post", lambda req: req.finish())
+    requests = []
+    page.on("request", lambda r: requests.append(r))
+    await page.evaluate(
+        """async () => {
+        await fetch('./post', { method: 'POST', body: new Uint8Array([255, 254, 65]) })
+    }"""
+    )
+    assert len(requests) == 1
+    assert requests[0].post_data == "\ufffd\ufffdA"
+    assert requests[0].post_data_buffer == b"\xff\xfeA"
+
+
 async def test_should_work_with_binary_post_data_and_interception(
     page: Page, server: Server
 ) -> None:


### PR DESCRIPTION
## Summary
- Make `Request.post_data` tolerate invalid UTF-8 bytes by decoding with replacement.
- Keep `Request.post_data_buffer` as the exact binary-safe API.
- Add a regression test for a non-UTF8 POST body.

Closes #3098

## Tests
- `python -m py_compile playwright\_impl\_network.py tests\async\test_network.py`
- source-level repro confirming `post_data` returns replacement text and `post_data_buffer` preserves `b"\xff\xfeA"`

Full browser tests were not run locally because this checkout does not contain the generated Playwright driver payload.