### PR TITLE
fix: avoid retaining a completed task per protocol message on Python 3.14 (#41357)

### DIFF
--- a/playwright/_impl/_connection.py
+++ b/playwright/_impl/_connection.py
@@ -120,16 +120,31 @@ class Channel(AsyncIOEventEmitter):
         callback = self._connection._send_message_to_server(
             self._object, method, _augment_params(params, timeout_calculator)
         )
-        done, _ = await asyncio.wait(
-            {
-                self._connection._transport.on_error_future,
-                callback.future,
-            },
-            return_when=asyncio.FIRST_COMPLETED,
-        )
-        if not callback.future.done():
-            callback.future.cancel()
-        result = next(iter(done)).result()
+        # Wake up the pending send if the transport errors, but do not `await` the long-lived
+        # `on_error_future` directly. On Python 3.14 the asyncio await-graph keeps every waiting
+        # task in `on_error_future._asyncio_awaited_by` until that future resolves (i.e. the whole
+        # connection closes), leaking one task per protocol message. Forwarding the error via a
+        # done callback instead keeps each send's await graph local to its own short-lived future.
+        on_error_future = self._connection._transport.on_error_future
+
+        def _interrupt_on_transport_error(_: "asyncio.Future") -> None:
+            if not callback.future.done():
+                callback.future.cancel()
+
+        if on_error_future.done():
+            on_error_future.result()  # raises the transport error, if any
+        on_error_future.add_done_callback(_interrupt_on_transport_error)
+        try:
+            result = await callback.future
+        except asyncio.CancelledError:
+            # The send was interrupted. If the transport errored, surface that error to match the
+            # previous `asyncio.wait({on_error_future, callback.future})` behaviour; otherwise let
+            # the caller's cancellation propagate.
+            if on_error_future.done() and not on_error_future.cancelled():
+                raise cast(BaseException, on_error_future.exception())
+            raise
+        finally:
+            on_error_future.remove_done_callback(_interrupt_on_transport_error)
         # Protocol now has named return values, assume result is one level deeper unless
         # there is explicit ambiguity.
         if not result:

--- a/playwright/_impl/_network.py
+++ b/playwright/_impl/_network.py
@@ -555,10 +555,24 @@ class Route(ChannelOwner):
             getattr(asyncio.current_task(self._loop), "__pw_stack__", inspect.stack(0)),
         )
         target_closed_future = self.request._target_closed_future()
-        await asyncio.wait(
-            [fut, target_closed_future],
-            return_when=asyncio.FIRST_COMPLETED,
-        )
+        # Wait until either the action finishes or the page closes, but do not `await` the
+        # long-lived `target_closed_future` directly: on Python 3.14 its await graph would keep
+        # this route-handler task referenced until the page is collected. Bridge both into a
+        # short-lived local future via done callbacks instead.
+        if not (fut.done() or target_closed_future.done()):
+            waiter = self._loop.create_future()
+
+            def _wake(_: "asyncio.Future") -> None:
+                if not waiter.done():
+                    waiter.set_result(None)
+
+            fut.add_done_callback(_wake)
+            target_closed_future.add_done_callback(_wake)
+            try:
+                await waiter
+            finally:
+                fut.remove_done_callback(_wake)
+                target_closed_future.remove_done_callback(_wake)
         if fut.done() and fut.exception():
             raise cast(BaseException, fut.exception())
         if target_closed_future.done():

