### PR TITLE
fix(sync): fail fast instead of spinning at 100% CPU when the dispatcher fiber dies

### DIFF
--- a/playwright/_impl/_sync_base.py
+++ b/playwright/_impl/_sync_base.py
@@ -32,6 +32,7 @@ from typing import (
 import greenlet
 
 from playwright._impl._connection import _capture_stack_trace
+from playwright._impl._errors import TargetClosedError
 from playwright._impl._helper import Error
 from playwright._impl._impl_to_api_mapping import ImplToApiMapping, ImplWrapper
 
@@ -110,6 +111,17 @@ class SyncBase(ImplWrapper):
 
         task.add_done_callback(lambda _: g_self.switch())
         while not task.done():
+            if self._dispatcher_fiber.dead:
+                # The dispatcher fiber runs the connection's event loop; when the
+                # transport ends without going through Connection.cleanup() (e.g.
+                # the driver process dies or a remote connection drops), the fiber
+                # finishes with this task still pending. Switching to a dead
+                # greenlet returns immediately to its parent - this very loop -
+                # so without this check the thread spins at 100% CPU forever.
+                task.cancel()
+                raise TargetClosedError(
+                    "Playwright connection closed while this call was pending"
+                )
             self._dispatcher_fiber.switch()
         asyncio._set_running_loop(self._loop)
         return task.result()

--- a/tests/sync/test_sync.py
+++ b/tests/sync/test_sync.py
@@ -399,6 +399,47 @@ def test_should_not_orphan_callback_on_non_serializable_params(
     assert "Future exception was never retrieved" not in result.stderr
 
 
+@pytest.mark.only_browser("chromium")  # browser-agnostic; run once
+def test_sync_call_fails_fast_when_dispatcher_dies_mid_call(tmp_path: Path) -> None:
+    # When the driver process dies without the transport reporting an error
+    # (its stdout hits EOF on the not-self-initiated stop path), the dispatcher
+    # fiber finishes silently and Connection.cleanup() never runs, so a pending
+    # sync call's task can never complete. Switching to the dead fiber returns
+    # immediately, degenerating the _sync() waiting loop into a 100% CPU spin
+    # that raises nothing and logs nothing. The loop must detect the dead
+    # dispatcher and raise instead. Run in a subprocess: without the fix the
+    # doomed call spins forever and this test would hang, not fail.
+    script = tmp_path / "dead_dispatcher.py"
+    script.write_text(
+        textwrap.dedent(
+            """
+            import sys
+
+            from playwright.sync_api import Error, sync_playwright
+
+            p = sync_playwright().start()
+            transport = p._impl_obj._connection._transport
+            # Emulate an abrupt driver death that reports no transport error:
+            # the same shape a wedged remote connection produces in the wild.
+            transport._stopped = True
+            transport._proc.kill()
+            try:
+                p.chromium.launch()
+                sys.exit(2)  # returned normally: the driver is gone, impossible
+            except Error:
+                sys.exit(0)  # failed fast instead of spinning
+            """
+        )
+    )
+    result = subprocess.run(
+        [sys.executable, str(script)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (result.stdout, result.stderr)
+
+
 def test_click_should_accept_timedelta_for_timeout(page: Page) -> None:
     with pytest.raises(TimeoutError, match="Timeout 1ms exceeded"):
         page.click("does-not-exist", timeout=timedelta(milliseconds=1))


### PR DESCRIPTION
### The bug

When the driver connection ends **without** going through `Connection.cleanup()`, any pending or subsequent sync API call spins one CPU core at 100% forever - raising nothing and logging nothing.

We hit this in production behind `connect_over_cdp` to a remote browser: worker threads were pinned at 100% CPU for hours, and two `py-spy` dumps taken 9 minutes apart showed them stopped on the *same line* - the waiting loop in `SyncBase._sync`:

```python
while not task.done():
    self._dispatcher_fiber.switch()
```

`strace` on a stuck thread over 4 seconds: **5780 futex calls (GIL churn), zero IO syscalls** - a pure userspace busy-loop.

### Mechanism

1. The dispatcher fiber's whole body is `loop.run_until_complete(connection.run_as_sync())`, and `Connection.run()` is essentially `await self._transport.run()`.
2. On the not-self-initiated stop path, `PipeTransport.run()` swallows `IncompleteReadError` and **returns silently** when `_stopped` is set - and even when it sets `on_error_future`, nothing on this path calls `Connection.cleanup()`. `cleanup()` has exactly three call sites (`stop_sync`, `stop_async`, and the child-connection `handle_transport_close` in `_browser_type.py`); none of them covers the root transport dying.
3. So `run_until_complete` returns, the dispatcher greenlet **ends silently**, and the pending call's future is never rejected → `task.done()` is forever false.
4. Switching to a dead greenlet returns immediately to its parent - which is the very greenlet doing the waiting - so the loop degenerates into `while not task.done(): pass` with greenlet/GIL bookkeeping per iteration. 100% CPU, unkillable (Python threads can't be terminated), invisible (no exception, no log).

Any sync call can be the victim: the one in flight when the connection died, or any later call on the same instance (e.g. `context.close()` in a `finally:` block) - `create_task` on the stopped loop never executes, same spin.

### The fix

Check `self._dispatcher_fiber.dead` inside the waiting loop and raise `TargetClosedError`. A dead dispatcher can never complete the task, so raising there is always correct - there is no false-positive window.

### The test

Recreates the failure end to end through public entry points (one `_impl` touch to take the silent path, mirroring what an abrupt remote disconnect produces): start a fresh `sync_playwright()`, set `transport._stopped = True`, kill the driver process, then make one more sync call. It runs in a subprocess with a timeout because without the fix the call **hangs forever** (spinning) rather than failing:

- without fix: the subprocess never exits → `subprocess.run(timeout=30)` trips (verified locally: 3/3 parametrized runs timed out at 30s each)
- with fix: raises `TargetClosedError` promptly, exits 0 (passes in ~1s)

The test needs no browser binaries (the driver dies before any launch completes).

### Related reports

Same stuck-in-`_dispatcher_fiber.switch()` symptom without a resolution: microsoft/playwright#35928, microsoft/playwright-python#1549. The tracing 100%-CPU hang reported against 1.31 (fixed by reworking tracing itself) was another instance of this same waiting-loop failure mode; this PR addresses the mode itself.

Verified the affected code is unchanged on current `main` (and in 1.60.0 / 1.62.x releases).
