### PR TITLE
fix(sync): clear __pw_stack__ on task completion to prevent memory le…

### DIFF
--- a/playwright/_impl/_sync_base.py
+++ b/playwright/_impl/_sync_base.py
@@ -108,7 +108,12 @@ class SyncBase(ImplWrapper):
         setattr(task, "__pw_stack__", _capture_stack_trace())
         setattr(task, "__pw_stack_trace__", traceback.extract_stack(limit=10))
 
-        task.add_done_callback(lambda _: g_self.switch())
+        def _on_done(_: Any) -> None:
+            if hasattr(task, "__pw_stack__"):
+                delattr(task, "__pw_stack__")
+            g_self.switch()
+
+        task.add_done_callback(_on_done)
         while not task.done():
             self._dispatcher_fiber.switch()
         asyncio._set_running_loop(self._loop)


### PR DESCRIPTION
### Summary of Changes
In `playwright/_impl/_sync_base.py`, `inspect.stack(0)` is attached to `task.__pw_stack__`. Because live `FrameInfo` objects pin all caller local variables in memory, retaining the task causes a memory leak.

This PR updates `task.add_done_callback` to delete `task.__pw_stack__` upon task completion, ensuring frame objects and local variables are garbage collected immediately.

Fixes #3157