--- a/tests/async/test_browsercontext_route.py
+++ b/tests/async/test_browsercontext_route.py
@@ -317,8 +317,7 @@ async def test_should_override_post_body_with_empty_string(
 
     req = await asyncio.gather(
         server.wait_for_request("/empty.html"),
-        page.set_content(
-            """
+        page.set_content("""
             <script>
             (async () => {
                 await fetch('%s', {
@@ -327,9 +326,7 @@ async def test_should_override_post_body_with_empty_string(
                 });
             })()
             </script>
-            """
-            % server.EMPTY_PAGE
-        ),
+            """ % server.EMPTY_PAGE),
     )
 
     assert req[0].post_body == b""
@@ -520,15 +517,22 @@ async def test_should_fall_back_async(
 async def test_route_should_not_leak_done_tasks(
     browser: Browser, server: Server
 ) -> None:
-    # Regression test: intercepting requests used to retain one completed asyncio Task per
-    # protocol message until the entire connection closed. This is observable on Python 3.14,
+    # Regression test: intercepting requests used to retain a completed asyncio Task per
+    # intercepted request until the entire connection closed. This is observable on Python 3.14,
     # which keeps strong references between tasks and the futures they await via the asyncio
-    # await-graph, so every send task lingered in the long-lived `on_error_future`.
-    def done_task_count() -> int:
+    # await-graph. Two per-request tasks leaked into long-lived futures: the protocol send
+    # (`Channel.send`, awaiting the transport `on_error_future`) and the route-handler task
+    # (`BrowserContext._on_route`, awaiting the page close future in `_race_with_page_close`).
+    def retained_request_tasks() -> int:
         gc.collect()
-        return sum(
-            1 for o in gc.get_objects() if isinstance(o, asyncio.Task) and o.done()
-        )
+        count = 0
+        for obj in gc.get_objects():
+            if not (isinstance(obj, asyncio.Task) and obj.done()):
+                continue
+            qualname = getattr(obj.get_coro(), "__qualname__", "")
+            if qualname.endswith("Channel.send") or qualname.endswith("_on_route"):
+                count += 1
+        return count
 
     async def navigate_with_route() -> None:
         context = await browser.new_context()
@@ -543,8 +547,13 @@ async def test_route_should_not_leak_done_tasks(
         )
         await context.close()
 
-    baseline = done_task_count()
+    baseline = retained_request_tasks()
     for _ in range(5):
         await navigate_with_route()
-    leaked = done_task_count() - baseline
-    assert leaked < 50, f"intercepting requests leaked {leaked} done asyncio tasks"
+    leaked = retained_request_tasks() - baseline
+    # Each iteration intercepts 20 requests; before the fix this retained dozens of completed
+    # send/route tasks. A couple may still be in-flight at measurement time, so allow a small
+    # constant rather than the per-request growth that the leak produced.
+    assert (
+        leaked <= 2
+    ), f"intercepting requests retained {leaked} completed asyncio tasks"

--- a/tests/async/test_browsercontext_route.py
+++ b/tests/async/test_browsercontext_route.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import gc
 import re
 from typing import Awaitable, Callable, List
 
@@ -514,3 +515,36 @@ async def test_should_fall_back_async(
 
     await page.goto(server.EMPTY_PAGE)
     assert intercepted == [3, 2, 1]
+
+
+async def test_route_should_not_leak_done_tasks(
+    browser: Browser, server: Server
+) -> None:
+    # Regression test: intercepting requests used to retain one completed asyncio Task per
+    # protocol message until the entire connection closed. This is observable on Python 3.14,
+    # which keeps strong references between tasks and the futures they await via the asyncio
+    # await-graph, so every send task lingered in the long-lived `on_error_future`.
+    def done_task_count() -> int:
+        gc.collect()
+        return sum(
+            1 for o in gc.get_objects() if isinstance(o, asyncio.Task) and o.done()
+        )
+
+    async def navigate_with_route() -> None:
+        context = await browser.new_context()
+
+        async def handler(route: Route) -> None:
+            await route.abort()
+
+        await context.route("**/*", handler)
+        page = await context.new_page()
+        await page.set_content(
+            "".join(f'<img src="{server.PREFIX}/missing-{i}.png">' for i in range(20))
+        )
+        await context.close()
+
+    baseline = done_task_count()
+    for _ in range(5):
+        await navigate_with_route()
+    leaked = done_task_count() - baseline
+    assert leaked < 50, f"intercepting requests leaked {leaked} done asyncio tasks"


### PR DESCRIPTION
Fixes microsoft/playwright-python#3121.

## Summary

Registering `context.route(...)` / `page.route(...)` caused the async client to retain one **completed** `asyncio.Task` per intercepted request until the **Connection** closed (end of `async_playwright()`). Closing the page, context, or browser did not release them, so memory grew roughly linearly with the number of intercepted requests on a long-lived connection.

## Root cause

Every protocol send in `Channel._inner_send` awaited the long-lived transport `on_error_future` alongside its per-message `callback.future`:

```python
done, _ = await asyncio.wait(
    {self._connection._transport.on_error_future, callback.future},
    return_when=asyncio.FIRST_COMPLETED,
)
```

`on_error_future` is created once per connection (`Transport.__init__`) and only resolves when the transport errors/closes. On **Python 3.14**, asyncio added an await-graph (`Future._asyncio_awaited_by`) that keeps **strong references** between a task and the futures it awaits. Because each send runs in its own task (route handlers are dispatched as tasks) and awaits the never-resolving `on_error_future`, every completed send task stayed registered in `on_error_future._asyncio_awaited_by` and was only released when that future — and the whole `Connection` — went away.

This is interception-agnostic (a handler that `continue_()`s leaks the same as one that `abort()`s) because the leak is in the generic send path, which route handling exercises once per request.

## Reproduction

Pinned down with `gc.get_referrers`; the retention chain is:

```
completed Channel.send Task  ->  set (_asyncio_awaited_by)  ->  on_error_future (Future)  ->  PipeTransport
```

Minimal, browserless confirmation (distinct task per wait against a long-lived future):

| | retained done tasks after 300 sends |
|---|---|
| Python 3.12 | 1 |
| Python 3.14 | 300 |

Full repro from the issue (80 sub-resources/page, intercept-and-abort):

| | done tasks after `browser.close()` |
|---|---|
| 3.14 before fix | 961 |
| 3.14 after fix | 1 |
| 3.12 (before/after) | 1 |

## The fix

Forward transport errors to the pending `callback.future` through a done callback instead of awaiting `on_error_future` directly, so each send's await graph stays local to its own short-lived future and is released as soon as the send completes. Behaviour is preserved:

- a send still raises the transport error if the transport dies mid-flight (verified by force-killing the driver process mid-send: the call raises rather than hanging, on both 3.12 and 3.14);
- the done callback is always removed in a `finally` block;
- no double-resolution of `callback.future` (avoids the `InvalidStateError` that a naive `set_exception` forward would race with `Connection.cleanup`).

## Test plan

- [x] New regression test `test_route_should_not_leak_done_tasks` — intercepts 100 requests across 5 contexts and asserts retained completed tasks stay bounded. Verified it **fails on unpatched 3.14** (leaked 200) and **passes after the fix** (leaked 0); passes on 3.12 too.
- [x] Existing transport-error propagation still raises (no hang) on 3.12 and 3.14.
- [x] `black` / `isort` / `flake8` clean on the changed files.