### PR TITLE
feat(docker): add Ubuntu 26.04 (Resolute Raccoon) image

### DIFF
--- a/.github/workflows/test_docker.yml
+++ b/.github/workflows/test_docker.yml
@@ -26,6 +26,7 @@ jobs:
         docker-image-variant:
           - jammy
           - noble
+          - resolute
         runs-on:
           - ubuntu-24.04
           - ubuntu-24.04-arm

--- a/utils/docker/Dockerfile.resolute
+++ b/utils/docker/Dockerfile.resolute
@@ -24,7 +24,7 @@ RUN apt-get update && \
     # clean apt cache
     rm -rf /var/lib/apt/lists/* && \
     # Create the pwuser
-    adduser pwuser
+    useradd -m -s /bin/bash pwuser
 
 # === BAKE BROWSERS INTO IMAGE ===
 

--- a/utils/docker/Dockerfile.resolute
+++ b/utils/docker/Dockerfile.resolute
@@ -1,0 +1,55 @@
+FROM ubuntu:resolute
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG TZ=America/Los_Angeles
+ARG DOCKER_IMAGE_NAME_TEMPLATE="mcr.microsoft.com/playwright/python:v%version%-resolute"
+
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+# === INSTALL Python ===
+
+RUN apt-get update && \
+    # Install Python
+    apt-get install -y python3 curl && \
+    # Align with upstream Python image and don't be externally managed:
+    # https://github.com/docker-library/python/issues/948
+    rm -f /usr/lib/python3.*/EXTERNALLY-MANAGED && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
+    curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+    python get-pip.py && \
+    rm get-pip.py && \
+    # Feature-parity with node.js base images.
+    apt-get install -y --no-install-recommends git openssh-client gpg && \
+    # clean apt cache
+    rm -rf /var/lib/apt/lists/* && \
+    # Create the pwuser
+    adduser pwuser
+
+# === BAKE BROWSERS INTO IMAGE ===
+
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+# 1. Add tip-of-tree Playwright package to install its browsers.
+#    The package should be built beforehand from tip-of-tree Playwright.
+COPY ./dist/*-manylinux*.whl /tmp/
+
+# 2. Bake in browsers & deps.
+#    Browsers will be downloaded in `/ms-playwright`.
+#    Note: make sure to set 777 to the registry so that any user can access
+#    registry.
+RUN mkdir /ms-playwright && \
+    mkdir /ms-playwright-agent && \
+    cd /ms-playwright-agent && \
+    pip install virtualenv && \
+    virtualenv venv && \
+    . venv/bin/activate && \
+    # if its amd64 then install the manylinux1_x86_64 pip package
+    if [ "$(uname -m)" = "x86_64" ]; then pip install /tmp/*manylinux1_x86_64*.whl; fi && \
+    # if its arm64 then install the manylinux1_aarch64 pip package
+    if [ "$(uname -m)" = "aarch64" ]; then pip install /tmp/*manylinux_2_17_aarch64*.whl; fi && \
+    playwright mark-docker-image "${DOCKER_IMAGE_NAME_TEMPLATE}" && \
+    playwright install --with-deps && rm -rf /var/lib/apt/lists/* && \
+    rm /tmp/*.whl && \
+    rm -rf /ms-playwright-agent && \
+    chmod -R 777 /ms-playwright

--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -3,7 +3,7 @@ set -e
 set +x
 
 if [[ ($1 == '--help') || ($1 == '-h') || ($1 == '') || ($2 == '') ]]; then
-  echo "usage: $(basename $0) {--arm64,--amd64} {jammy,noble} playwright:localbuild-noble"
+  echo "usage: $(basename $0) {--arm64,--amd64} {jammy,noble,resolute} playwright:localbuild-noble"
   echo
   echo "Build Playwright docker image and tag it as 'playwright:localbuild-noble'."
   echo "Once image is built, you can run it with"

--- a/utils/docker/publish_docker.sh
+++ b/utils/docker/publish_docker.sh
@@ -32,6 +32,11 @@ NOBLE_TAGS=(
   "v${PW_VERSION}-noble"
 )
 
+# Ubuntu 26.04
+RESOLUTE_TAGS=(
+  "v${PW_VERSION}-resolute"
+)
+
 tag_and_push() {
   local source="$1"
   local target="$2"
@@ -68,8 +73,10 @@ publish_docker_images_with_arch_suffix() {
     TAGS=("${JAMMY_TAGS[@]}")
   elif [[ "$FLAVOR" == "noble" ]]; then
     TAGS=("${NOBLE_TAGS[@]}")
+  elif [[ "$FLAVOR" == "resolute" ]]; then
+    TAGS=("${RESOLUTE_TAGS[@]}")
   else
-    echo "ERROR: unknown flavor - $FLAVOR. Must be either 'jammy', or 'noble'"
+    echo "ERROR: unknown flavor - $FLAVOR. Must be either 'jammy', 'noble', or 'resolute'"
     exit 1
   fi
   local ARCH="$2"
@@ -94,8 +101,10 @@ publish_docker_manifest () {
     TAGS=("${JAMMY_TAGS[@]}")
   elif [[ "$FLAVOR" == "noble" ]]; then
     TAGS=("${NOBLE_TAGS[@]}")
+  elif [[ "$FLAVOR" == "resolute" ]]; then
+    TAGS=("${RESOLUTE_TAGS[@]}")
   else
-    echo "ERROR: unknown flavor - $FLAVOR. Must be either 'jammy', or 'noble'"
+    echo "ERROR: unknown flavor - $FLAVOR. Must be either 'jammy', 'noble', or 'resolute'"
     exit 1
   fi
 
@@ -122,3 +131,7 @@ publish_docker_manifest jammy amd64 arm64
 publish_docker_images_with_arch_suffix noble amd64
 publish_docker_images_with_arch_suffix noble arm64
 publish_docker_manifest noble amd64 arm64
+
+publish_docker_images_with_arch_suffix resolute amd64
+publish_docker_images_with_arch_suffix resolute arm64
+publish_docker_manifest resolute amd64 arm64


### PR DESCRIPTION
## Summary
- Add `Dockerfile.resolute` based on Ubuntu 26.04 LTS (Resolute Raccoon).
- Wire the `resolute` flavor through `build.sh` and `publish_docker.sh` (new `v<version>-resolute` tag).
- Add `resolute` to the docker test matrix.

The `EXTERNALLY-MANAGED` removal is made Python-version-agnostic since 26.04 ships a newer Python than noble.