### PR TITLE
fix(asyncio): do not hang when async_playwright() is cancelled while connecting

### DIFF
--- a/playwright/_impl/_connection.py
+++ b/playwright/_impl/_connection.py
@@ -356,10 +356,8 @@ class Connection(EventEmitter):
         try:
             await self._transport.run()
         except asyncio.CancelledError:
-            # This task is cancelled by asyncio.run() at loop shutdown. Release
-            # any tasks waiting on protocol replies that will never arrive,
-            # otherwise their cancellation is absorbed by Channel._abort()
-            # waiting for the reply and the loop never finishes closing.
+            # Cancelled at loop shutdown - release tasks waiting on replies
+            # that will never arrive.
             if not self._closed_error:
                 self.cleanup()
             raise
@@ -481,10 +479,7 @@ class Connection(EventEmitter):
                 return_when=asyncio.FIRST_COMPLETED,
             )
         finally:
-            # Retrieve exceptions in a finally so that this happens even if the
-            # wait above is interrupted by another cancellation (e.g. when the
-            # loop is being shut down), avoiding 'Future exception was never
-            # retrieved' errors.
+            # Retrieve exceptions even if the wait itself was cancelled.
             if not callback.future.done():
                 callback.future.cancel()
             for future in (callback.future, self._transport.on_error_future):

--- a/playwright/_impl/_connection.py
+++ b/playwright/_impl/_connection.py
@@ -461,16 +461,17 @@ class Connection(EventEmitter):
     async def _abort(
         self, object: ChannelOwner, callback: ProtocolCallback, reason: str
     ) -> None:
