### PR TITLE
fix(evaluate): serialize and parse RegExp values

### DIFF
--- a/playwright/_impl/_js_handle.py
+++ b/playwright/_impl/_js_handle.py
@@ -16,15 +16,17 @@ import base64
 import collections.abc
 import datetime
 import math
+import re
 import struct
 import traceback
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Pattern, Union
 from urllib.parse import ParseResult, urlparse, urlunparse
 
 from playwright._impl._connection import Channel, ChannelOwner, from_channel
 from playwright._impl._errors import Error, is_target_closed_error
 from playwright._impl._map import Map
+from playwright._impl._str_utils import escape_regex_flags, parse_regex_flags
 
 if TYPE_CHECKING:  # pragma: no cover
     from playwright._impl._element_handle import ElementHandle
@@ -182,6 +184,8 @@ def serialize_value(
         return {"s": value}
     if isinstance(value, ParseResult):
         return {"u": urlunparse(value)}
+    if isinstance(value, Pattern):
+        return {"r": {"p": value.pattern, "f": escape_regex_flags(value)}}
 
     if value in visitor_info.visited:
         return dict(ref=visitor_info.visited[value])
@@ -246,6 +250,9 @@ def parse_value(value: Any, refs: Optional[Dict[int, Any]] = None) -> Any:
             error._name = value["e"]["n"]
             error._stack = value["e"]["s"]
             return error
+
+        if "r" in value:
+            return re.compile(value["r"]["p"], parse_regex_flags(value["r"]["f"]))
 
         if "a" in value:
             a: List = []

--- a/playwright/_impl/_str_utils.py
+++ b/playwright/_impl/_str_utils.py
@@ -35,6 +35,18 @@ def escape_regex_flags(pattern: Pattern) -> str:
     return flags
 
 
+def parse_regex_flags(flags: str) -> int:
+    re_flags = 0
+    if "i" in flags:
+        re_flags |= re.IGNORECASE
+    if "s" in flags:
+        re_flags |= re.DOTALL
+    if "m" in flags:
+        re_flags |= re.MULTILINE
+    # The remaining JavaScript flags (g, y, d, u, v) have no re equivalent.
+    return re_flags
+
+
 def escape_for_regex(text: str) -> str:
     return re.sub(r"[.*+?^>${}()|[\]\\]", "\\$&", text)
 

--- a/tests/async/test_page_evaluate.py
+++ b/tests/async/test_page_evaluate.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import math
+import re
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 from urllib.parse import ParseResult, urlparse
@@ -353,3 +354,34 @@ async def test_evaluate_jsonvalue_url(page: Page) -> None:
     url = urlparse("https://example.com/")
     result = await page.evaluate('() => ({ someKey: new URL("https://example.com/") })')
     assert result == {"someKey": url}
+
+
+async def test_should_evaluate_regex(page: Page) -> None:
+    out = await page.evaluate("() => ({ someKey: /foo.bar/im })")
+    assert out["someKey"] == re.compile("foo.bar", re.IGNORECASE | re.MULTILINE)
+
+
+async def test_should_roundtrip_regex(page: Page) -> None:
+    regex = re.compile("hello", re.IGNORECASE | re.MULTILINE)
+    result = await page.evaluate("regex => regex", regex)
+    assert result == regex
+
+
+async def test_should_pass_regex_as_a_working_regexp(page: Page) -> None:
+    assert await page.evaluate("re => re instanceof RegExp", re.compile("foo"))
+    assert await page.evaluate("re => re.test('a123')", re.compile(r"a\d+"))
+    assert await page.evaluate("re => re.source", re.compile(r"a\d+")) == "a\\d+"
+    assert await page.evaluate("re => re.flags", re.compile("foo", re.DOTALL)) == "s"
+
+
+async def test_should_evaluate_regex_in_nested_structures(page: Page) -> None:
+    out = await page.evaluate("() => ({ list: [/foo/s], nested: { re: /bar/ } })")
+    assert out == {
+        "list": [re.compile("foo", re.DOTALL)],
+        "nested": {"re": re.compile("bar")},
+    }
+
+
+async def test_evaluate_jsonvalue_regex(page: Page) -> None:
+    handle = await page.evaluate_handle("() => ({ someKey: /foo/i })")
+    assert await handle.json_value() == {"someKey": re.compile("foo", re.IGNORECASE)}


### PR DESCRIPTION
`serialize_value()` has no branch for `re.Pattern`, so passing a compiled pattern to `evaluate()` silently sends `undefined`. `parse_value()` has no branch for `"r"`, so a RegExp coming back from the page reaches the caller as the raw wire dict instead of a pattern:

```py
>>> page.evaluate("(v) => String(v)", re.compile(r"a\d+", re.I))
'undefined'
>>> page.evaluate("() => /a\\d+/gi")
{'r': {'p': 'a\\d+', 'f': 'gi'}}
```

The protocol already carries regexes as `{r: {p, f}}` and the driver implements both sides, so this just adds the two missing branches on the Python side. playwright-dotnet does the same in `EvaluateArgumentValueConverter.cs`.

Flags reuse the existing `escape_regex_flags()` helper. On the way back, the JavaScript-only flags (`g`, `y`, `d`, `u`, `v`) have no `re` equivalent and are dropped.

Fixes https://github.com/microsoft/playwright-python/issues/3188