### PR TITLE
fix(network): prevent UnicodeDecodeError in Request.post_data for non-UTF8 bodies (fixes #3098)

### DIFF
--- a/playwright/_impl/_network.py
+++ b/playwright/_impl/_network.py
@@ -209,10 +209,10 @@ class Request(ChannelOwner):
     def post_data(self) -> Optional[str]:
         data = self._fallback_overrides.post_data_buffer
         if data:
-            return data.decode()
+            return data.decode(errors="replace")
         base64_post_data = self._initializer.get("postData")
         if base64_post_data is not None:
-            return base64.b64decode(base64_post_data).decode()
+            return base64.b64decode(base64_post_data).decode(errors="replace")
         return None
 
     @property


### PR DESCRIPTION
### Summary of Changes
In `playwright/_impl/_network.py`, `Request.post_data` called `.decode()` without specifying error handling, which raises `UnicodeDecodeError` when request bodies contain non-UTF-8 payload bytes (e.g. binary data, Shift-JIS, or compressed bytes).

This PR updates `.decode()` calls to use `errors="replace"` to decode safely without raising exceptions.

Fixes #3098