-        try:
-            self._transport.send(
-                {
-                    "guid": object._guid,
-                    "method": "__abort__",
-                    "params": {"id": callback.id, "reason": reason},
-                }
-            )
-        except (Error, OSError):
-            pass
+        if not self._closed_error:
+            try:
+                self._transport.send(
+                    {
+                        "guid": object._guid,
+                        "method": "__abort__",
+                        "params": {"id": callback.id, "reason": reason},
+                    }
+                )
+            except (Error, OSError):
+                pass
         try:
             await asyncio.wait(
                 {
@@ -486,11 +487,9 @@ class Connection(EventEmitter):
             # retrieved' errors.
             if not callback.future.done():
                 callback.future.cancel()
-            elif not callback.future.cancelled():
-                callback.future.exception()
-            error_future = self._transport.on_error_future
-            if error_future.done() and not error_future.cancelled():
-                error_future.exception()
+            for future in (callback.future, self._transport.on_error_future):
+                if future.done() and not future.cancelled():
+                    future.exception()
 
     def dispatch(self, msg: ParsedMessagePayload) -> None:
         if self._closed_error:

--- a/playwright/_impl/_connection.py
+++ b/playwright/_impl/_connection.py
@@ -353,7 +353,16 @@ class Connection(EventEmitter):
 
         await self._transport.connect()
         self._init_task = self._loop.create_task(init())
-        await self._transport.run()
+        try:
+            await self._transport.run()
+        except asyncio.CancelledError:
+            # This task is cancelled by asyncio.run() at loop shutdown. Release
+            # any tasks waiting on protocol replies that will never arrive,
+            # otherwise their cancellation is absorbed by Channel._abort()
+            # waiting for the reply and the loop never finishes closing.
+            if not self._closed_error:
+                self.cleanup()
+            raise
 
     def stop_sync(self) -> None:
         self._transport.request_stop()
@@ -463,7 +472,7 @@ class Connection(EventEmitter):
         except (Error, OSError):
             pass
         try:
-            done, _ = await asyncio.wait(
+            await asyncio.wait(
                 {
                     self._transport.on_error_future,
                     callback.future,
@@ -471,11 +480,17 @@ class Connection(EventEmitter):
                 return_when=asyncio.FIRST_COMPLETED,
             )
         finally:
+            # Retrieve exceptions in a finally so that this happens even if the
+            # wait above is interrupted by another cancellation (e.g. when the
+            # loop is being shut down), avoiding 'Future exception was never
+            # retrieved' errors.
             if not callback.future.done():
                 callback.future.cancel()
-        for future in done:
-            if not future.cancelled():
-                future.exception()
+            elif not callback.future.cancelled():
+                callback.future.exception()
+            error_future = self._transport.on_error_future
+            if error_future.done() and not error_future.cancelled():
+                error_future.exception()
 
     def dispatch(self, msg: ParsedMessagePayload) -> None:
         if self._closed_error:

--- a/playwright/_impl/_json_pipe.py
+++ b/playwright/_impl/_json_pipe.py
@@ -42,12 +42,7 @@ class JsonPipeTransport(AsyncIOEventEmitter, Transport):
         self.on_error_future.cancel()
         self._stopped_future.cancel()
 
-    async def wait_until_stopped(self) -> None:
-        await self._stopped_future
-
     async def connect(self) -> None:
-        self._stopped_future: asyncio.Future = asyncio.Future()
-
         def handle_message(message: Dict) -> None:
             if self._stop_requested:
                 return

--- a/playwright/_impl/_transport.py
+++ b/playwright/_impl/_transport.py
@@ -92,18 +92,20 @@ class PipeTransport(Transport):
     def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
         super().__init__(loop)
         self._stopped = False
+        self._output: Optional[asyncio.StreamWriter] = None
+        self._stopped_future: asyncio.Future = loop.create_future()
 
     def request_stop(self) -> None:
-        assert self._output
         self._stopped = True
-        self._output.close()
+        # The stop can be requested while connect() is still spawning the
+        # driver; connect() will close the pipe once it is available.
+        if self._output:
+            self._output.close()
 
     async def wait_until_stopped(self) -> None:
         await self._stopped_future
 
     async def connect(self) -> None:
-        self._stopped_future: asyncio.Future = asyncio.Future()
-
         try:
             # For pyinstaller and Nuitka
             env = get_driver_env()
@@ -129,10 +131,14 @@ class PipeTransport(Transport):
                 startupinfo=startupinfo,
             )
         except Exception as exc:
+            if not self._stopped_future.done():
+                self._stopped_future.set_result(None)
             self.on_error_future.set_exception(exc)
             raise exc
 
         self._output = self._proc.stdin
+        if self._stopped and self._output:
+            self._output.close()
 
     async def run(self) -> None:
         assert self._proc.stdout

--- a/playwright/_impl/_transport.py
+++ b/playwright/_impl/_transport.py
@@ -96,8 +96,7 @@ class PipeTransport(Transport):
 
     def request_stop(self) -> None:
         self._stopped = True
-        # The stop can be requested while connect() is still spawning the
-        # driver; connect() will close the pipe once it is available.
+        # May be called before connect() has spawned the driver.
         if self._output:
             self._output.close()
 

--- a/playwright/_impl/_transport.py
+++ b/playwright/_impl/_transport.py
@@ -50,6 +50,7 @@ class Transport(ABC):
         self._loop = loop
         self.on_message: Callable[[ParsedMessagePayload], None] = lambda _: None
         self.on_error_future: asyncio.Future = loop.create_future()
+        self._stopped_future: asyncio.Future = loop.create_future()
 
     @abstractmethod
     def request_stop(self) -> None:
@@ -58,9 +59,8 @@ class Transport(ABC):
     def dispose(self) -> None:
         pass
 
-    @abstractmethod
     async def wait_until_stopped(self) -> None:
-        pass
+        await self._stopped_future
 
     @abstractmethod
     async def connect(self) -> None:
@@ -93,7 +93,6 @@ class PipeTransport(Transport):
         super().__init__(loop)
         self._stopped = False
         self._output: Optional[asyncio.StreamWriter] = None
-        self._stopped_future: asyncio.Future = loop.create_future()
 
     def request_stop(self) -> None:
         self._stopped = True
@@ -101,9 +100,6 @@ class PipeTransport(Transport):
         # driver; connect() will close the pipe once it is available.
         if self._output:
             self._output.close()
-
-    async def wait_until_stopped(self) -> None:
-        await self._stopped_future
 
     async def connect(self) -> None:
         try:
@@ -131,14 +127,13 @@ class PipeTransport(Transport):
                 startupinfo=startupinfo,
             )
         except Exception as exc:
-            if not self._stopped_future.done():
-                self._stopped_future.set_result(None)
+            self._stopped_future.set_result(None)
             self.on_error_future.set_exception(exc)
             raise exc
 
         self._output = self._proc.stdin
-        if self._stopped and self._output:
-            self._output.close()
+        if self._stopped:
+            self.request_stop()
 
     async def run(self) -> None:
         assert self._proc.stdout

--- a/playwright/async_api/_context_manager.py
+++ b/playwright/async_api/_context_manager.py
@@ -37,10 +37,18 @@ class PlaywrightContextManager:
         loop.create_task(self._connection.run())
         playwright_future = self._connection.playwright_future
 
-        done, _ = await asyncio.wait(
-            {self._connection._transport.on_error_future, playwright_future},
-            return_when=asyncio.FIRST_COMPLETED,
-        )
+        try:
+            done, _ = await asyncio.wait(
+                {self._connection._transport.on_error_future, playwright_future},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        except asyncio.CancelledError:
+            # Cancelled while connecting - stop the driver process and the
+            # background tasks, otherwise they keep running with no owner.
+            if not playwright_future.done():
+                playwright_future.cancel()
+            await self._connection.stop_async()
+            raise
         if not playwright_future.done():
             playwright_future.cancel()
         playwright = AsyncPlaywright(next(iter(done)).result())

--- a/playwright/async_api/_context_manager.py
+++ b/playwright/async_api/_context_manager.py
@@ -42,16 +42,15 @@ class PlaywrightContextManager:
                 {self._connection._transport.on_error_future, playwright_future},
                 return_when=asyncio.FIRST_COMPLETED,
             )
-        except asyncio.CancelledError:
-            # Cancelled while connecting - stop the driver process and the
-            # background tasks, otherwise they keep running with no owner.
             if not playwright_future.done():
                 playwright_future.cancel()
-            await self._connection.stop_async()
-            raise
-        if not playwright_future.done():
+            playwright = AsyncPlaywright(next(iter(done)).result())
+        except BaseException:
+            # Startup failed or was cancelled - stop the driver process and the
+            # background tasks, otherwise they keep running with no owner.
             playwright_future.cancel()
-        playwright = AsyncPlaywright(next(iter(done)).result())
+            await self.__aexit__()
+            raise
         playwright.stop = self.__aexit__  # type: ignore
         return playwright
 

--- a/playwright/async_api/_context_manager.py
+++ b/playwright/async_api/_context_manager.py
@@ -46,8 +46,6 @@ class PlaywrightContextManager:
                 playwright_future.cancel()
             playwright = AsyncPlaywright(next(iter(done)).result())
         except BaseException:
-            # Startup failed or was cancelled - stop the driver process and the
-            # background tasks, otherwise they keep running with no owner.
             playwright_future.cancel()
             await self.__aexit__()
             raise

--- a/tests/async/test_asyncio.py
+++ b/tests/async/test_asyncio.py
@@ -146,10 +146,8 @@ def test_stop_does_not_deadlock_with_asyncio_atexit(tmp_path: Path) -> None:
 
 def test_cancelled_playwright_start_does_not_hang(tmp_path: Path) -> None:
     # Regression test for https://github.com/microsoft/playwright/issues/42296.
-    # Cancelling __aenter__ used to leave the driver process and the transport
-    # tasks running; at loop shutdown the init task absorbed its cancellation
-    # in Channel._abort() waiting for a reply that could never arrive, so
-    # asyncio.run() never returned.
+    # Cancelling __aenter__ left the driver and the transport tasks running,
+    # and asyncio.run() hung at loop shutdown.
     script = tmp_path / "cancel_start.py"
     script.write_text(
         textwrap.dedent(

--- a/tests/async/test_asyncio.py
+++ b/tests/async/test_asyncio.py
@@ -174,7 +174,7 @@ def test_cancelled_playwright_start_does_not_hang(tmp_path: Path) -> None:
                     pass
 
 
-            for delay in (0.001, 0.01, 0.05, 0.1, 0.5):
+            for delay in (0.001, 0.05, 0.5):
                 asyncio.run(main(delay))
             print("DONE", flush=True)
             """

--- a/tests/async/test_asyncio.py
+++ b/tests/async/test_asyncio.py
@@ -144,6 +144,53 @@ def test_stop_does_not_deadlock_with_asyncio_atexit(tmp_path: Path) -> None:
     assert "STOPPED" in result.stdout
 
 
+def test_cancelled_playwright_start_does_not_hang(tmp_path: Path) -> None:
+    # Regression test for https://github.com/microsoft/playwright/issues/42296.
+    # Cancelling __aenter__ used to leave the driver process and the transport
+    # tasks running; at loop shutdown the init task absorbed its cancellation
+    # in Channel._abort() waiting for a reply that could never arrive, so
+    # asyncio.run() never returned.
+    script = tmp_path / "cancel_start.py"
+    script.write_text(
+        textwrap.dedent(
+            """
+            import asyncio
+
+            from playwright.async_api import async_playwright
+
+
+            async def run_playwright():
+                async with async_playwright():
+                    pass
+
+
+            async def main(delay):
+                task = asyncio.create_task(run_playwright())
+                await asyncio.sleep(delay)
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+
+
+            for delay in (0.001, 0.01, 0.05, 0.1, 0.5):
+                asyncio.run(main(delay))
+            print("DONE", flush=True)
+            """
+        )
+    )
+    result = subprocess.run(
+        [sys.executable, str(script)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "DONE" in result.stdout
+    assert "Future exception was never retrieved" not in result.stderr
+
+
 async def test_should_return_proper_api_name_on_error(page: Page) -> None:
     try:
         await page.evaluate("does_not_exist")


### PR DESCRIPTION
## Summary
- stop the connection (driver process and background tasks) when `__aenter__` fails or is cancelled, reusing `__aexit__` like the sync context manager does
- allow `PipeTransport.request_stop()` before the driver has spawned
- release pending protocol callbacks when the `Connection.run()` task is cancelled at loop shutdown, so their cancellation is not absorbed by `Channel._abort()` waiting for a reply that can never arrive
- retrieve callback exceptions in `Channel._abort()` even when its wait is interrupted by another cancellation

Fixes https://github.com/microsoft/playwright/issues/42296